### PR TITLE
Optimise hierarchy joins and add indexes for paginated listings

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
@@ -38,7 +38,17 @@ public final class JooqSupport {
     }
 
     public static Condition arrayContains(Field<String[]> arrayField, Field<String> valueField) {
+        // `value = ANY(array)` form: only useful when the *value* side is the scanned column
+        // (e.g. e2.iri = ANY(e1.direct_parents) in a nested loop, served by a btree index on
+        // e2.iri). When the *array* side is the scanned column, use arrayContainsField instead.
         return DSL.condition("{0} = ANY({1})", valueField, arrayField);
+    }
+
+    public static Condition arrayContainsField(Field<String[]> arrayField, Field<String> valueField) {
+        // GIN-accelerated containment for joins where the array column is on the scanned side
+        // (e.g. e2.direct_parents @> ARRAY[e1.iri]). The `= ANY` form cannot use the GIN index
+        // and scans every row of the ontology per lookup. See GitHub issue #1276.
+        return DSL.condition("{0} @> ARRAY[{1}]", arrayField, valueField);
     }
 
     public static Field<String> castAsText(Field<?> field) {

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
@@ -31,6 +31,7 @@ import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.INFORMATION_SCH
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.OLS_EMBEDDING_NODES;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.OLS_ENTITIES;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContains;
+import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContainsField;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.castAsText;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.field;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.unnest;
@@ -229,7 +230,7 @@ public class OlsPostgresClient {
             Field<byte[]> e2Json = field("e2", "_json", byte[].class);
 
             Condition where = e1Id.eq(id)
-                    .and(arrayContains(e2Sources, e1Iri))
+                    .and(arrayContainsField(e2Sources, e1Iri))
                     .and(e2OntologyId.eq(e1OntologyId))
                     .and(buildNodePropCondition("e2", nodeProps));
 
@@ -246,14 +247,14 @@ public class OlsPostgresClient {
 
             long count = Optional.ofNullable(dsl.selectCount()
                             .from(e1)
-                            .join(e2).on(arrayContains(e2Sources, e1Iri).and(e2OntologyId.eq(e1OntologyId)))
+                            .join(e2).on(arrayContainsField(e2Sources, e1Iri).and(e2OntologyId.eq(e1OntologyId)))
                             .where(where)
                             .fetchOne(0, Long.class))
                     .orElse(0L);
 
             var records = dsl.select(e2Json)
                     .from(e1)
-                    .join(e2).on(arrayContains(e2Sources, e1Iri).and(e2OntologyId.eq(e1OntologyId)))
+                    .join(e2).on(arrayContainsField(e2Sources, e1Iri).and(e2OntologyId.eq(e1OntologyId)))
                     .where(where)
                     .orderBy(e2Iri.asc())
                     .offset(pageable.getOffset())

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1GraphRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1GraphRepository.java
@@ -20,6 +20,7 @@ import uk.ac.ebi.spot.ols.service.PostgresClient;
 import static uk.ac.ebi.ols.shared.DefinedFields.*;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.OLS_ENTITIES;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContains;
+import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContainsField;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.field;
 
 import java.sql.Connection;
@@ -173,7 +174,7 @@ public class V1GraphRepository {
                                             DSL.inline("child").as("rel_type"),
                                             field("e1", "iri", String.class).as("source_iri"))
                                     .from(e1)
-                                    .join(e2).on(arrayContains(field("e2", "direct_parents", String[].class), field("e1", "iri", String.class))
+                                    .join(e2).on(arrayContainsField(field("e2", "direct_parents", String[].class), field("e1", "iri", String.class))
                                             .and(field("e2", "ontology_id", String.class).eq(field("e1", "ontology_id", String.class))))
                                     .where(field("e1", "id", String.class).eq(entityId)))
                     .unionAll(
@@ -225,7 +226,7 @@ public class V1GraphRepository {
                             field("e2", "iri", String.class).as("node_iri"),
                             field("e1", "iri", String.class).as("target_iri"))
                     .from(e1)
-                    .join(e2).on(arrayContains(field("e2", "related_to", String[].class), field("e1", "iri", String.class))
+                    .join(e2).on(arrayContainsField(field("e2", "related_to", String[].class), field("e1", "iri", String.class))
                             .and(field("e2", "ontology_id", String.class).eq(field("e1", "ontology_id", String.class))))
                     .where(field("e1", "id", String.class).eq(entityId))
                     .limit(200)

--- a/dataload/create_postgres_schema.py
+++ b/dataload/create_postgres_schema.py
@@ -118,6 +118,17 @@ CREATE INDEX idx_ent_synonym ON ols_entities USING gin (synonym);
 CREATE INDEX idx_ent_related_to ON ols_entities USING gin (related_to);
 CREATE INDEX idx_ent_fts ON ols_entities USING gin (ts_search);
 CREATE INDEX idx_ent_trgm_suggest ON ols_entities USING gin (label_for_suggest gin_trgm_ops);
+-- Composite indexes ending in id: paginated listings ORDER BY id LIMIT n. Without an index
+-- providing (filter equality + id order) the planner walks the whole primary key expecting an
+-- early match, which scans the entire table when matches are rare (e.g. tree roots). These also
+-- enable index-only-scan counts since COPY FREEZE leaves all pages visible.
+CREATE INDEX idx_ent_st_obs_id ON ols_entities (search_type, is_obsolete, id);
+CREATE INDEX idx_ent_onto_st_obs_id ON ols_entities (ontology_id, search_type, is_obsolete, id);
+-- Expression indexes for case-insensitive dynamic filters (?iri=, ?shortForm=, ?curie=),
+-- which compare lower(column) = lower(value) and otherwise force a full table scan.
+CREATE INDEX idx_ent_lower_iri ON ols_entities (lower(iri));
+CREATE INDEX idx_ent_lower_short_form ON ols_entities (lower(short_form));
+CREATE INDEX idx_ent_lower_curie ON ols_entities (lower(curie));
 """
 
 EMBEDDING_NODE_INDEX_SQL = """\


### PR DESCRIPTION
Use GIN-accelerated containment (@>) instead of value = ANY(array) in joins where the array column is on the scanned side (children, descendants, relatedFrom, v1 graph). The = ANY form cannot use the GIN indexes and scans every row of the ontology per lookup (57ms vs 17ms on EFO; far worse on large ontologies). Parents/ancestors joins keep = ANY since there the value side is the scanned column, served by the btree on (ontology_id, iri) at under 1ms.

Add composite indexes (search_type, is_obsolete, id) and (ontology_id, search_type, is_obsolete, id) so paginated listings with ORDER BY id LIMIT n stop at the limit instead of walking the whole primary key, which scanned the full 11M-row table when matches were rare (tree roots: 31s observed in production, 254ms with a filter-first plan). They also enable index-only-scan counts.

Add expression indexes on lower(iri), lower(short_form), lower(curie) for the case-insensitive dynamic filters, which were forcing full table scans (20.8s observed for an ?iri= filter in production).

Related to #1276.