### PR TITLE
Add UOGTO ontology

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -1989,6 +1989,20 @@
         "https://w3id.org/metpo/1000186",
         "https://w3id.org/metpo/1000188"
       ]
+    },
+    {
+      "id": "uogto",
+      "preferredPrefix": "UOGTO",
+      "title": "Universal Open Game Theory Ontology",
+      "ontology_purl": "https://github.com/edithatogo/UOGTO/releases/download/v1.0.0/uogto.ttl",
+      "base_uri": [
+        "https://w3id.org/uogto/core#",
+        "https://w3id.org/uogto/extensions#"
+      ],
+      "homepage": "https://github.com/edithatogo/UOGTO",
+      "repository": "https://github.com/edithatogo/UOGTO",
+      "tracker": "https://github.com/edithatogo/UOGTO/issues",
+      "license": "https://creativecommons.org/licenses/by/4.0/"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Adds the Universal Open Game Theory Ontology (UOGTO) entry to `ebi_ontologies.json`, using the metadata requested in the issue: `preferredPrefix: uogto`, ontology PURL, core/extension namespaces, homepage, repository, tracker, and license.

Closes #1305

## Test plan
- [x] Validated `ebi_ontologies.json` still parses as valid JSON (122 ontologies total)
- [ ] Confirm the ontology loads correctly in the dataload pipeline once run