### PR TITLE
Corrected base uri for BCIO

### DIFF
--- a/dataload/configs/ols.json
+++ b/dataload/configs/ols.json
@@ -826,7 +826,7 @@
         "http://purl.obolibrary.org/obo/BFO_0000050"
       ],
       "base_uri": [
-        "http://humanbehaviourchange.org/ontology"
+        "http://humanbehaviourchange.org/ontology/BCIO_"
       ],
       "oboSlims": false,
       "reasoner": "OWL2",

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -821,7 +821,7 @@
         "http://purl.obolibrary.org/obo/BFO_0000050"
       ],
       "base_uri": [
-        "http://humanbehaviourchange.org/ontology"
+        "http://humanbehaviourchange.org/ontology/BCIO_"
       ],
       "oboSlims": false,
       "reasoner": "OWL2",


### PR DESCRIPTION
Corrected base URI for BCIO.

The terms for the BCIO were displayed with a strange format. For example: `BCIO:/BCIO_001000` instead of `BCIO:001000` for the full `http://humanbehaviourchange.org/ontology/BCIO_001000`. Changing the base URI fixes the issue.