### PR TITLE
fix(dataload): add prefix and ontology fields to SSSOM other block

### DIFF
--- a/dataload/extras/json2sssom/src/main/java/JSON2SSSOM.java
+++ b/dataload/extras/json2sssom/src/main/java/JSON2SSSOM.java
@@ -214,8 +214,15 @@ public class JSON2SSSOM {
                     yamlHeader.put("mapping_set_title", "OLS extracted " + mappingSetOntologyName + " mappings");
                     yamlHeader.put("mapping_set_description", "These mappings were extracted during the OLS dataload from " + mappingSetOntologyName);
                     yamlHeader.put("mapping_date", mappingDate);
+                    String mappingSetOntologyTitle = getStringProperty(ontologyProperties, "title");
+                    String mappingSetOntologyFullName = mappingSetOntologyTitle == null || mappingSetOntologyTitle.isBlank()
+                            ? mappingSetOntologyName
+                            : mappingSetOntologyTitle + " (" + mappingSetOntologyName + ")";
+
                     Map<String, Object> yamlHeaderOther = new LinkedHashMap<>();
                     yamlHeaderOther.put("local_id", ontologyId + ".ols");
+                    yamlHeaderOther.put("prefix", mappingSetOntologyName);
+                    yamlHeaderOther.put("ontology", mappingSetOntologyFullName);
                     yamlHeader.put("other", yamlHeaderOther);
                     yamlHeader.put("local_name", ontologyId + ".ols.sssom.tsv");
                     yamlHeader.put("curie_map", curieMap.curiePrefixToNamespace);

--- a/dataload/extras/json2sssom/src/test/java/JSON2SSSOMTest.java
+++ b/dataload/extras/json2sssom/src/test/java/JSON2SSSOMTest.java
@@ -28,6 +28,7 @@ public class JSON2SSSOMTest {
                 "    {\n" +
                 "      \"ontologyId\": \"apo\",\n" +
                 "      \"preferredPrefix\": \"APO\",\n" +
+                "      \"title\": \"Ascomycete Phenotype Ontology\",\n" +
                 "      \"classes\": [],\n" +
                 "      \"properties\": [],\n" +
                 "      \"individuals\": [],\n" +
@@ -51,8 +52,38 @@ public class JSON2SSSOMTest {
         assertTrue(sssom.contains("# mapping_set_title: OLS extracted APO mappings\n"));
         assertTrue(sssom.contains("# mapping_set_description: These mappings were extracted during the OLS dataload from APO\n"));
         assertTrue(sssom.contains("# mapping_date: '2026-04-30'\n") || sssom.contains("# mapping_date: 2026-04-30\n"));
-        assertTrue(sssom.contains("# other:\n#   local_id: apo.ols\n# local_name: apo.ols.sssom.tsv\n"));
+        assertTrue(sssom.contains("# other:\n#   local_id: apo.ols\n#   prefix: APO\n#   ontology: Ascomycete Phenotype Ontology (APO)\n# local_name: apo.ols.sssom.tsv\n"));
         assertFalse(sssom.contains("mapping_set_source"));
+    }
+
+    @Test
+    public void fallsBackToPrefixForOntologyFieldWhenTitleMissing() throws Exception {
+        File input = temporaryFolder.newFile("notitle.json");
+        File outputDir = temporaryFolder.newFolder("sssom-notitle");
+
+        Files.writeString(input.toPath(), "{\n" +
+                "  \"ontologies\": [\n" +
+                "    {\n" +
+                "      \"ontologyId\": \"nt\",\n" +
+                "      \"preferredPrefix\": \"NT\",\n" +
+                "      \"classes\": [],\n" +
+                "      \"properties\": [],\n" +
+                "      \"individuals\": [],\n" +
+                "      \"linkedEntities\": {}\n" +
+                "    }\n" +
+                "  ]\n" +
+                "}\n", StandardCharsets.UTF_8);
+
+        JSON2SSSOM.main(new String[] {
+                "--input", input.getAbsolutePath(),
+                "--outDir", outputDir.getAbsolutePath(),
+                "--mappingDate", "2026-04-30"
+        });
+
+        Path output = outputDir.toPath().resolve("nt.ols.sssom.tsv");
+        String sssom = Files.readString(output, StandardCharsets.UTF_8).replace("\r\n", "\n");
+
+        assertTrue(sssom.contains("# other:\n#   local_id: nt.ols\n#   prefix: NT\n#   ontology: NT\n# local_name: nt.ols.sssom.tsv\n"));
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Closes latest ask on #1243: extends the SSSOM extract's `other:` header with `prefix` and `ontology`, alongside the existing `local_id`.
- `prefix` = preferred ontology prefix (e.g. `APO`).
- `ontology` = full ontology title + prefix (e.g. `Ascomycete Phenotype Ontology (APO)`), falling back to just the prefix when no `title` is configured for the ontology.

## Test plan
- [x] `mvn test` in `dataload/extras/json2sssom` — all 3 tests pass (added `fallsBackToPrefixForOntologyFieldWhenTitleMissing`, extended `writesMappingSetMetadataAlignedWithSssomSpec`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)