### PR TITLE
fix(LabelAnnotator): Added code to clear the default properties if properties are defined in the config file.

### DIFF
--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/LabelAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/LabelAnnotator.java
@@ -30,6 +30,7 @@ public class LabelAnnotator {
         Object configLabelProperties = graph.config.get("label_property");
 
         if(configLabelProperties instanceof Collection<?>) {
+            labelProperties.clear();
             labelProperties.addAll((Collection<String>) configLabelProperties);
         }
 


### PR DESCRIPTION
I fixed the issue https://github.com/EBISPOT/ols4/issues/853 by adding a line to the corresponding Java class [LabelAnnotator](https://github.com/EBISPOT/ols4/blob/dev/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/LabelAnnotator.java). As an test I indexed two ontologies. For RadLex I used the following line at the config file for the label `"label_property": [ "http://radlex.org/RID/Preferred_name"]` . For the second ontology I didn't defined any property for the label in the config file.  For RadLex `http://radlex.org/RID/Preferred_name` was used and for the other ontology the default property `rdfs:label` was used. The indexed ontologies looks as expected. I used in my case just the Plasma Ontology since it is not so huge and I know that it uses `rdfs:label` for the labels. 

![Image](https://github.com/user-attachments/assets/366a3fa0-c863-4b26-b7d7-c42ffddc351b)

![Image](https://github.com/user-attachments/assets/081f5909-2758-4b49-908f-33a95d57ab48)
