### PR TITLE
Fix for pgatlas.com CORS issue for GWAS

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/config/CrossOriginResourceSharingFilter.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/config/CrossOriginResourceSharingFilter.java
@@ -44,7 +44,6 @@ public class CrossOriginResourceSharingFilter implements Filter {
             httpResponse.addHeader("Access-Control-Allow-Origin", "*");
             httpResponse.addHeader("Access-Control-Allow-Headers", "*");
             httpResponse.addHeader("Access-Control-Allow-Methods", "GET");
-            httpResponse.addHeader("Access-Control-Allow-Credentials", "true");
         }
 
         chain.doFilter(request, response);


### PR DESCRIPTION
This solves: https://github.com/EBISPOT/ols4/issues/801

We already allow requests from any origin, so technically, pgatlas.com shouldn't have an issue with CORS but we use `*` as allowed origin with credentials set as true so this might result in error on the browsers because of security issue. Hence, the reason pgatlas.com facing cors error. Further reading:

https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS/Errors/CORSNotSupportingCredentials
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Origin

Have tested it locally with different Origin domains using curl and seems to be working fine.