### PR TITLE
allow overriding label of links in annotation properties using rdfs:label

### DIFF
--- a/frontend/src/pages/ontologies/entities/entityPageSections/EntityAnnotationsSection.tsx
+++ b/frontend/src/pages/ontologies/entities/entityPageSections/EntityAnnotationsSection.tsx
@@ -7,6 +7,7 @@ import LinkedEntities from "../../../../model/LinkedEntities";
 import Reified from "../../../../model/Reified";
 import MetadataTooltip from "./MetadataTooltip";
 import addLinksToText from "./addLinksToText";
+import Link from "@mui/material/Link";
 
 export default function EntityAnnotationsSection({
   entity,
@@ -91,6 +92,18 @@ export default function EntityAnnotationsSection({
         />
       );
     } else {
+      // Allows overriding the label of a link with an rdfs:label annotation
+      // on the link annotation.
+      //
+      if (typeof(value.value) === 'string' && value.value.indexOf('://') !== -1) {
+        let metadata = value.getMetadata();
+        if(metadata) {
+          let linkLabel = metadata["http://www.w3.org/2000/01/rdf-schema#label"];
+          if(linkLabel) {
+            return <Link className="link-default" href={value.value}>{linkLabel}</Link>
+          }
+        }
+      }
       if (typeof value.value !== "string" && typeof value.value !== "boolean" && typeof value.value !== "number") {
         return (
           <ClassExpression


### PR DESCRIPTION
CC @dosumis, @hkir-dev

Context: 

> We are in the process of adding links from ontology terms and individuals generated to related content  at the Allen Brain Atlas. [..] It makes no sense to generate OWL entities with labels for these types of links.   Would best practice here be to provide a block of hyperlinked text in html?  Would that be supported by OLS4?  More generally, does OLS4 support other options for turning bare IRIs into hyperlinked text besides making named OWL entities with labels?

This PR provides a simple solution by using the `rdfs:label` annotation-on-annotation as the label for the link instead of the link href itself.
