### PR TITLE
add GOLD

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1,6 +1,10 @@
 {
   "ontologies": [
     {
+      "id": "gold",
+      "ontology_purl": "https://raw.githubusercontent.com/cmungall/gold-ontology/refs/heads/main/gold.owl"
+    },
+    {
       "id": "mondo",
       "ontology_purl": "https://purl.obolibrary.org/obo/mondo/mondo-international.owl"
     },


### PR DESCRIPTION
Add conversion of GOLD to OWL from https://github.com/cmungall/gold-ontology to OLS

GOLD is used by MGnify (an EBI resource) to classify environmental samples, but is currently only browseable via bioportal.



