### PR TITLE
Add cohort ontology (COHO)

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1,6 +1,11 @@
 {
   "ontologies": [
     {
+      "id": "coho",
+      "preferredPrefix": "COHO",
+      "ontology_purl": "https://raw.githubusercontent.com/EBISPOT/cohort-ontology/refs/heads/main/coho.owl"
+    },
+    {
       "id": "medgen",
       "ontology_purl": "https://github.com/monarch-initiative/medgen/releases/latest/download/medgen.ttl.gz"
     },


### PR DESCRIPTION
Resolves #1283

Adds the cohort ontology to ebi_ontologies.json:
- id: coho
- preferredPrefix: COHO
- ontology_purl: https://raw.githubusercontent.com/EBISPOT/cohort-ontology/refs/heads/main/coho.owl
