### PR TITLE
fix(dataload): broadcast global filter-property list to json2postgres

### DIFF
--- a/dataload/nextflow/ols_dataload.nf
+++ b/dataload/nextflow/ols_dataload.nf
@@ -153,7 +153,10 @@ workflow {
 
     // Broadcast the global filter-property union to every ontology (not each ontology's own
     // subset) so json2postgres writes the same column count for every *_entities.pgbin file.
-    linked_with_filter_props = linked_ontologies_by_id.combine(all_filter_props)
+    // combine() flattens list-typed items into the resulting tuple, so the property list must
+    // be wrapped in an outer list here — otherwise each URI gets spliced in as its own tuple
+    // position instead of arriving at json2postgres as a single nested list value.
+    linked_with_filter_props = linked_ontologies_by_id.combine(all_filter_props.map { [it] })
 
     postgres_tsvs = json2postgres(linked_with_filter_props, embedding_parquets)
 

--- a/dataload/nextflow/ols_dataload.nf
+++ b/dataload/nextflow/ols_dataload.nf
@@ -77,12 +77,12 @@ workflow {
     ontologies = merged_config.flatMap { it.ontologies }
     ontology_ids = ontologies.map { it.id }
 
-    // Extract filter properties per ontology (from merged config which includes defaults)
-    filter_props_by_id = ontologies.map { ont ->
-        def props = ont.filterProperty ?: []
-        [ont.id, props]
-    }
-    // Collect global union of all filter properties for schema creation
+    // Collect global union of all filter properties for schema creation.
+    // Every ontology's json2postgres invocation gets this same global list (not just
+    // its own filterProperty subset) so every *_entities.pgbin file has the same column
+    // count/order — populate_external_postgres.py builds one fixed schema from this union
+    // and COPYs every file against it, so a narrower per-ontology list breaks binary COPY
+    // with a "row field count" mismatch.
     all_filter_props = merged_config.map { config ->
         config.ontologies.collectMany { it.filterProperty ?: [] }.unique()
     }
@@ -151,8 +151,9 @@ workflow {
         pca_json_files = Channel.of(file('NO_FILE'))
     }
 
-    // Join filter properties with linked ontology JSONs by ontology_id
-    linked_with_filter_props = linked_ontologies_by_id.combine(filter_props_by_id, by: 0)
+    // Broadcast the global filter-property union to every ontology (not each ontology's own
+    // subset) so json2postgres writes the same column count for every *_entities.pgbin file.
+    linked_with_filter_props = linked_ontologies_by_id.combine(all_filter_props)
 
     postgres_tsvs = json2postgres(linked_with_filter_props, embedding_parquets)
 


### PR DESCRIPTION
## Summary
- Jenkins postgres populate step failed: `ols_entities load failed: ERROR: row field count is 34, expected 40`
- Root cause: `json2postgres` wrote each ontology's own `filterProperty` subset as entity columns, while `populate_external_postgres.py` builds one fixed COPY schema from the **global union** of `filterProperty` across all ontologies. Any ontology whose own list is narrower than the union writes fewer binary columns than the schema expects, breaking `\copy ... FREEZE`.
- Triggered by adding `filterProperty` to ICTV in `ebi_ontologies.json` — widened the global union (1 → 7), exposing the pre-existing per-ontology vs. global-union mismatch that had been silently matching by coincidence until now.
- Fix: broadcast the global `all_filter_props` union to every ontology's `json2postgres` invocation instead of that ontology's own subset (`ols_dataload.nf`). `extract_localized_strings` in the Rust writer already returns an empty value for a property an entity doesn't have, so this is safe — every `*_entities.pgbin` file now always has the same column count/order.

## Test plan
- [ ] Run the Nextflow dataload pipeline (or at minimum `json2postgres` + `populate_external_postgres` stages) with a config where ontologies have differing `filterProperty` lists (e.g. ICTV vs. others) and confirm `ols_entities` COPY succeeds
- [ ] Spot-check `ols_entities` filter_* columns are populated (non-null) for ontologies whose own config previously excluded some of the now-broadcast properties, and null/empty for entities without that property