### PR TITLE
Add index of URI prefixes using the Bioregistry

### DIFF
--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -28,6 +28,7 @@ public class Bioregistry {
 
     JsonObject theRegistry;
     Map<String, JsonObject> prefixToDatabase = new HashMap<>();
+    Map<String, JsonObject> iriPrefixToDatabase = new HashMap<>();
     Map<String, Pattern> patterns = new HashMap<>();
 
     public Bioregistry() {
@@ -55,6 +56,12 @@ public class Bioregistry {
                     prefixToDatabase.put(synonym.getAsString(), db);
                 }
             }
+            
+            JsonElement uriFormat = db.get("uri_format");
+            if (uriFormat != null && uriFormat.endsWith("$1) {
+                String uriPrefix = uriFormat.substring(0, uriFormat.length() - 2);                              
+                iriPrefixToDatabase.put(uriPrefix, db);                                                                        
+            }  
         }
 
     }
@@ -91,6 +98,11 @@ public class Bioregistry {
         }
             
         return uriFormat.getAsString().replace("$1", id);
+    }
+                                                        
+    public String getCurieForUrl(String url) {
+        // needs to be implemented, ideally using a trie data structure
+        return "";
     }
 
     private Pattern getPattern(String patternStr) {

--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -28,7 +28,7 @@ public class Bioregistry {
 
     JsonObject theRegistry;
     Map<String, JsonObject> prefixToDatabase = new HashMap<>();
-    Map<String, JsonObject> iriPrefixToDatabase = new HashMap<>();
+    Map<String, String> iriPrefixToDatabase = new HashMap<>();
     Map<String, Pattern> patterns = new HashMap<>();
 
     public Bioregistry() {
@@ -60,7 +60,7 @@ public class Bioregistry {
             JsonElement uriFormat = db.get("uri_format");
             if (uriFormat != null && uriFormat.endsWith("$1) {
                 String uriPrefix = uriFormat.substring(0, uriFormat.length() - 2);                              
-                iriPrefixToDatabase.put(uriPrefix, db);                                                                        
+                iriPrefixToDatabase.put(uriPrefix, entry.getKey());                                                                        
             }  
         }
 
@@ -101,8 +101,18 @@ public class Bioregistry {
     }
                                                         
     public String getCurieForUrl(String url) {
-        // needs to be implemented, ideally using a trie data structure
-        return "";
+        // has known issues with overlapping prefixes, should sort entry set from longest to shortest
+        // alternatively, needs to be re-implemented, with a more efficient trie data structure that
+        // deals with this implicitly
+        for (var entry : iriPrefixToDatabase.entrySet()) {
+          String key = entry.getKey();
+          if (url.startsWith(key)) {
+              // get everything following the 
+              String local_unique_identifier = url.substring(key.length(), url.length())
+              return entry.getValue() + ":" + local_unique_identifier
+          }
+        }
+        return null;
     }
 
     private Pattern getPattern(String patternStr) {

--- a/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
+++ b/dataload/owl2json/src/main/java/uk/ac/ebi/owl2json/xrefs/Bioregistry.java
@@ -108,8 +108,8 @@ public class Bioregistry {
           String key = entry.getKey();
           if (url.startsWith(key)) {
               // get everything following the 
-              String local_unique_identifier = url.substring(key.length(), url.length())
-              return entry.getValue() + ":" + local_unique_identifier
+              String local_unique_identifier = url.substring(key.length(), url.length());
+              return entry.getValue() + ":" + local_unique_identifier;
           }
         }
         return null;


### PR DESCRIPTION
Related to #166

This is a stub PR showing that the Bioregistry is also a good place to index URL/IRI prefixes for compressing nasty long URLs into human-readable CURIEs.

Also relevant for #173 since this can allow for parsing a whole variety of different IRIs that can correspond to the same entity

> **Warning**
> This implementation currently is naïve and prone to some errors. Ideally, this implementation would use a `trie` data structure to index URI formats instead of a hashmap, but I'm not sure what you policy is on finding external libraries and making them dependencies, such as the one from [apache commons](https://github.com/robertsmieja/apache-commons-examples/blob/master/src/test/java/com/robertsmieja/example/apache/commons/collections4/TrieExamples.java) as suggested by James