### PR TITLE
add new linksTo field to solr

### DIFF
--- a/dataload/json2solr/src/main/java/JSON2Solr.java
+++ b/dataload/json2solr/src/main/java/JSON2Solr.java
@@ -199,6 +199,56 @@ public class JSON2Solr {
 
     static private void flattenProperties(Map<String,Object> properties, Map<String,Object> flattened) {
 
+        var linkedEntites = properties.get("linkedEntities");
+        if(linkedEntites != null) {
+
+                    /*   "linkedEntities" : {
+            "http://purl.obolibrary.org/obo/HP_0000118" : {
+            "definedBy" : [ "hp" ],
+            "numAppearsIn" : 22.0,
+            "hasLocalDefinition" : true,
+            "label" : [ "Phenotypic abnormality" ],
+            "curie" : "HP:0000118",
+            "type" : [ "class", "entity" ]
+            } */
+
+            List<String> linksTo = new ArrayList<>();
+
+            for(var entry : ((Map<String, Object>) linkedEntites).entrySet()) {
+
+                String entityId = (String) entry.getKey();
+                Map<String, Object> linkedEntity = (Map<String, Object>) entry.getValue();
+
+                linksTo.add(entityId);
+
+                var curie = linkedEntity.get("curie");
+
+                if(curie instanceof Map) {
+                    var curieValue = ((Map) curie).get("value");
+                    linksTo.add((String) curieValue);
+                } else {
+                    linksTo.add((String) curie);
+                }
+    
+                var labels = linkedEntity.get("label");
+
+                if(labels != null) {
+
+                    if(labels instanceof String) {
+                        linksTo.add((String) labels);
+                    } else {
+                        for(var label : (List) labels) {
+                            if(label instanceof String) {
+                                linksTo.add((String) label);
+                            }
+                        }
+                    }
+                }
+
+                flattened.put("linksTo", linksTo);
+            }
+        }
+
         for (String k : properties.keySet()) {
 
             Object v = discardMetadata(properties.get(k));


### PR DESCRIPTION
Use case is I want to extract links to entities which are buried in class expressions like

https://www.ebi.ac.uk/ols4/ontologies/hp/classes/http%253A%252F%252Fpurl.obolibrary.org%252Fobo%252FHP_0004361

![image](https://github.com/user-attachments/assets/1ec3a1a6-673d-429a-b20f-73b982a276d9)

I would like to be able to retrieve HP terms in the API based on "leptin" as an input but currently there is no queryable connection in OLS.

This pr would add a `linksTo` field to Solr which will be searchable using the API
