### PR TITLE
Add term size config

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/config/WebConfig.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/config/WebConfig.java
@@ -1,14 +1,20 @@
 package uk.ac.ebi.spot.ols.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.web.filter.CharacterEncodingFilter;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.*;
 import org.springframework.web.util.UrlPathHelper;
+
+import java.util.List;
 
 /**
  * @author Simon Jupp
@@ -25,6 +31,10 @@ public class WebConfig extends WebMvcConfigurerAdapter {
      *
      * @param configurer
      */
+
+    @Value("${ols.solr.max-rows:1000}")
+    private int maxPageSize;
+
     @Override
     public void configurePathMatch(PathMatchConfigurer configurer) {
 //        UrlPathHelper urlPathHelper = new UrlPathHelper();
@@ -51,6 +61,14 @@ public class WebConfig extends WebMvcConfigurerAdapter {
     @Override
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/api/**").allowedOrigins("*").allowedHeaders("*").allowedMethods("GET");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        PageableHandlerMethodArgumentResolver resolver = new PageableHandlerMethodArgumentResolver();
+        resolver.setFallbackPageable(PageRequest.of(0, maxPageSize));
+        resolver.setMaxPageSize(maxPageSize);
+        argumentResolvers.add(resolver);
     }
 
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/solr/OlsSolrClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/solr/OlsSolrClient.java
@@ -17,6 +17,7 @@ import org.apache.solr.client.solrj.response.QueryResponse;
 import org.apache.solr.common.SolrDocument;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -33,14 +34,16 @@ public class OlsSolrClient {
 
 
     @NotNull
-    @org.springframework.beans.factory.annotation.Value("${ols.solr.host:http://localhost:8999}")
-    public String host = "http://localhost:8999";
+    @org.springframework.beans.factory.annotation.Value("${ols.solr.host:http://localhost:8983}")
+    public String host = "http://localhost:8983";
 
 
     private Gson gson = new Gson();
 
     private static final Logger logger = LoggerFactory.getLogger(OlsSolrClient.class);
-    public static final int MAX_ROWS = 1000;
+
+    @Value("${ols.solr.max-rows:1000}")
+    private int maxRows;
 
     public Map<String,Object> getCoreStatus() throws IOException {
         try (CloseableHttpClient httpClient = HttpClients.createDefault()) {
@@ -113,7 +116,7 @@ public class OlsSolrClient {
 
         if(pageable != null) {
             query.setStart((int)pageable.getOffset());
-            query.setRows(pageable.getPageSize() > MAX_ROWS ? MAX_ROWS : pageable.getPageSize());
+            query.setRows(pageable.getPageSize() > maxRows ? maxRows : pageable.getPageSize());
         }
 
         logger.debug("solr rows: {} ", query.getRows());
@@ -143,7 +146,7 @@ public class OlsSolrClient {
 
     public QueryResponse dispatchSearch(SolrQuery query, String core) throws IOException, SolrServerException {
         org.apache.solr.client.solrj.SolrClient mySolrClient = new HttpSolrClient.Builder(host + "/solr/" + core).build();
-        final int rows = query.getRows().intValue() > MAX_ROWS ? MAX_ROWS : query.getRows().intValue();
+        final int rows = query.getRows().intValue() > maxRows ? maxRows : query.getRows().intValue();
         query.setRows(rows);
         QueryResponse qr = mySolrClient.query(query);
         mySolrClient.close();

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,4 +10,4 @@ spring.web.resources.add-mappings=false
 server.error.whitelabel.enabled=false
 
 # this is optional. This property will determine the size of result you get back from solr. By default its 1000 rows
-ols.solr.max-rows=5000
+ols.solr.max-rows=1000

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -8,3 +8,6 @@ spring.mvc.throw-exception-if-no-handler-found=true
 spring.web.resources.add-mappings=false
 
 server.error.whitelabel.enabled=false
+
+# this is optional. This property will determine the size of result you get back from solr. By default its 1000 rows
+ols.solr.max-rows=1000

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -10,4 +10,4 @@ spring.web.resources.add-mappings=false
 server.error.whitelabel.enabled=false
 
 # this is optional. This property will determine the size of result you get back from solr. By default its 1000 rows
-ols.solr.max-rows=1000
+ols.solr.max-rows=5000


### PR DESCRIPTION
This fixes: https://github.com/EBISPOT/ols4/issues/810

Here hows the functionality has changed.

Anyone running their own instance of OLS can provide the param in application.properties. The value of param will be treated as upper limit on the number of rows fetched from solr. For example if the param value is 5000 then

- If no size param is defined in the URL then by default 5000 rows would be fetched in the API call
- If size param is specified in the URL e.g. 100 and the size is less than the value of config param then the 100 rows would be fetched
- If size param is specified in the URL e.g. 20000 and the size is greater than the value of config param then 5000 rows would be fetched.


In case of OLS, config param is optional and its default value is 1000.