### PR TITLE
Add definition properties to description

### DIFF
--- a/frontend/src/model/Entity.ts
+++ b/frontend/src/model/Entity.ts
@@ -238,4 +238,54 @@ export default abstract class Entity extends Thing {
 
     return result;
   }
+
+  getDescriptionsFromProperties(): { property: string; descriptions: Reified<any>[] }[] {
+    const result: { property: string; descriptions: Reified<any>[] }[] = [];
+    // Check if 'definitionProperty' exists in 'this.properties'
+    if (!this.properties || !this.properties.hasOwnProperty("definitionProperty")) {
+      return result; // Return empty array if 'definitionProperty' doesn't exist
+    }
+
+    const definitionProperties = this.properties["definitionProperty"];
+    const definitionPropsArray = Array.isArray(definitionProperties)
+        ? definitionProperties
+        : [definitionProperties];
+
+    definitionPropsArray.forEach((definitionProperty: string) => {
+      if (this.properties.hasOwnProperty(definitionProperty)) {
+        const descriptions = this.properties[definitionProperty];
+        if (descriptions) {
+          const reifiedDescriptions = Reified.fromJson(
+              Array.isArray(descriptions) ? descriptions : [descriptions]
+          );
+
+          if (reifiedDescriptions.length > 0) {
+            // Get property short name for display
+            const propertyName = this.getPropertyShortName(definitionProperty);
+            result.push({
+              property: propertyName,
+              descriptions: reifiedDescriptions
+            });
+          }
+        }
+      }
+    });
+
+    return result;
+  }
+
+  private getPropertyShortName(propertyIri: string): string {
+    // Special case for IAO_0000115
+    if (propertyIri === "http://purl.obolibrary.org/obo/IAO_0000115") {
+      return "Definition";
+    }
+
+    // Extract the last part of the IRI for display
+    const parts = propertyIri.split(/[/#]/);
+    const lastPart = parts[parts.length - 1];
+
+    return lastPart
+        .replace(/^./, str => str.toUpperCase()) // Capitalize first letter
+        .trim();
+  }
 }

--- a/frontend/src/pages/ontologies/entities/entityPageSections/EntityDescriptionSection.tsx
+++ b/frontend/src/pages/ontologies/entities/entityPageSections/EntityDescriptionSection.tsx
@@ -12,33 +12,41 @@ export default function EntityDescriptionSection({
   entity: Entity;
   linkedEntities: LinkedEntities;
 }) {
-  let desc = entity.getDescriptionAsArray();
+  const propertyDescriptions = entity.getDescriptionsFromProperties();
+
   return (
-    <div className="mb-2">
-      {desc.map((definition: Reified<any>, i: number) => {
-        return (
-          <p
-            key={definition.value.toString().substring(0, 10) + randomString()}
-            className="pb-3"
-          >
-            <span>
-              {addLinksToText(
-                definition.value,
-                linkedEntities,
-                entity.getOntologyId(),
-                entity,
-                entity.getTypePlural()
-              )}
-              {definition.hasMetadata() ? (
-                <MetadataTooltip
-                  metadata={definition.getMetadata()}
-                  linkedEntities={linkedEntities}
-                />
-              ) : null}
-            </span>
-          </p>
-        );
-      })}
-    </div>
+      <div className="mb-2">
+        {propertyDescriptions.length > 0 ? (
+            propertyDescriptions.map((propertyGroup, groupIndex) => (
+                <div key={`group-${groupIndex}`} className="mb-4">
+                  <h4 className="font-semibold text-gray-700 mb-2">
+                    {propertyGroup.property}:
+                  </h4>
+                  {propertyGroup.descriptions.map((definition: Reified<any>, i: number) => (
+                      <p
+                          key={definition.value.toString().substring(0, 10) + randomString()}
+                          className="pb-3 pl-4"
+                      >
+                <span>
+                  {addLinksToText(
+                      definition.value,
+                      linkedEntities,
+                      entity.getOntologyId(),
+                      entity,
+                      entity.getTypePlural()
+                  )}
+                  {definition.hasMetadata() ? (
+                      <MetadataTooltip
+                          metadata={definition.getMetadata()}
+                          linkedEntities={linkedEntities}
+                      />
+                  ) : null}
+                </span>
+                      </p>
+                  ))}
+                </div>
+            ))
+        ) : null }
+      </div>
   );
 }


### PR DESCRIPTION
This fixes this: https://github.com/EBISPOT/ols4/issues/823

Now it shows from which definition property the description is coming from.

![Screenshot 2025-04-11 at 00 13 41](https://github.com/user-attachments/assets/3786a5f1-8ece-4c03-b8a9-5c29afe5cd42)

<img width="1268" alt="Screenshot 2025-04-11 at 17 24 40" src="https://github.com/user-attachments/assets/5f3a6a4e-e85f-4243-993f-dc2cc7d6a7f2" />

