### PR TITLE
Update API URL in Swagger-UI

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 spring.jackson.serialization.INDENT_OUTPUT=true
 
 springdoc.swagger-ui.path=/swagger-ui-ols4.html
+springdoc.api-docs.path=/ols-api-docs
+springdoc.swagger-ui.url=/ols-api-docs
+springdoc.swagger-ui.config-url=/ols-api-docs/swagger-config
 springdoc.swagger-ui.operationsSorter=method
 springdoc.swagger-ui.disable-swagger-default-url=true
 


### PR DESCRIPTION
This fixes https://github.com/EBISPOT/ols4/issues/824

Now the URL is updated to show /ols-api-docs

![Screenshot 2025-01-15 at 13 57 36](https://github.com/user-attachments/assets/54bb975f-516b-4b17-9918-8a71dc440001)
