### PR TITLE
EntityTreeWidget

### DIFF
--- a/frontend/src/widgets/styles/treestyles.css
+++ b/frontend/src/widgets/styles/treestyles.css
@@ -1135,12 +1135,19 @@ filter: gray;
   --tw-text-opacity: 1;
   color: rgb(255 255 255/var(--tw-text-opacity));
 }
+.bg-white {
+  --tw-bg-opacity: 1;
+  background-color: rgb(255 255 255/var(--tw-bg-opacity));
+}
 .uppercase {
   text-transform: uppercase;
 }
 .text-sm {
   font-size: .875rem;
   line-height: 1.25rem;
+}
+.pb-3 {
+  padding-bottom: .75rem;
 }
 .py-0\.5 {
   padding-top: .125rem;
@@ -1150,8 +1157,12 @@ filter: gray;
   padding-left: .5rem;
   padding-right: .5rem;
 }
-.rounded-md {
-  border-radius: .375rem;
+.px-3 {
+  padding-left: .75rem;
+  padding-right: .75rem;
+}
+.m-1 {
+  margin: .25rem;
 }
 .ml-1 {
   margin-left: .25rem;
@@ -1159,4 +1170,19 @@ filter: gray;
 .mx-1 {
   margin-left: .25rem;
   margin-right: .25rem;
+}
+.rounded-lg {
+  border-radius: .5rem;
+}
+.rounded-md {
+  border-radius: .375rem;
+}
+.overflow-x-auto {
+  overflow-x: auto;
+}
+.flex {
+  display: flex;
+}
+.flex-col {
+  flex-direction: column;
 }


### PR DESCRIPTION
Code from cooperative session 2 weeks ago, plus styles, and updated to newest version of the dev branch.

Widget styles are manually bundled because rollup plugins for CSS and images weren't cooperating.

Some further styles had to be added from main.css, the result looks like this:

![image](https://github.com/EBISPOT/ols4/assets/130765495/5611638f-7709-4d0a-85d4-660741179b56)

@serjoshua @udp Draft PR: Since this code was originally not meant to be merged, but only to produce widgets, there are some heavy-handed changes to the frontend package that would break your package.json, for example. For the repository to both function as frontend, and produce widgets, some more changes are required: Please discuss how you would like widgets to be integrated in the project structure.