### PR TITLE
fix(docs): correct searchFields example to singular synonym field

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassController.java
@@ -96,7 +96,7 @@ public class V2ClassController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",
@@ -149,7 +149,7 @@ public class V2ClassController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
@@ -57,7 +57,7 @@ public class V2EntityController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",
@@ -123,7 +123,7 @@ public class V2EntityController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualController.java
@@ -54,7 +54,7 @@ public class V2IndividualController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",
@@ -105,7 +105,7 @@ public class V2IndividualController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyController.java
@@ -52,7 +52,7 @@ public class V2OntologyController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label, ontologyId and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "ontologyId") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2PropertyController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2PropertyController.java
@@ -53,7 +53,7 @@ public class V2PropertyController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1",
+                            "For example, label^3 synonym^2 description^1 logical_definition^1",
                     example = "label^100 description") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boostFields",
@@ -105,7 +105,7 @@ public class V2PropertyController {
                             "The fields are weighted equally. The fields are defined in the schema. " +
                             "The default fields are label and definition. " +
                             "The fields weights can be boosted by appending a caret ^ and a positive integer to the field name. " +
-                            "For example, label^3 synonyms^2 description^1 logical_definition^1") String searchFields,
+                            "For example, label^3 synonym^2 description^1 logical_definition^1") String searchFields,
             @RequestParam(value = "boostFields", required = false)
             @Parameter(name = "boost fields",
                     description = "This parameter is a white space separated list of fields appended with a caret to boost in search. " +


### PR DESCRIPTION
## Summary
- The V2 API docs for the `searchFields` param showed the example `label^3 synonyms^2 description^1 logical_definition^1`, using plural `synonyms`.
- The actual queryable field is singular `synonym` (see `DefinedFields.SYNONYM` and `SearchFieldsParser`), and has been singular since before the Postgres migration.
- Fixes the doc example across all 5 V2 controllers that expose this param: Class, Entity, Individual, Ontology, Property.

Reported by @Angatar in #1276 — using `searchFields=synonyms` per the doc silently returns zero results, while `searchFields=synonym` works.

## Test plan
- [x] Grepped for remaining `synonyms^2` occurrences — none left
- [x] Confirmed `synonym` is the actual field name in `DefinedFields.java` and `OlsSearchQuery.java` column registry
- [ ] Docs-only change, no behavioral/test impact expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)