### PR TITLE
openAPI documentation and Swagger

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -126,6 +126,12 @@
             <scope>compile</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-ui</artifactId>
+            <version>1.6.4</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.jackson.serialization.INDENT_OUTPUT=true
+
+springdoc.swagger-ui.path=/swagger-ui-ols4.html
+springdoc.swagger-ui.operationsSorter=method

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -1,6 +1,8 @@
 import { Fragment } from "react";
 import Header from "../../components/Header";
 import HelpSection from "./HelpSection";
+import {Link} from "react-router-dom";
+import {Home} from "@mui/icons-material";
 
 export default function Help() {
   document.title = "Ontology Lookup Service (OLS)";
@@ -9,6 +11,16 @@ export default function Help() {
       <Header section="help" />
       <main className="container mx-auto">
         <HelpSection title="Using the API"></HelpSection>
+          {process.env.REACT_APP_APIURL && (
+              <Link to={process.env.REACT_APP_APIURL + "swagger-ui/index.html"} target="_blank">
+                  <button className="button-secondary font-bold self-center">
+                      <div className="flex gap-2">
+                          <Home />
+                          <div>Swagger Documentation</div>
+                      </div>
+                  </button>
+              </Link>
+          )}
       </main>
     </Fragment>
   );

--- a/frontend/src/pages/help/HelpPage.tsx
+++ b/frontend/src/pages/help/HelpPage.tsx
@@ -2,7 +2,7 @@ import { Fragment } from "react";
 import Header from "../../components/Header";
 import HelpSection from "./HelpSection";
 import {Link} from "react-router-dom";
-import {Home} from "@mui/icons-material";
+import {Source} from "@mui/icons-material";
 
 export default function Help() {
   document.title = "Ontology Lookup Service (OLS)";
@@ -15,7 +15,7 @@ export default function Help() {
               <Link to={process.env.REACT_APP_APIURL + "swagger-ui/index.html"} target="_blank">
                   <button className="button-secondary font-bold self-center">
                       <div className="flex gap-2">
-                          <Home />
+                          <Source />
                           <div>Swagger Documentation</div>
                       </div>
                   </button>


### PR DESCRIPTION
- OpenApi documentation maven dependency added,
- Swagger page link configured,
- API paths are sorted in order of their HTTP methods in swagger.
