### PR TITLE
gscmixs: tune OLS rendering config for MIxS

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1705,11 +1705,21 @@
       "mailing_list": "gensc-cig@googlegroups.com",
       "label_property": [
         "http://www.w3.org/2000/01/rdf-schema#label",
-        "http://purl.org/dc/terms/title",
-        "http://schema.org/keywords"
+        "http://purl.org/dc/terms/title"
       ],
       "definition_property": [
         "http://www.w3.org/2004/02/skos/core#definition"
+      ],
+      "synonym_property": [
+        "http://www.w3.org/2004/02/skos/core#altLabel",
+        "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym",
+        "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym"
+      ],
+      "preferred_root_term": [
+        "https://w3id.org/mixs/Checklist",
+        "https://w3id.org/mixs/Extension",
+        "https://w3id.org/linkml/EnumDefinition",
+        "https://w3id.org/linkml/PermissibleValue"
       ],
       "base_uri": [
         "https://w3id.org/mixs/"

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1692,7 +1692,7 @@
       "tracker": "https://github.com/arpcard/aro/issues"
     },
     {
-      "id": "gscmixs",
+      "id": "mixs",
       "creator": [
         "The Genomic Standards Consortium."
       ],
@@ -1704,7 +1704,6 @@
       "homepage": "https://w3id.org/mixs",
       "mailing_list": "gensc-cig@googlegroups.com",
       "label_property": [
-        "http://www.w3.org/2000/01/rdf-schema#label",
         "http://purl.org/dc/terms/title"
       ],
       "definition_property": [


### PR DESCRIPTION
Tunes the `gscmixs` OLS config so MIxS renders better. All of this works against the current published OWL (v6.3.1, loaded by OLS on 2026-07-16), so the earlier "wait for a MIxS release" gate is satisfied.

- **`label_property` -> `[dcterms:title]`** (title-only): OLS shows the human title as the term heading (e.g. "sample name" instead of "samp_name"). Safe because every element now carries `dcterms:title` in the OWL, so nothing falls back to a shortform. Also drops `schema:keywords`, which the OWL no longer emits.
- **Add `synonym_property`** (`skos:altLabel` + oboInOwl exact/related): surfaces the ~46 synonyms already in the OWL that OLS currently does not display.
- **Add `preferred_root_term`** (Checklist, Extension, and the LinkML grouping classes): cleaner tree roots.
- **Rename `id`: `gscmixs` -> `mixs`**: shorter, and matches `preferredPrefix: MIXS`. Note this changes the OLS URL to `/ontologies/mixs` and breaks existing `/ontologies/gscmixs` links. @jamesamcl / @haideriqbal, flagging since it is the one breaking change here; happy to split it into its own PR if you would rather land the rendering config first.

Credit: the original gscmixs display was set up by Tim Van Den Bossche; this builds on it.
