### PR TITLE
fix frontend exception when linked property has no type

### DIFF
--- a/frontend/src/model/Entity.ts
+++ b/frontend/src/model/Entity.ts
@@ -116,8 +116,8 @@ export default abstract class Entity extends Thing {
       // Object properties and data properties are not annotation properties, except in the case of informal vocabularies.
       if (!this.isPredicateFromInformalVocabulary(predicate)) {
         let linkedEntity = this.getLinkedEntities().get(predicate)
-        if (linkedEntity != undefined && linkedEntity.type.indexOf("objectProperty") !== -1) continue;
-        if (linkedEntity != undefined && linkedEntity.type.indexOf("dataProperty") !== -1) continue;
+        if (linkedEntity != undefined && linkedEntity.type && linkedEntity.type.indexOf("objectProperty") !== -1) continue;
+        if (linkedEntity != undefined && linkedEntity.type && linkedEntity.type.indexOf("dataProperty") !== -1) continue;
       }
 
       // If the value was already interpreted as definition/synonym/hierarchical, do


### PR DESCRIPTION
Fixes frontend crashing when a linked property entity has no type. In this case it was because the linked enttiy was from the bioregistry not from OLS

![image](https://github.com/EBISPOT/ols4/assets/454895/3173ceea-2fe5-48ec-bd09-4f1ed1c7bec2)

