### PR TITLE
Fix #1042: Remove relatedFrom from dataload and add paginated endpoint

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassController.java
@@ -439,5 +439,39 @@ public class V2ClassController {
                 HttpStatus.OK);
 
     }
+
+    // New paginated endpoint for relatedFrom (issue #1042)
+    // This endpoint retrieves entities that reference the specified class in their relatedTo field
+    //
+    @RequestMapping(path = "/ontologies/{onto}/classes/{class}/relatedFrom", produces = {MediaType.APPLICATION_JSON_VALUE}, method = RequestMethod.GET)
+    public HttpEntity<V2PagedResponse<V2Entity>> getRelatedFromByOntology(
+            @PageableDefault(size = 20, page = 0)
+            @Parameter(name = "pageable",
+                    description = "Specify the size of the result you want to get in the output",
+                    example = "{\"page\": 0,\"size\": 20}") Pageable pageable,
+            @PathVariable("onto")
+            @Parameter(name = "onto",
+                    description = "Ontology Id to get the information about.",
+                    example = "efo") String ontologyId,
+            @PathVariable("class")
+            @Parameter(name = "class",
+                    description = "The IRI of the class, this value must be double URL encoded",
+                    example = "http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000001") String iri,
+            @RequestParam(value = "includeObsoleteEntities", required = false, defaultValue = "false")
+            @Parameter(name = "includeObsoleteEntities",
+                    description = "A boolean parameter to specify if obsolete entities should be included or not. Default value is false.") boolean includeObsoleteEntities,
+            @RequestParam(value = "lang", required = false, defaultValue = "en") String lang,
+            JsonTransformOptions outputOpts
+    ) throws ResourceNotFoundException {
+
+        iri = UriUtils.decode(iri, "UTF-8");
+
+        return new ResponseEntity<>(
+                new V2PagedResponse<V2Entity>(
+                    classRepository.getRelatedFromByOntologyId(ontologyId, pageable, iri, includeObsoleteEntities, lang, outputOpts)
+                    .map(V2Entity::new)
+                ),
+                HttpStatus.OK);
+    }
 }
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
@@ -171,6 +171,40 @@ public class V2EntityController {
         if (entity == null) throw new ResourceNotFoundException("The requested resource was not found.");
         return new ResponseEntity<V2Entity>( new V2Entity(entity), HttpStatus.OK);
     }
+
+    // New paginated endpoint for relatedFrom (issue #1042)
+    // This endpoint retrieves entities that reference the specified entity in their relatedTo field
+    //
+    @RequestMapping(path = "/ontologies/{onto}/entities/{entity}/relatedFrom", produces = {MediaType.APPLICATION_JSON_VALUE}, method = RequestMethod.GET)
+    public HttpEntity<V2PagedAndFacetedResponse<V2Entity>> getRelatedFromByOntology(
+            @PageableDefault(size = 20, page = 0)
+            @Parameter(name = "pageable",
+                    description = "Specify the size of the result you want to get in the output",
+                    example = "{\"page\": 0,\"size\": 20}") Pageable pageable,
+            @PathVariable("onto")
+            @Parameter(name = "onto",
+                    description = "Ontology Id to get the information about.",
+                    example = "efo") String ontologyId,
+            @PathVariable("entity")
+            @Parameter(name = "entity",
+                    description = "The IRI of the entity, this value must be double URL encoded",
+                    example = "http%3A%2F%2Fwww.ebi.ac.uk%2Fefo%2FEFO_0000001") String iri,
+            @RequestParam(value = "includeObsoleteEntities", required = false, defaultValue = "false")
+            @Parameter(name = "includeObsoleteEntities",
+                    description = "A boolean parameter to specify if obsolete entities should be included or not. Default value is false.") boolean includeObsoleteEntities,
+            @RequestParam(value = "lang", required = false, defaultValue = "en") String lang,
+            JsonTransformOptions outputOpts
+    ) throws ResourceNotFoundException {
+
+        iri = UriUtils.decode(iri, "UTF-8");
+
+        return new ResponseEntity<>(
+                new V2PagedAndFacetedResponse<V2Entity>(
+                    entityRepository.getRelatedFromByOntologyId(ontologyId, pageable, iri, includeObsoleteEntities, lang, outputOpts)
+                    .map(V2Entity::new)
+                ),
+                HttpStatus.OK);
+    }
 }
 
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
@@ -252,4 +252,29 @@ public class ClassRepository {
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
                 ;
     }
