### PR TITLE
Remove upheno from ebi_ontologies.json

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1,10 +1,6 @@
 {
   "ontologies": [
     {
-      "id": "upheno",
-      "ontology_purl": "https://github.com/obophenotype/upheno-dev/releases/latest/download/upheno.owl"
-    },
-    {
       "id": "uniprotrdfs",
       "ontology_purl": "https://ftp.uniprot.org/pub/databases/uniprot/current_release/rdf/core.owl"
     },


### PR DESCRIPTION
Since http://purl.obolibrary.org/obo/upheno.owl, this entry provides an unnecessary future point of failure. Note that right now, http://purl.obolibrary.org/obo/upheno.owl redirects the the exact URL in ebi_ontologies.json, but this may change in the future, cc @jamesamcl