### PR TITLE
Add METPO (Microbial Ecophysiological Trait and Phenotype Ontology)

### DIFF
--- a/dataload/nextflow/ols_dataload.nf
+++ b/dataload/nextflow/ols_dataload.nf
@@ -204,8 +204,8 @@ process merge_configs {
 
 process rdf2json {
     cache "lenient"
-    memory 500.GB
-    time "10h"
+    memory 256.GB
+    time "4h"
     errorStrategy 'ignore'
 
     input:
@@ -353,9 +353,9 @@ process create_postgres {
 
     input:
     path(postgres_tsvs)
-    path(embedding_parquets)
+    path(embedding_parquets, stageAs: 'embeddings_in/*')
     val(filter_properties)
-    path(pca_jsons)
+    path(pca_jsons, stageAs: 'pca_in/*')
     path(text_tagger_db)
 
     output:
@@ -390,9 +390,9 @@ process populate_external_postgres {
 
     input:
     path(postgres_tsvs)
-    path(embedding_parquets)
+    path(embedding_parquets, stageAs: 'embeddings_in/*')
     val(filter_properties)
-    path(pca_jsons)
+    path(pca_jsons, stageAs: 'pca_in/*')
     path(text_tagger_db)
 
     output:

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1942,7 +1942,7 @@
       "id": "metpo",
       "preferredPrefix": "METPO",
       "title": "Microbial Ecophysiological Trait and Phenotype Ontology (METPO)",
-      "description": "An ontology of ecophysiological traits of microbes, including preferred and tolerated growth conditions (temperature, pH, salinity, oxygen, etc.), harmonizing terminology across major trait databases (BacDive, BactoTraits, Madin bacteria_archaea_traits, MetaTraits). Developed for use in KG-Microbe.",
+      "description": "An ontology of ecophysiological traits of microbes, including preferred and tolerated growth conditions (temperature, pH, salinity, oxygen, etc.). It harmonizes terminology across four microbial trait databases: BacDive (https://bacdive.dsmz.de/), BactoTraits (https://ordar.otelo.univ-lorraine.fr/files/ORDAR-53/BactoTraits_databaseV2_Jun2022.csv), the Madin et al. bacteria and archaea traits compilation (https://github.com/jmadin/bacteria_archaea_traits), and MetaTraits (https://metatraits.embl.de/). Developed for use in KG-Microbe.",
       "uri": "https://w3id.org/metpo/metpo.owl",
       "ontology_purl": "https://w3id.org/metpo/metpo.owl",
       "base_uri": [
@@ -1964,7 +1964,6 @@
         "orcid": "0000-0001-9076-6066"
       },
       "license": "https://creativecommons.org/licenses/by/4.0/",
-      "is_foundary": false,
       "reasoner": "EL",
       "oboSlims": false,
       "label_property": "http://www.w3.org/2000/01/rdf-schema#label",

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1937,6 +1937,51 @@
       "ontology_purl": "http://purl.obolibrary.org/obo/vsao.owl",
       "is_obsolete": false,
       "is_deprecated": true
+    },
+    {
+      "id": "metpo",
+      "preferredPrefix": "METPO",
+      "title": "Microbial Ecophysiological Trait and Phenotype Ontology (METPO)",
+      "description": "An ontology of ecophysiological traits of microbes, including preferred and tolerated growth conditions (temperature, pH, salinity, oxygen, etc.), harmonizing terminology across major trait databases (BacDive, BactoTraits, Madin bacteria_archaea_traits, MetaTraits). Developed for use in KG-Microbe.",
+      "uri": "https://w3id.org/metpo/metpo.owl",
+      "ontology_purl": "https://w3id.org/metpo/metpo.owl",
+      "base_uri": [
+        "https://w3id.org/metpo/"
+      ],
+      "homepage": "https://github.com/berkeleybop/metpo",
+      "repository": "https://github.com/berkeleybop/metpo",
+      "tracker": "https://github.com/berkeleybop/metpo/issues",
+      "creator": [
+        "Mark Andrew Miller",
+        "Marcin P. Joachimiak",
+        "Chris Mungall",
+        "Sujay Patil"
+      ],
+      "contact": {
+        "label": "Mark Andrew Miller",
+        "email": "MAM@lbl.gov",
+        "github": "turbomam",
+        "orcid": "0000-0001-9076-6066"
+      },
+      "license": "https://creativecommons.org/licenses/by/4.0/",
+      "is_foundary": false,
+      "reasoner": "EL",
+      "oboSlims": false,
+      "label_property": "http://www.w3.org/2000/01/rdf-schema#label",
+      "definition_property": [
+        "http://purl.obolibrary.org/obo/IAO_0000115"
+      ],
+      "synonym_property": [
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym"
+      ],
+      "preferred_root_term": [
+        "https://w3id.org/metpo/1000630",
+        "https://w3id.org/metpo/1000186",
+        "https://w3id.org/metpo/1000188"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Hello @haideriqbal and  @jamesamcl. Thanks for helping load and tweak GSC MIxS. I'll probably have another issue or two about that next week.

Is requesting the addition of a new real ontology with edits to `ebi_ontologies.json` OK?

METPO harmonizes microbial ecophysiological trait terminology (growth temperature, pH, salinity, and oxygen preferences) across databases like BacDive, BactoTraits, Madin bacteria_archaea_traits, and MetaTraits. It make cross-references to 

- load URL `https://w3id.org/metpo/metpo.owl` resolves (HTTP 200)
- CC BY 4.0
- no `owl:imports`.
- already defined in Bioregistry: https://bioregistry.io/registry/metpo (prefix METPO, ID pattern `^\d+$`).
- Validated locally on the OLS4 `dev` docker build: 1455 classes load, with labels, IAO:0000115 definitions, and source-bound oboInOwl synonyms all rendering; terms are recognized as native (base_uri match), and the three `preferred_root_term` classes pin the tree and keep obsolete classes off it.


<img width="1903" height="962" alt="image" src="https://github.com/user-attachments/assets/de03afd8-d3ab-432b-90b4-ac9a5074e5b4" />