+
+    // New method for issue #1042: Get entities that reference the specified class in their relatedTo field
+    // This effectively computes relatedFrom on-demand by querying relatedTo in reverse
+    public Page<JsonElement> getRelatedFromByOntologyId(String ontologyId, Pageable pageable, String iri, boolean includeObsolete, String lang, JsonTransformOptions outputOpts) {
+
+        Validation.validateOntologyId(ontologyId);
+        Validation.validateLang(lang);
+
+        OlsSolrQuery query = new OlsSolrQuery();
+        query.addFilter("type", List.of("class"), SearchType.WHOLE_FIELD);
+        query.addFilter("ontologyId", List.of(ontologyId), SearchType.CASE_INSENSITIVE_TOKENS);
+        // Search for entities where relatedTo.value contains the target IRI
+        query.addFilter("relatedTo.value", List.of(iri), SearchType.WHOLE_FIELD);
+
+        if (!includeObsolete) {
+            query.addFilter(IS_OBSOLETE.getText(), List.of("false"), SearchType.WHOLE_FIELD);
+        }
+
+        try {
+            return solrClient.searchSolrPaginated(query, pageable)
+                    .map(e -> JsonTransformer.transformJson(e, lang, outputOpts));
+        } catch (IOException e) {
+            throw new RuntimeException("Error querying Solr for relatedFrom entities", e);
+        }
+    }
 }

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/EntityRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/EntityRepository.java
@@ -24,6 +24,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.springframework.data.domain.Page;
+
+import static uk.ac.ebi.ols.shared.DefinedFields.*;
+
 @Component
 public class EntityRepository {
 
@@ -97,8 +101,30 @@ public class EntityRepository {
                 outputOpts);
     }
 
+    // New method for issue #1042: Get entities that reference the specified entity in their relatedTo field
+    // This effectively computes relatedFrom on-demand by querying relatedTo in reverse
+    public OlsFacetedResultsPage<JsonElement> getRelatedFromByOntologyId(String ontologyId, Pageable pageable, String iri, boolean includeObsolete, String lang, JsonTransformOptions outputOpts) {
 
+        Validation.validateOntologyId(ontologyId);
+        Validation.validateLang(lang);
 
+        OlsSolrQuery query = new OlsSolrQuery();
+        query.addFilter("type", List.of("entity"), SearchType.WHOLE_FIELD);
+        query.addFilter("ontologyId", List.of(ontologyId), SearchType.CASE_INSENSITIVE_TOKENS);
+        // Search for entities where relatedTo.value contains the target IRI
+        query.addFilter("relatedTo.value", List.of(iri), SearchType.WHOLE_FIELD);
+
+        if (!includeObsolete) {
+            query.addFilter(IS_OBSOLETE.getText(), List.of("false"), SearchType.WHOLE_FIELD);
+        }
+
+        try {
+            return solrClient.searchSolrPaginated(query, pageable)
+                    .map(e -> JsonTransformer.transformJson(e, lang, outputOpts));
+        } catch (IOException e) {
+            throw new RuntimeException("Error querying Solr for relatedFrom entities", e);
+        }
+    }
 
 }
 

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/RelatedAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/RelatedAnnotator.java
@@ -312,10 +312,12 @@ public class RelatedAnnotator {
 			relatedToMap.put(ontologyNode, relatedToSetToUpdate);
 		}
 		void updateOntologyNodesWithRelatedLists() {
-			for(OntologyNode ontologyNode: relatedFromMap.keySet()) {
-				ontologyNode.properties.addProperty(RELATED_FROM.getText(),
-						new PropertyValueList(Arrays.asList(relatedFromMap.get(ontologyNode).toArray())));
-			}
+			// relatedFrom has been removed from dataload to improve performance (issue #1042)
+			// It can be computed on-demand by querying relatedTo in reverse via the new paginated endpoint
+			// for(OntologyNode ontologyNode: relatedFromMap.keySet()) {
+			// 	ontologyNode.properties.addProperty(RELATED_FROM.getText(),
+			// 			new PropertyValueList(Arrays.asList(relatedFromMap.get(ontologyNode).toArray())));
+			// }
 			for(OntologyNode ontologyNode: relatedToMap.keySet()) {
 				ontologyNode.properties.addProperty(RELATED_TO.getText(),
 						new PropertyValueList(Arrays.asList(relatedToMap.get(ontologyNode).toArray())));


### PR DESCRIPTION
This commit addresses the performance issue caused by the relatedFrom field in OLS4, which was causing 167 MB responses for certain classes (e.g., "Homo Sapiens" in NCIT) and crashing backend pods.

Changes:
1. Removed relatedFrom field generation from RelatedAnnotator in dataload
   - RelatedFrom is now computed on-demand instead of being stored
   - Significantly reduces Solr document sizes and memory usage

2. Added new paginated endpoints for relatedFrom:
   - /api/v2/ontologies/{onto}/classes/{class}/relatedFrom
   - /api/v2/ontologies/{onto}/entities/{entity}/relatedFrom

3. Added repository methods to compute relatedFrom dynamically:
   - Queries relatedTo.value in reverse to find entities referencing the target
   - Supports pagination to handle large result sets
   - Includes includeObsoleteEntities parameter

The solution eliminates the 167 MB response problem while maintaining functionality through on-demand, paginated queries.