### PR TITLE
fix(backend): make v1 search groupField collapse results by IRI

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
@@ -91,8 +91,10 @@ public class V1SearchController {
                     example = "false") boolean exact,
             @RequestParam(value = "groupField", required = false)
             @Parameter(name = "groupField",
-                    description = "Group results by unique id (IRI)",
-                    example = "http://www.ebi.ac.uk/efo/EFO_0001421") String groupField,
+                    description = "Set to true to group results by unique id (IRI), returning only the "
+                            + "best match for each IRI instead of one result per ontology containing it. "
+                            + "Any value other than false enables grouping.",
+                    example = "true") String groupField,
             @RequestParam(value = "obsoletes", defaultValue = "false")
             @Parameter(name = "obsoletes",
                     description = "Set to true to include obsoleted terms in the results",
@@ -182,9 +184,11 @@ public class V1SearchController {
         searchQuery.addFacetField(IS_DEFINING_ONTOLOGY.getText());
         searchQuery.addFacetField(IS_OBSOLETE.getText());
 
-        logger.debug("V1 SEARCH QUERY: searchText={}", query);
+        boolean groupByIri = isGroupingEnabled(groupField);
 
-        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(searchQuery, start, rows);
+        logger.debug("V1 SEARCH QUERY: searchText={} groupByIri={}", query, groupByIri);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(searchQuery, start, rows, groupByIri);
 
         List<Object> docs = new ArrayList<>();
         for (String _json : result.jsonStrings) {
@@ -312,6 +316,19 @@ public class V1SearchController {
         response.setCharacterEncoding(StandardCharsets.UTF_8.name());
         response.getOutputStream().write(gson.toJson(responseObj).getBytes(StandardCharsets.UTF_8));
         response.flushBuffer();
+    }
+
+    /**
+     * The v1 API has always collapsed on IRI regardless of the value passed to groupField: the
+     * Solr implementation applied {@code {!collapse field=uri}} whenever the parameter was present,
+     * so clients in the wild send both {@code groupField=true} and an IRI (which the old
+     * documentation gave as the example). Both are honoured; only an absent, blank or explicitly
+     * false value turns grouping off.
+     */
+    private static boolean isGroupingEnabled(String groupField) {
+        return groupField != null
+                && !groupField.isBlank()
+                && !groupField.equalsIgnoreCase("false");
     }
 
     // Built from DefinedFields enum (ols3Text → text) plus a few non-enum V1 aliases.

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
@@ -40,6 +40,10 @@ public class OlsSearchClient {
     private static final Field<String> COLUMN_NAME = field("column_name", String.class);
     private static final Field<String> ENTITY_ID = field("id", String.class);
     private static final Field<byte[]> ENTITY_JSON = field("_json", byte[].class);
+    private static final Field<String> ENTITY_IRI = field("iri", String.class);
+    private static final String GROUP_HEAD_ID = "group_head_id";
+    private static final String GROUP_SCORE = "group_score";
+    private static final String GROUP_TOTAL = "group_total";
     private static final Field<String> LABEL_FOR_SUGGEST = field("label_for_suggest", String.class);
     private static final Field<String> STRING_VALUE = field("string", String.class);
     private static final Field<String> ONTOLOGY_ID = field("ontology_id", String.class);
@@ -273,24 +277,55 @@ public class OlsSearchClient {
      * Used by V1 controllers that build their own response format.
      */
     public RawSearchResult searchRaw(OlsSearchQuery query, int start, int rows) {
+        return searchRaw(query, start, rows, false);
+    }
+
+    /**
+     * Raw paginated search, optionally collapsing results so that only one entity per distinct IRI
+     * is returned.
+     *
+     * <p>The same term is usually present in many ontologies (a defining ontology plus every
+     * ontology that imports it), all sharing one IRI. Collapsing keeps the best-ranked entity of
+     * each IRI group — which, because {@link OlsSearchQuery#buildOrderBy} boosts defining
+     * ontologies, is normally the entity from the ontology that defines the term. {@code numFound}
+     * becomes the number of distinct IRIs rather than the number of entities. This backs the v1
+     * {@code groupField} search parameter (GitHub issue #1333).
+     *
+     * <p>Facet counts stay entity-level even when collapsing, so the ontology facet still answers
+     * "which ontologies contain this term" for a grouped result.
+     */
+    public RawSearchResult searchRaw(OlsSearchQuery query, int start, int rows, boolean collapseByIri) {
         try (Connection conn = postgresClient.getConnection()) {
             DSLContext dsl = postgresClient.dsl(conn);
             Condition where = query.buildCondition(getAvailableFilterColumns());
             List<SortField<?>> orderBy = query.buildOrderBy();
 
-            long count = Optional.ofNullable(dsl.selectCount()
-                            .from(OLS_ENTITIES)
-                            .where(where)
-                            .fetchOne(0, Long.class))
-                    .orElse(0L);
+            long count;
+            org.jooq.Result<? extends Record> records;
 
-            var records = dsl.select(ENTITY_JSON)
-                    .from(OLS_ENTITIES)
-                    .where(where)
-                    .orderBy(orderBy)
-                    .offset(start)
-                    .limit(rows)
-                    .fetch();
+            if (collapseByIri) {
+                records = fetchCollapsedByIri(dsl, query, where, orderBy, start, rows);
+                // The number of IRI groups is carried out of the page query itself; it is only
+                // unavailable when the page came back empty, which is the one case cheap enough
+                // to count separately.
+                count = records.isEmpty()
+                        ? countDistinctIris(dsl, where)
+                        : records.get(0).get(GROUP_TOTAL, Long.class);
+            } else {
+                count = Optional.ofNullable(dsl.selectCount()
+                                .from(OLS_ENTITIES)
+                                .where(where)
+                                .fetchOne(0, Long.class))
+                        .orElse(0L);
+
+                records = dsl.select(ENTITY_JSON)
+                        .from(OLS_ENTITIES)
+                        .where(where)
+                        .orderBy(orderBy)
+                        .offset(start)
+                        .limit(rows)
+                        .fetch();
+            }
 
             List<String> jsonStrings = readJsonStrings(records);
 
@@ -303,6 +338,90 @@ public class OlsSearchClient {
         } catch (SQLException e) {
             throw new RuntimeException("Raw search query failed", e);
         }
+    }
+
+    /**
+     * Fetch one row per distinct IRI: rank the matches within each IRI group using the query's own
+     * ordering, keep the first of each group, page over those group heads, and only then join the
+     * compressed {@code _json} payload back on.
+     *
+     * <p>Ordering and paging happen on id/iri/score alone so that the {@code LIMIT} is applied
+     * before the payload lookup — otherwise PostgreSQL joins {@code _json} for every group head in
+     * the result set (hundreds of thousands of primary key lookups for a broad query) just to
+     * return ten rows.
+     *
+     * <p>Entities from a defining ontology win their group: the query ordering already boosts them
+     * when there is search text to rank, and the explicit tiebreak keeps that true for filter-only
+     * queries, which are ordered by id alone.
+     */
+    private org.jooq.Result<? extends Record> fetchCollapsedByIri(DSLContext dsl, OlsSearchQuery query,
+                                                                 Condition where,
+                                                                 List<SortField<?>> orderBy,
+                                                                 int start, int rows) {
+        List<SortField<?>> groupHeadOrder = new ArrayList<>();
+        groupHeadOrder.add(field("is_defining_ontology", Boolean.class).desc());
+        groupHeadOrder.addAll(orderBy);
+
+        Field<Double> rank = query.buildRankExpression(null);
+        Field<Integer> rn = DSL.rowNumber()
+                .over(DSL.partitionBy(ENTITY_IRI).orderBy(groupHeadOrder))
+                .as("rn");
+
+        List<Field<?>> rankedFields = new ArrayList<>();
+        rankedFields.add(ENTITY_ID.as(GROUP_HEAD_ID));
+        if (rank != null) {
+            rankedFields.add(rank.as(GROUP_SCORE));
+        }
+        rankedFields.add(rn);
+
+        Table<?> ranked = dsl.select(rankedFields)
+                .from(OLS_ENTITIES)
+                .where(where)
+                .asTable("ranked");
+
+        List<Field<?>> headFields = new ArrayList<>();
+        headFields.add(field("ranked", GROUP_HEAD_ID, String.class));
+        if (rank != null) {
+            headFields.add(field("ranked", GROUP_SCORE, Double.class));
+        }
+        // Counted over the group heads before the LIMIT applies, so the page query also yields the
+        // total number of IRI groups without a second pass over the matches.
+        headFields.add(DSL.count().over().cast(Long.class).as(GROUP_TOTAL));
+
+        Table<?> groupHeads = dsl.select(headFields)
+                .from(ranked)
+                .where(field("ranked", "rn", Integer.class).eq(1))
+                .orderBy(collapsedOrderBy("ranked", rank != null))
+                .offset(start)
+                .limit(rows)
+                .asTable("group_heads");
+
+        return dsl.select(ENTITY_JSON, field("group_heads", GROUP_TOTAL, Long.class))
+                .from(OLS_ENTITIES)
+                .join(groupHeads)
+                .on(field("group_heads", GROUP_HEAD_ID, String.class).eq(ENTITY_ID))
+                .orderBy(collapsedOrderBy("group_heads", rank != null))
+                .fetch();
+    }
+
+    private long countDistinctIris(DSLContext dsl, Condition where) {
+        return Optional.ofNullable(dsl.select(DSL.countDistinct(ENTITY_IRI))
+                        .from(OLS_ENTITIES)
+                        .where(where)
+                        .fetchOne(0, Long.class))
+                .orElse(0L);
+    }
+
+    /**
+     * Ordering over already-collapsed group heads: by the score column carried out of the ranking
+     * subquery, falling back to id for filter-only queries that have no score.
+     */
+    private static List<SortField<?>> collapsedOrderBy(String qualifier, boolean hasScore) {
+        Field<String> id = field(qualifier, GROUP_HEAD_ID, String.class);
+        if (!hasScore) {
+            return List.of(id.asc());
+        }
+        return List.of(field(qualifier, GROUP_SCORE, Double.class).desc(), id.asc());
     }
 
     /**

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -171,20 +171,33 @@ public class OlsSearchQuery {
     }
 
     public List<SortField<?>> buildOrderBy(String qualifier) {
-        if (searchText != null && !searchText.isBlank()) {
-            Field<Double> rank = DSL.function(
-                    "ts_rank_cd",
-                    SQLDataType.DOUBLE,
-                    field(qualifier, "ts_search", Object.class),
-                    buildTsQuery(),
-                    DSL.inline(32))
-                    .plus(DSL.when(field(qualifier, "is_defining_ontology", Boolean.class).isTrue(), 100.0).otherwise(0.0))
-                    .plus(DSL.when(field(qualifier, "search_type", String.class).eq("ontology"), 1.0).otherwise(0.0))
-                    .plus(DSL.when(arrayContains(field(qualifier, "label", String[].class), searchText), 1000.0).otherwise(0.0));
-
+        Field<Double> rank = buildRankExpression(qualifier);
+        if (rank != null) {
             return List.of(rank.desc(), field(qualifier, "id", String.class).asc());
         }
         return List.of(field(qualifier, "id", String.class).asc());
+    }
+
+    /**
+     * The relevance score results are ordered by, or null when there is no search text to rank
+     * (filter-only queries are ordered by id alone).
+     *
+     * <p>Exposed separately from {@link #buildOrderBy} so callers can select the score as a column
+     * — needed when ordering has to happen in a subquery rather than on the base table.
+     */
+    public Field<Double> buildRankExpression(String qualifier) {
+        if (searchText == null || searchText.isBlank()) {
+            return null;
+        }
+        return DSL.function(
+                "ts_rank_cd",
+                SQLDataType.DOUBLE,
+                field(qualifier, "ts_search", Object.class),
+                buildTsQuery(),
+                DSL.inline(32))
+                .plus(DSL.when(field(qualifier, "is_defining_ontology", Boolean.class).isTrue(), 100.0).otherwise(0.0))
+                .plus(DSL.when(field(qualifier, "search_type", String.class).eq("ontology"), 1.0).otherwise(0.0))
+                .plus(DSL.when(arrayContains(field(qualifier, "label", String[].class), searchText), 1000.0).otherwise(0.0));
     }
 
     /**


### PR DESCRIPTION
Fixes #1333

## Problem

`groupField` on `/api/search` has been accepted and then ignored since the move from Solr to PostgreSQL (`e03231ee0`). The Solr implementation applied `{!collapse field=uri}` whenever the parameter was present; the collapse was not carried over, leaving the request param parsed but unused.

Searching for a term that many ontologies import therefore returned one result per ontology with an unchanged `numFound`, whatever `groupField` was set to — the behaviour reported in the issue:

```
q=UBERON:0002107&queryFields=obo_id&exact=true              → numFound 42
… &groupField=true                                          → numFound 42
… &groupField=http://purl.obolibrary.org/obo/UBERON_0002107 → numFound 42
```

All 42 entities share a single IRI: uberon defines the term, 41 ontologies import it.

## Change

Collapse in PostgreSQL with a `row_number()` window partitioned by `iri`, keeping the best-ranked entity of each group. `numFound` becomes the number of distinct IRIs.

Entities from a defining ontology win their group: the search ranking already boosts them, and an explicit tiebreak keeps that true for filter-only queries, which are ordered by id alone.

Grouping is enabled by any value other than blank or `false`, matching the old presence-only Solr semantics — clients in the wild send both `groupField=true` (e.g. [biovalidator](https://github.com/elixir-europe/biovalidator/blob/f45bd45202a751aeea6a058a74788077ab90834f/src/utils/curie_expansion.js#L20)) and an IRI, which is what the old parameter documentation gave as its example.

Facet counts stay entity-level, so the ontology facet still answers "which ontologies contain this term" for a grouped result.

## Query shape

Two details matter for cost, both found by measuring against a copy of the production database:

1. Ordering, paging and the group count all happen on `id`/`iri`/score alone; the compressed `_json` payload is joined back only for the rows that survive the `LIMIT`. Ordering the outer query on the base table instead made PostgreSQL run a primary key lookup for **every** group head (`loops=497168` on a broad query) just to return ten rows.
2. `numFound` comes out of the same pass as a window count over the group heads, rather than a separate `count(distinct iri)`. The count query is now only issued as a fallback when the page came back empty.

Measured on `spotolspub` (warm, order-independent):

| query | matches | plain | grouped |
|---|---|---|---|
| `UBERON:0002107` (exact, obo_id) | 42 | 88ms | 41ms |
| `liver` | 15.9k | 111ms | 196ms |
| `cell` | 349k | 856ms | 2.1s |
| `protein` | 891k | 1.3s | 4.1s |

Grouping a pathological 891k-match query costs ~3x the plain query. It is opt-in, and the counts were identical at every stage of the optimisation, so the speedups did not change results.

## Verification

Ran against a copy of the production database (no test suite exists in `backend/`, so this is manual verification):

**The issue's requests**

| request | numFound | docs |
|---|---|---|
| no `groupField` | 42 | uberon, aism, bao … |
| `groupField=true` | 1 | uberon |
| `groupField=<iri>` | 1 | uberon |
| `groupField=false` | 42 | unchanged |

The surviving entity is the uberon one (`isDefiningOntology=true`). biovalidator's exact request shape returns `numFound 1` with the right IRI.

**Nothing else moves.** Compared this branch against production for the same requests — `numFound`/`totalElements` plus the identity and order of the first five hits — 15/15 identical:

`/api/search` (plain, `exact=true`, `queryFields=obo_id`, `ontology=`, `type=`+`local=true`, prefix match, `obsoletes=true`, `start=20`), `/api/select` ×2, `/api/suggest` (byte-identical), `/api/v2/entities?search=`, `/api/v2/ontologies/efo/classes?search=`, `/api/v2/ontologies`, `/api/ontologies/efo/terms`.

Also checked: filter-only collapsed queries (no rank column), the empty-page count fallback (`start=1000000` still reports the right total), and paging over collapsed groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)