### PR TITLE
Hard code PHI and PECO ontology paths

### DIFF
--- a/dataload/configs/foundry.json
+++ b/dataload/configs/foundry.json
@@ -7844,17 +7844,17 @@
         "logo": "http://mirrors.creativecommons.org/presskit/buttons/80x15/png/by.png",
         "url": "https://creativecommons.org/licenses/by/4.0/"
       },
-      "ontology_purl": "http://purl.obolibrary.org/obo/peco.owl",
+      "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/peco.owl",
       "page": "http://browser.planteome.org/amigo/term/PECO:0007359",
       "preferredPrefix": "PECO",
       "products": [
         {
           "id": "peco.owl",
-          "ontology_purl": "http://purl.obolibrary.org/obo/peco.owl"
+          "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/peco.owl"
         },
         {
           "id": "peco.obo",
-          "ontology_purl": "http://purl.obolibrary.org/obo/peco.obo"
+          "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/peco.obo"
         }
       ],
       "publications": [

--- a/dataload/configs/ols.json
+++ b/dataload/configs/ols.json
@@ -22,7 +22,7 @@
       "base_uri": [
         "http://purl.obolibrary.org/obo/PHI_"
       ],
-      "ontology_purl": "file:/nfs/panda/ensembl/production/ensprod/ontologies/phi/PHI.obo"
+      "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/phi.obo"
     },
     {
       "id": "msio",

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -112,7 +112,7 @@
       "base_uri": [
         "http://purl.obolibrary.org/obo/PHI_"
       ],
-      "ontology_purl": "file:/nfs/panda/ensembl/production/ensprod/ontologies/phi/PHI.obo"
+      "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod/local_ontologies/phi.obo"
     },
     {
       "id": "msio",


### PR DESCRIPTION
PECO ontology versions using import `<owl:imports rdf:resource="http://purl.obolibrary.org/obo/peco/patterns/exposure-chebi_pattern.owl"/>` are broken so have hard coded the version not using this import.

For PHI, have updated the path of obo file.