### PR TITLE
Add configuration for HGNC Gene Group

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1661,6 +1661,39 @@
       "repository": "https://github.com/arpcard/aro",
       "title": "Antibiotic Resistance Ontology",
       "tracker": "https://github.com/arpcard/aro/issues"
+    },
+    {
+      "id": "hgnc.genegroup",
+      "reasoner": "none",
+      "oboSlims": false,
+      "is_foundary": false,
+      "ontology_purl": "https://w3id.org/biopragmatics/resources/hgnc.genegroup/hgnc.genegroup.owl",
+      "creator": [
+        "Elspeth Bruford"
+      ],
+      "preferredPrefix": "hgnc.genegroup",
+      "title": "HGNC Gene Group",
+      "description": "The HGNC (HUGO Gene Nomenclature Committee) provides an approved gene name and symbol (short-form abbreviation) for each known human gene. All approved symbols are stored in the HGNC database, and each symbol is unique. In addition, HGNC also provides a unique numerical ID to identify gene families, providing a display of curated hierarchical relationships between families. Licensed under CC0-1.0.",
+      "uri": "https://www.genenames.org",
+      "homepage": "https://www.genenames.org",
+      "mailing_list": "elspeth@genenames.org",
+      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": [
+        "http://purl.org/dc/terms/description"
+      ],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
+      ],
+      "hierarchical_property": [
+        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
+      ],
+      "hidden_property": [],
+      "base_uri": [
+        "https://www.genenames.org/data/genegroup/#!/group/"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Following https://github.com/EBISPOT/ols4/pull/931, this PR adds an additional configuration to import HGNC gene groups. This will make the HGNC gene pages more valuable because the gene group annotations (like shown with the red arrow below for [AKT1](https://www.ebi.ac.uk/ols4/ontologies/hgnc/classes/https%253A%252F%252Fwww.genenames.org%252Fdata%252Fgene-symbol-report%252F%2523!%252Fhgnc_id%252F391)) will then get labels in OLS

<img width="1609" height="1191" alt="Screenshot 2025-10-16 at 15 18 03" src="https://github.com/user-attachments/assets/81d652a4-4958-49ab-b123-5d732632d246" />
