### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 <a href="https://github.com/EBISPOT/ols4/actions/workflows/test.yml"><img src="https://github.com/EBISPOT/ols4/actions/workflows/test.yml/badge.svg"/></a>
 
-OLS4 is available at <b>[https://www.ebi.ac.uk/ols4/](https://www.ebi.ac.uk/ols4/)</b>. Please report any issues to the
-tracker in this repository.
+The Ontology Lookup Service (OLS) is a repository for biomedical ontologies that aims to provide a single point of access to the latest ontology versions. 
+
+See also:
+
+    - The public OLS instance at EMBL-EBI: <b>[https://www.ebi.ac.uk/ols4/](https://www.ebi.ac.uk/ols4/)</a>
+    - [OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem](https://academic.oup.com/bioinformatics/article/41/5/btaf279/8125017)
+    - [API documentation](https://www.ebi.ac.uk/ols4/help)
+
+If you use OLS in your work, please cite [our recent publication in <i>Bioinformatics</i>](https://academic.oup.com/bioinformatics/article/41/5/btaf279/8125017).
 
 ---
-
-Version 4 of the EMBL-EBI Ontology Lookup Service (OLS), featuring:
-
-* Much faster dataload (loads the OBO foundry in hours instead of days)
-* Modular dataload pipeline with decoupled, individually testable stages
-* Automated CI testing of the dataload with minimal testcase ontologies
-* A lossless data representation: everything in the ontology is preserved in the databases
-* Coverage of the whole OWL2 spec, and also loads vocabularies defined purely in RDFS
-* Uses updated versions of Solr and Neo4j (no embedded databases, no MongoDB)
-* React frontend using Redux and Tailwind
-* Backwards compatibility with the OLS3 API
 
 This repository contains three projects:
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ The Ontology Lookup Service (OLS) is a repository for biomedical ontologies that
 
 See also:
 
-    - The public OLS instance at EMBL-EBI: <b>[https://www.ebi.ac.uk/ols4/](https://www.ebi.ac.uk/ols4/)</a>
-    - [OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem](https://academic.oup.com/bioinformatics/article/41/5/btaf279/8125017)
-    - [API documentation](https://www.ebi.ac.uk/ols4/help)
+* The public OLS instance at EMBL-EBI: <b>[https://www.ebi.ac.uk/ols4/](https://www.ebi.ac.uk/ols4/)</a></b>
+* [<i>OLS4: a new Ontology Lookup Service for a growing interdisciplinary knowledge ecosystem</i>](https://academic.oup.com/bioinformatics/article/41/5/btaf279/8125017)
+* [API documentation](https://www.ebi.ac.uk/ols4/help)
 
 If you use OLS in your work, please cite [our recent publication in <i>Bioinformatics</i>](https://academic.oup.com/bioinformatics/article/41/5/btaf279/8125017).
 


### PR DESCRIPTION
Update the README to add the recent publication. Comparison bullet points to OLS3 are now removed because OLS4 has been around for a while (also, these details are in the paper).
