### PR TITLE
issue-425: streamline term model with select and search API results

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
@@ -210,26 +210,26 @@ public class V1SearchController {
                 fieldList.add("obo_id");
                 fieldList.add("is_defining_ontology");
                 fieldList.add("type");
-                fieldList.add("synonym");
+                fieldList.add("synonyms");
             }
 
             if (fieldList.contains("id")) outDoc.put("id", JsonHelper.getString(json, "id"));
             if (fieldList.contains("iri")) outDoc.put("iri", JsonHelper.getString(json, "iri"));
             if (fieldList.contains("ontology_name")) outDoc.put("ontology_name", JsonHelper.getString(json, "ontologyId"));
             if (fieldList.contains("label")) {
-                var label = outDoc.put("label", JsonHelper.getStrings(json, "label"));
+                var label = outDoc.put("label", JsonHelper.getString(json, "label"));
                 if(label!=null) {
                     outDoc.put("label", label);
                 }
             }
             if (fieldList.contains("description")) outDoc.put("description", JsonHelper.getStrings(json, "definition"));
-            if (fieldList.contains("short_form")) outDoc.put("short_form", JsonHelper.getStrings(json, "shortForm").get(0));
-            if (fieldList.contains("obo_id")) outDoc.put("obo_id", JsonHelper.getStrings(json, "curie"));
+            if (fieldList.contains("short_form")) outDoc.put("short_form", JsonHelper.getString(json, "shortForm"));
+            if (fieldList.contains("obo_id")) outDoc.put("obo_id", JsonHelper.getString(json, "curie"));
             if (fieldList.contains("is_defining_ontology")) outDoc.put("is_defining_ontology",
                     JsonHelper.getString(json, "isDefiningOntology") == null ? false :
                             JsonHelper.getString(json, "isDefiningOntology").equals("true"));
             if (fieldList.contains("type")) outDoc.put("type", "class");
-            if (fieldList.contains("synonym")) outDoc.put("synonym", JsonHelper.getStrings(json, "synonym"));
+            if (fieldList.contains("synonyms")) outDoc.put("synonyms", JsonHelper.getStrings(json, "synonym"));
 
             // TODO: ontology_prefix
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectController.java
@@ -146,7 +146,7 @@ public class V1SelectController {
                 fieldList.add("is_defining_ontology");
                 fieldList.add("description");
                 fieldList.add("type");
-                fieldList.add("synonym");
+                fieldList.add("synonyms");
             }
 
             Map<String, Object> outDoc = new HashMap<>();
@@ -155,14 +155,14 @@ public class V1SelectController {
             if (fieldList.contains("iri")) outDoc.put("iri", JsonHelper.getString(json, "iri"));
             if (fieldList.contains("ontology_name")) outDoc.put("ontology_name", JsonHelper.getString(json, "ontologyId"));
             if (fieldList.contains("label")) outDoc.put("label", JsonHelper.getString(json, "label"));
-            if (fieldList.contains("description")) outDoc.put("description", JsonHelper.getString(json, "definition"));
+            if (fieldList.contains("description")) outDoc.put("description", JsonHelper.getStrings(json, "definition"));
             if (fieldList.contains("short_form")) outDoc.put("short_form", JsonHelper.getString(json, "shortForm"));
             if (fieldList.contains("obo_id")) outDoc.put("obo_id", JsonHelper.getString(json, "curie"));
             if (fieldList.contains("is_defining_ontology")) outDoc.put("is_defining_ontology",
                     JsonHelper.getString(json, "isDefiningOntology") == null ? false :
                             JsonHelper.getString(json, "isDefiningOntology").equals("true"));
             if (fieldList.contains("type")) outDoc.put("type", "class");
-            if (fieldList.contains("synonym")) outDoc.put("synonym", JsonHelper.getStrings(json, "synonym"));
+            if (fieldList.contains("synonyms")) outDoc.put("synonyms", JsonHelper.getStrings(json, "synonym"));
             if (fieldList.contains("ontology_prefix")) outDoc.put("ontology_prefix", JsonHelper.getString(json, "ontologyPreferredPrefix"));
 
             docs.add(outDoc);


### PR DESCRIPTION
- fix for #425 and #407
- description and synonyms are string[], rest are just string
- update synonym to synonyms in select and search