### PR TITLE
Add configuration for EC

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1691,33 +1691,6 @@
       "ontology_purl": "https://w3id.org/mixs/mixs.owl.ttl"
     },
     {
-      "id": "rhea",
-      "reasoner": "none",
-      "oboSlims": false,
-      "is_foundary": false,
-      "ontology_purl": "https://w3id.org/biopragmatics/resources/rhea/rhea.owl.gz",
-      "creator": ["Anne Morgat"],
-      "preferredPrefix": "rhea",
-      "title": "Rhea reaction",
-      "description": "Rhea is an expert-curated knowledgebase of chemical and transport reactions of biological interest. Enzyme-catalyzed and spontaneously occurring reactions are curated from peer-reviewed literature and represented in a computationally tractable manner by using the ChEBI (Chemical Entities of Biological Interest) ontology to describe reaction participants.\n\nRhea covers the reactions described by the IUBMB Enzyme Nomenclature as well as many additional reactions and can be used for enzyme annotation, genome-scale metabolic modeling and omics-related analyses. Rhea is the standard for enzyme and transporter annotation in UniProtKB. Licensed under CC-BY-4.0.",
-      "uri": "https://www.rhea-db.org/",
-      "homepage": "https://www.rhea-db.org/",
-      "mailing_list": "anne.morgat@sib.swiss",
-      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
-      "definition_property": ["http://purl.org/dc/terms/description"],
-      "synonym_property": [
-        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
-      ],
-      "hierarchical_property": [
-        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
-      ],
-      "hidden_property": [],
-      "base_uri": ["https://www.rhea-db.org/rhea/"]
-    },
-    {
       "id": "ec",
       "reasoner": "none",
       "oboSlims": false,

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1745,6 +1745,60 @@
       "base_uri": ["https://www.enzyme-database.org/query.php?ec="]
     },
     {
+      "id": "rgd",
+      "reasoner": "none",
+      "oboSlims": false,
+      "is_foundary": false,
+      "ontology_purl": "https://w3id.org/biopragmatics/resources/rgd/rgd.owl.gz",
+      "creator": ["Jennifer R Smith"],
+      "preferredPrefix": "rgd",
+      "title": "Rat Genome Database",
+      "description": "Rat Genome Database seeks to collect, consolidate, and integrate rat genomic and genetic data with curated functional and physiological data and make these data widely available to the scientific community. This collection references genes. Licensed under CC-BY-4.0.",
+      "uri": "http://rgd.mcw.edu/",
+      "homepage": "http://rgd.mcw.edu/",
+      "mailing_list": "jrsmith@mcw.edu",
+      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": ["http://purl.org/dc/terms/description"],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
+      ],
+      "hierarchical_property": [
+        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
+      ],
+      "hidden_property": [],
+      "base_uri": ["http://rgd.mcw.edu/rgdweb/report/gene/main.html?id="]
+    },
+    {
+      "id": "mgi",
+      "reasoner": "none",
+      "oboSlims": false,
+      "is_foundary": false,
+      "ontology_purl": "https://w3id.org/biopragmatics/resources/mgi/mgi.owl.gz",
+      "creator": ["Joel Richardson"],
+      "preferredPrefix": "MGI",
+      "title": "Mouse Genome Informatics",
+      "description": "The Mouse Genome Database (MGD) project includes data on gene characterization, nomenclature, mapping, gene homologies among mammals, sequence links, phenotypes, allelic variants and mutants, and strain data. Licensed under CC-BY-4.0.",
+      "uri": "http://www.informatics.jax.org/",
+      "homepage": "http://www.informatics.jax.org/",
+      "mailing_list": "joel.richardson@jax.org",
+      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": ["http://purl.org/dc/terms/description"],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
+      ],
+      "hierarchical_property": [
+        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
+      ],
+      "hidden_property": [],
+      "base_uri": ["http://www.informatics.jax.org/accession/MGI:"]
+    },
+    {
       "id": "hgnc.genegroup",
       "reasoner": "none",
       "oboSlims": false,

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1691,6 +1691,33 @@
       "ontology_purl": "https://w3id.org/mixs/mixs.owl.ttl"
     },
     {
+      "id": "rhea",
+      "reasoner": "none",
+      "oboSlims": false,
+      "is_foundary": false,
+      "ontology_purl": "https://w3id.org/biopragmatics/resources/rhea/rhea.owl.gz",
+      "creator": ["Anne Morgat"],
+      "preferredPrefix": "rhea",
+      "title": "Rhea reaction",
+      "description": "Rhea is an expert-curated knowledgebase of chemical and transport reactions of biological interest. Enzyme-catalyzed and spontaneously occurring reactions are curated from peer-reviewed literature and represented in a computationally tractable manner by using the ChEBI (Chemical Entities of Biological Interest) ontology to describe reaction participants.\n\nRhea covers the reactions described by the IUBMB Enzyme Nomenclature as well as many additional reactions and can be used for enzyme annotation, genome-scale metabolic modeling and omics-related analyses. Rhea is the standard for enzyme and transporter annotation in UniProtKB. Licensed under CC-BY-4.0.",
+      "uri": "https://www.rhea-db.org/",
+      "homepage": "https://www.rhea-db.org/",
+      "mailing_list": "anne.morgat@sib.swiss",
+      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": ["http://purl.org/dc/terms/description"],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
+      ],
+      "hierarchical_property": [
+        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
+      ],
+      "hidden_property": [],
+      "base_uri": ["https://www.rhea-db.org/rhea/"]
+    },
+    {
       "id": "hgnc.genegroup",
       "reasoner": "none",
       "oboSlims": false,

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1718,60 +1718,6 @@
       "base_uri": ["https://www.enzyme-database.org/query.php?ec="]
     },
     {
-      "id": "rgd",
-      "reasoner": "none",
-      "oboSlims": false,
-      "is_foundary": false,
-      "ontology_purl": "https://w3id.org/biopragmatics/resources/rgd/rgd.owl.gz",
-      "creator": ["Jennifer R Smith"],
-      "preferredPrefix": "rgd",
-      "title": "Rat Genome Database",
-      "description": "Rat Genome Database seeks to collect, consolidate, and integrate rat genomic and genetic data with curated functional and physiological data and make these data widely available to the scientific community. This collection references genes. Licensed under CC-BY-4.0.",
-      "uri": "http://rgd.mcw.edu/",
-      "homepage": "http://rgd.mcw.edu/",
-      "mailing_list": "jrsmith@mcw.edu",
-      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
-      "definition_property": ["http://purl.org/dc/terms/description"],
-      "synonym_property": [
-        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
-      ],
-      "hierarchical_property": [
-        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
-      ],
-      "hidden_property": [],
-      "base_uri": ["http://rgd.mcw.edu/rgdweb/report/gene/main.html?id="]
-    },
-    {
-      "id": "mgi",
-      "reasoner": "none",
-      "oboSlims": false,
-      "is_foundary": false,
-      "ontology_purl": "https://w3id.org/biopragmatics/resources/mgi/mgi.owl.gz",
-      "creator": ["Joel Richardson"],
-      "preferredPrefix": "MGI",
-      "title": "Mouse Genome Informatics",
-      "description": "The Mouse Genome Database (MGD) project includes data on gene characterization, nomenclature, mapping, gene homologies among mammals, sequence links, phenotypes, allelic variants and mutants, and strain data. Licensed under CC-BY-4.0.",
-      "uri": "http://www.informatics.jax.org/",
-      "homepage": "http://www.informatics.jax.org/",
-      "mailing_list": "joel.richardson@jax.org",
-      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
-      "definition_property": ["http://purl.org/dc/terms/description"],
-      "synonym_property": [
-        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
-        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
-      ],
-      "hierarchical_property": [
-        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
-      ],
-      "hidden_property": [],
-      "base_uri": ["http://www.informatics.jax.org/accession/MGI:"]
-    },
-    {
       "id": "hgnc.genegroup",
       "reasoner": "none",
       "oboSlims": false,

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1718,6 +1718,33 @@
       "base_uri": ["https://www.rhea-db.org/rhea/"]
     },
     {
+      "id": "ec",
+      "reasoner": "none",
+      "oboSlims": false,
+      "is_foundary": false,
+      "ontology_purl": "https://w3id.org/biopragmatics/resources/ec/ec.owl",
+      "creator": ["Kristian Axelsen"],
+      "preferredPrefix": "EC",
+      "title": "Enzyme Nomenclature",
+      "description": "The Enzyme Nomenclature (also known as the Enzyme Commission Code) is a species-agnostic controlled vocabulary for specific enzymes and an associated hierarchical classification into 7 main categories.\n\nThe Enzyme Nomenclature is maintained by the [Nomenclature Committee](https://iubmb.org/about/committees/nomenclature-committee/) of the International Union of Biochemistry and Molecular Biology (IUBMB). A detailed history of the nomenclature since the 1950s can be found [here](https://iubmb.qmul.ac.uk/enzyme/history.html).\n\nThere are few notable resources providing access to the Enzyme Nomenclature:\n\n<table class=\"table table-striped\"><thead><tr><th>Website</th><th>Homepage</td><th>Notes</td></tr></thead><tbody><tr><td>ExplorEnz</td><td><a href=\"https://www.enzyme-database.org\">https://www.enzyme-database.org</a></td><td>This is the resource officially recommended by IUBMB</td></tr><tr><td>IUBMB (via by Queen Mary)</td><td><a href=\"https://iubmb.qmul.ac.uk/enzyme\">https://iubmb.qmul.ac.uk/enzyme</a></td><td>This is a web-based version of the <a href=\"https://archive.org/details/enzymenomenclatu0000inte_d6c2\">1992 publication</a>.</td></tr><tr><td>IntEnz</td><td><a href=\"https://www.ebi.ac.uk/intenz\">https://www.ebi.ac.uk/intenz</a></td><td>Shutdown in 2024</td></tr><tr><td>ExPaSy</td><td><a href=\"https://enzyme.expasy.org\">https://enzyme.expasy.org</a></td></tr><tr><td>EnzymePortal</td><td><a href=\"https://www.ebi.ac.uk/enzymeportal\">https://www.ebi.ac.uk/enzymeportal</a></td><td></td></tr></tbody></table> Licensed under CC-BY-4.0.",
+      "uri": "https://www.enzyme-database.org/",
+      "homepage": "https://www.enzyme-database.org/",
+      "mailing_list": "kristian.axelsen@sib.swiss",
+      "label_property": "https://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": ["http://purl.org/dc/terms/description"],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasCloseSynonym"
+      ],
+      "hierarchical_property": [
+        "https://www.w3.org/2000/01/rdf-schema#subClassOf"
+      ],
+      "hidden_property": [],
+      "base_uri": ["https://www.enzyme-database.org/query.php?ec="]
+    },
+    {
       "id": "hgnc.genegroup",
       "reasoner": "none",
       "oboSlims": false,


### PR DESCRIPTION
This PR adds four new configurations for widely-used databases for which there is no first-party ontology artifact that I've converted into ontologies using PyOBO (similar to #909, #895, #1007, #931):

1. RGD (Rat Genome Database) genes, data licensed under CC BY 4.0
2. MGI (Mouse Genome Informatics) genes, data licensed under CC BY 4.0
4. EC (enzyme classes), data licensed under CC BY 4.0

cc @haideriqbal 