### PR TITLE
Implement normalized prefix lookup in the Bioregisry

### DIFF
--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -109,12 +109,12 @@ public class Bioregistry {
     
     private static String norm(String s) {
         // see https://github.com/biopragmatics/bioregistry/blob/a7424ef4a0d22eaca61d3a86c6175e2059e9c855/src/bioregistry/utils.py#L128-L133
-        s = s.toLowerCase(Locale.ROOT)
-        s = s.replace(".", "")
-        s = s.replace("-", "")
-        s = s.replace("_", "")
-        s = s.replace("/", "")
-        return s
+        s = s.toLowerCase(Locale.ROOT);
+        s = s.replace(".", "");
+        s = s.replace("-", "");
+        s = s.replace("_", "");
+        s = s.replace("/", "");
+        return s;
     }
 
     private Pattern getPattern(String patternStr) {

--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -107,7 +107,7 @@ public class Bioregistry {
         return uriFormat.getAsString().replace("$1", id);
     }
     
-    private static norm(String s) {
+    private static String norm(String s) {
         // see https://github.com/biopragmatics/bioregistry/blob/a7424ef4a0d22eaca61d3a86c6175e2059e9c855/src/bioregistry/utils.py#L128-L133
         s = s.toLowerCase(Locale.ROOT)
         s = s.replace(".", "")

--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -20,6 +20,15 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
 
+
+/**
+ * The Bioregistry (https://bioregistry.io) is an open source, community curated registry
+ * of prefixes for biomedical ontologies/vocabularies and their associated metadata. It
+ * can be used to look generate links for prefixes found in xrefs and other components of
+ * ontologies.
+ *
+ * Source code and data is availale under CC0/MIT licenses at https://github.com/biopragmatics/bioregistry
+ */
 public class Bioregistry {
 
     Gson gson = new Gson();
@@ -45,14 +54,19 @@ public class Bioregistry {
         }
 
         for(var entry : theRegistry.entrySet()) {
+            // The key is the canonical Bioregistry prefix, always lowercase
+            prefixToDatabase.put(norm(entry.getKey()), db);
+            
+            // The preferred prefix can have various capitalization,
+            // usually is same as canonical
             JsonObject db = entry.getValue().getAsJsonObject();
-            prefixToDatabase.put(db.get("preferred_prefix").getAsString(), db);
+            prefixToDatabase.put(norm(db.get("preferred_prefix").getAsString()), db);
 
             JsonElement synonyms = db.get("synonyms");
 
             if(synonyms != null) {
                 for(JsonElement synonym : synonyms.getAsJsonArray()) {
-                    prefixToDatabase.put(synonym.getAsString(), db);
+                    prefixToDatabase.put(norm(synonym.getAsString()), db);
                 }
             }
         }
@@ -65,7 +79,7 @@ public class Bioregistry {
 
     public String getUrlForId(String databaseId, String id) {
 
-        JsonObject db = prefixToDatabase.get(databaseId);
+        JsonObject db = prefixToDatabase.get(norm(databaseId));
 
         if(db == null)
             return null;
@@ -91,6 +105,16 @@ public class Bioregistry {
         }
             
         return uriFormat.getAsString().replace("$1", id);
+    }
+    
+    private static norm(String s) {
+        // see https://github.com/biopragmatics/bioregistry/blob/a7424ef4a0d22eaca61d3a86c6175e2059e9c855/src/bioregistry/utils.py#L128-L133
+        s = s.toLowerCase(Locale.ROOT)
+        s = s.replace(".", "")
+        s = s.replace("-", "")
+        s = s.replace("_", "")
+        s = s.replace("/", "")
+        return s
     }
 
     private Pattern getPattern(String patternStr) {


### PR DESCRIPTION
Follow-up to #168, related to #167

This PR does the following:

1. Include the canonical Bioregistry prefix in the `prefixToDatabase` index
2. Apply string normalization when putting into and getting from the `prefixToDatabase` index. This is important since there are lots of different possible capitalization variants of prefix, and the Bioregistry does not explicitly list them all.
3. Add a bit of extra context in a class docstring

This should improve the image in https://github.com/EBISPOT/ols4/issues/167#issuecomment-1383341518 to additionally get the `Orphanet` CURIE linkified.

I coded this in browser and my java is rusty, so please feel free to commit on top of my PR with any appropriate changes