### PR TITLE
fix(backend): case-insensitive + field-restricted search fixes (#1309, #1308, #1312)

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
@@ -102,4 +102,12 @@ public final class JooqSupport {
     public static Condition matchesTsQuery(Field<?> tsVector, Field<?> tsQuery) {
         return DSL.condition("{0} @@ {1}", tsVector, tsQuery);
     }
+
+    public static Condition tsvectorMatches(Field<?> textOrArrayField, Field<?> tsQuery) {
+        // ols_tsvector() has both a text and text[] overload (see create_postgres_schema.py);
+        // Postgres resolves the right one from the column's runtime type. Used to restrict
+        // non-exact search to specific searchFields/queryFields instead of the blanket ts_search
+        // column, which spans every field regardless of what was requested. See GitHub issue #1308.
+        return DSL.condition("ols_tsvector({0}) @@ {1}", textOrArrayField, tsQuery);
+    }
 }

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
@@ -37,6 +37,14 @@ public final class JooqSupport {
         return DSL.condition("{0} @> ARRAY[{1}]::text[]", arrayField, DSL.val(value));
     }
 
+    public static Condition arrayContainsCaseInsensitive(Field<String[]> arrayField, String lowerValue) {
+        // Case-insensitive counterpart to arrayContains(): matches against the ols_lower_array()
+        // expression (see idx_ent_label_lower / idx_ent_synonym_lower) instead of the raw column,
+        // so the comparison stays GIN-accelerated. Caller must lowercase `lowerValue` already.
+        // See GitHub issue #1309.
+        return DSL.condition("ols_lower_array({0}) @> ARRAY[{1}]::text[]", arrayField, DSL.val(lowerValue));
+    }
+
     public static Condition arrayContains(Field<String[]> arrayField, Field<String> valueField) {
         // `value = ANY(array)` form: only useful when the *value* side is the scanned column
         // (e.g. e2.iri = ANY(e1.direct_parents) in a nested loop, served by a btree index on

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -17,6 +17,7 @@ import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.field;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.matchesTsQuery;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.phraseToTsQuery;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.toTsQuery;
+import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.tsvectorMatches;
 
 /**
  * Builds jOOQ conditions and ordering for entity search/filter operations.
@@ -139,8 +140,10 @@ public class OlsSearchQuery {
         Condition condition = DSL.trueCondition();
 
         if (searchText != null && !searchText.isBlank()) {
-            if (exactMatch && searchFields != null && !searchFields.isEmpty()) {
-                condition = condition.and(buildExactFieldCondition(qualifier, availableFilterColumns));
+            if (searchFields != null && !searchFields.isEmpty()) {
+                condition = condition.and(exactMatch
+                        ? buildExactFieldCondition(qualifier, availableFilterColumns)
+                        : buildFieldRestrictedTsCondition(qualifier, availableFilterColumns));
             } else {
                 condition = condition.and(matchesTsQuery(field(qualifier, "ts_search", Object.class), buildTsQuery()));
             }
@@ -237,6 +240,39 @@ public class OlsSearchQuery {
             } else {
                 anyField = anyField.or(DSL.lower(field(qualifier, col, String.class)).eq(lowerSearch));
             }
+        }
+        return anyField;
+    }
+
+    /**
+     * For non-exact queries with explicit searchFields, restrict full-text matching to those
+     * specific fields instead of the blanket ts_search column.
+     *
+     * ts_search is a single generated tsvector spanning every searchable column (label, short_form,
+     * curie, synonym, definition, iri), so matching against it ignores which fields the caller
+     * asked for — a query restricted to queryFields=label,synonym would still match on hits inside
+     * definition. This builds an ad-hoc ols_tsvector(column) @@ tsquery per requested field instead,
+     * OR'd together, mirroring buildExactFieldCondition()'s column resolution. See GitHub issue #1308.
+     *
+     * Backed by per-field GIN expression indexes (idx_ent_label_fts, idx_ent_synonym_fts) so the
+     * restricted match stays index-accelerated for the fields callers actually request in practice.
+     * Fields without such an index still match correctly, just via a slower scan.
+     */
+    private Condition buildFieldRestrictedTsCondition(String qualifier, Set<String> availableFilterColumns) {
+        Field<Object> tsQuery = buildTsQuery();
+        Condition anyField = DSL.falseCondition();
+        for (String qf : searchFields) {
+            boolean knownCol = COLUMN_MAP.containsKey(qf);
+            String col;
+            try {
+                col = resolveColumn(qf);
+            } catch (IllegalArgumentException e) {
+                continue;
+            }
+            boolean filterCol = !knownCol && availableFilterColumns != null && availableFilterColumns.contains(col);
+            if (!knownCol && !filterCol) continue;
+            if (knownCol && resolveColumnType(qf) == ColumnType.BOOLEAN) continue;
+            anyField = anyField.or(tsvectorMatches(field(qualifier, col, Object.class), tsQuery));
         }
         return anyField;
     }

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContains;
+import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.arrayContainsCaseInsensitive;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.field;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.matchesTsQuery;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.phraseToTsQuery;
@@ -213,7 +214,8 @@ public class OlsSearchQuery {
      * results from completely unrelated fields, which is misleading — the caller explicitly asked
      * for a specific field and should get zero results if that field is not indexed.
      *
-     * Array columns use GIN @> containment for fast bitmap index scans.
+     * Array columns use case-insensitive GIN @> containment against ols_lower_array(column)
+     * (idx_ent_label_lower / idx_ent_synonym_lower) for fast bitmap index scans.
      * Scalar columns use lower()=lower() for case-insensitive equality.
      */
     private Condition buildExactFieldCondition(String qualifier, Set<String> availableFilterColumns) {
@@ -231,7 +233,7 @@ public class OlsSearchQuery {
             if (!knownCol && !filterCol) continue;
             ColumnType ct = knownCol ? resolveColumnType(qf) : ColumnType.TEXT_ARRAY;
             if (ct == ColumnType.TEXT_ARRAY) {
-                anyField = anyField.or(arrayContains(field(qualifier, col, String[].class), searchText));
+                anyField = anyField.or(arrayContainsCaseInsensitive(field(qualifier, col, String[].class), lowerSearch));
             } else {
                 anyField = anyField.or(DSL.lower(field(qualifier, col, String.class)).eq(lowerSearch));
             }

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -201,7 +201,12 @@ public class OlsSearchQuery {
                 DSL.inline(32))
                 .plus(DSL.when(field(qualifier, "is_defining_ontology", Boolean.class).isTrue(), 100.0).otherwise(0.0))
                 .plus(DSL.when(field(qualifier, "search_type", String.class).eq("ontology"), 1.0).otherwise(0.0))
-                .plus(DSL.when(arrayContains(field(qualifier, "label", String[].class), searchText), 1000.0).otherwise(0.0));
+                // Case-insensitive so an exact-label hit still gets the ranking bonus regardless of
+                // input casing (e.g. "mus musculus" vs stored "Mus musculus") — matches the
+                // case-insensitive semantics buildExactFieldCondition() already uses. Without this,
+                // exact matches whose case differs from the query rank purely on ts_rank_cd and can
+                // end up buried many pages deep. See GitHub issue #1312.
+                .plus(DSL.when(arrayContainsCaseInsensitive(field(qualifier, "label", String[].class), searchText.toLowerCase(Locale.ROOT)), 1000.0).otherwise(0.0));
     }
 
     /**

--- a/dataload/create_postgres_schema.py
+++ b/dataload/create_postgres_schema.py
@@ -130,7 +130,7 @@ CREATE INDEX idx_ent_synonym_lower ON ols_entities USING gin (ols_lower_array(sy
 -- Per-field full-text indexes, used by buildFieldRestrictedTsCondition() (JooqSupport.tsvectorMatches)
 -- to keep non-exact searchFields/queryFields-restricted queries index-accelerated instead of matching
 -- against the blanket ts_search column, which spans every field regardless of what was requested.
--- Scoped to label/synonym for now (the reported case); extend to other fields if they see real
+-- Scoped to label/synonym for now (the reported case) -- extend to other fields if they see real
 -- queryFields usage. See GitHub issue #1308.
 CREATE INDEX idx_ent_label_fts ON ols_entities USING gin (ols_tsvector(label));
 CREATE INDEX idx_ent_synonym_fts ON ols_entities USING gin (ols_tsvector(synonym));

--- a/dataload/create_postgres_schema.py
+++ b/dataload/create_postgres_schema.py
@@ -42,6 +42,12 @@ CREATE OR REPLACE FUNCTION ols_tsvector(txt text)
 CREATE OR REPLACE FUNCTION ols_tsvector(arr text[])
     RETURNS tsvector LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE AS
     $$ BEGIN RETURN to_tsvector('pg_catalog.english', coalesce(array_to_string(arr, ' '), '')); END $$;
+
+-- Lowercases every element of a text[] so exact-match array containment (label @>, synonym @>)
+-- can be done case-insensitively while still using a GIN expression index. See GitHub issue #1309.
+CREATE OR REPLACE FUNCTION ols_lower_array(arr text[])
+    RETURNS text[] LANGUAGE sql IMMUTABLE PARALLEL SAFE AS
+    $$ SELECT array_agg(lower(x)) FROM unnest(arr) AS x $$;
 """
 
 ENTITIES_TABLE_SQL = """\
@@ -116,6 +122,11 @@ CREATE INDEX idx_ent_pref_root ON ols_entities (is_preferred_root) WHERE is_pref
 CREATE INDEX idx_ent_subset ON ols_entities USING gin (subset);
 CREATE INDEX idx_ent_label ON ols_entities USING gin (label);
 CREATE INDEX idx_ent_synonym ON ols_entities USING gin (synonym);
+-- Case-insensitive counterparts, used by exact-match array containment (see arrayContainsCaseInsensitive
+-- in JooqSupport.java / GitHub issue #1309). Without these the case-insensitive query falls back to an
+-- unindexed unnest() scan of the whole table.
+CREATE INDEX idx_ent_label_lower ON ols_entities USING gin (ols_lower_array(label));
+CREATE INDEX idx_ent_synonym_lower ON ols_entities USING gin (ols_lower_array(synonym));
 CREATE INDEX idx_ent_related_to ON ols_entities USING gin (related_to);
 CREATE INDEX idx_ent_fts ON ols_entities USING gin (ts_search);
 CREATE INDEX idx_ent_trgm_suggest ON ols_entities USING gin (label_for_suggest gin_trgm_ops);

--- a/dataload/create_postgres_schema.py
+++ b/dataload/create_postgres_schema.py
@@ -127,6 +127,13 @@ CREATE INDEX idx_ent_synonym ON ols_entities USING gin (synonym);
 -- unindexed unnest() scan of the whole table.
 CREATE INDEX idx_ent_label_lower ON ols_entities USING gin (ols_lower_array(label));
 CREATE INDEX idx_ent_synonym_lower ON ols_entities USING gin (ols_lower_array(synonym));
+-- Per-field full-text indexes, used by buildFieldRestrictedTsCondition() (JooqSupport.tsvectorMatches)
+-- to keep non-exact searchFields/queryFields-restricted queries index-accelerated instead of matching
+-- against the blanket ts_search column, which spans every field regardless of what was requested.
+-- Scoped to label/synonym for now (the reported case); extend to other fields if they see real
+-- queryFields usage. See GitHub issue #1308.
+CREATE INDEX idx_ent_label_fts ON ols_entities USING gin (ols_tsvector(label));
+CREATE INDEX idx_ent_synonym_fts ON ols_entities USING gin (ols_tsvector(synonym));
 CREATE INDEX idx_ent_related_to ON ols_entities USING gin (related_to);
 CREATE INDEX idx_ent_fts ON ols_entities USING gin (ts_search);
 CREATE INDEX idx_ent_trgm_suggest ON ols_entities USING gin (label_for_suggest gin_trgm_ops);


### PR DESCRIPTION
## Summary

Three related search-correctness regressions from the Solr→Postgres migration, same file/class, fixed together.

### #1309 — exact-match array search was case-sensitive
`exact=true` search with `queryFields=label,synonym` (V1) / `searchFields` (V2) compared `TEXT[]` columns with a raw `@>` containment check, which is case-sensitive in PostgreSQL — scalar columns already lowercased, arrays didn't. Root cause traced to `70cf4b9fb`, `109906221`; the old Solr path lowercased both sides.

- Adds `ols_lower_array()` immutable SQL function + `idx_ent_label_lower`/`idx_ent_synonym_lower` GIN expression indexes.
- Adds `JooqSupport.arrayContainsCaseInsensitive()`, used in `buildExactFieldCondition()`'s array branch. `arrayContains()` unchanged everywhere else (filters, joins).
- Verified against a fallback VDB copy of production before implementing (confirmed live data reproduces the bug, confirmed the case-insensitive plan uses the new indexes once `ANALYZE` runs).

### #1308 — non-exact search ignored queryFields entirely
`exact=false` search always matched against the blanket `ts_search` column, which spans every field (label, short_form, curie, synonym, definition, iri) regardless of what `queryFields`/`searchFields` requested. A query restricted to `queryFields=label,synonym` could still match on hits found only inside `definition` text — reported repro: searching `squamous cell carcinoma of the head and neck` with `queryFields=label,synonym` returned `MONDO_0800467`, which mentions the query only in its description.

- Adds `buildFieldRestrictedTsCondition()`, used whenever `searchFields` is set, exact or not — matches `ols_tsvector(col) @@ tsquery` per requested column, OR'd together, instead of the combined `ts_search`.
- Adds `JooqSupport.tsvectorMatches()` (reuses the existing `ols_tsvector()` fn, no new SQL function needed).
- Adds `idx_ent_label_fts`/`idx_ent_synonym_fts` GIN expression indexes so the restricted match stays index-accelerated. Scoped to label/synonym (the reported case) — other fields still match correctly if requested, just via a slower scan until/unless they get their own index.

### #1312 — exact matches not prioritized in results
Reported via the frontend: searching `mus musculus` / `homo sapiens` in an ontology-scoped search box (e.g. NCBITaxon) buried the exact term at position 18/12 instead of first. Traced to the same case-sensitivity bug as #1309, but in the *ranking* bonus rather than the filter condition: `buildRankExpression()`'s +1000 exact-label bonus also used the case-sensitive `arrayContains()`. NCBITaxon labels follow binomial-nomenclature capitalization (`Mus musculus`), the frontend's default "Exact match" checkbox is unchecked, so the query goes through the non-exact/ranking-only path — the casing mismatch meant the bonus never applied, leaving ranking entirely to `ts_rank_cd`'s prefix-tsquery match (`mus:* & musculus:*`, matching many unrelated lexemes).

- Swaps that one comparison to `arrayContainsCaseInsensitive()`, reusing `idx_ent_label_lower` already added for #1309 — no new index needed.

## Test plan
- [x] `mvn compile` (JDK 17) — builds clean
- [x] `python3 dataload/create_postgres_schema.py` — emits all new function/index SQL
- [ ] Full dataload reload against a test DB, then:
  - [ ] `exact=true&queryFields=label` with a mixed-case query returns the expected row (#1309)
  - [ ] `exact=false&queryFields=label,synonym` no longer returns matches that only hit `definition` (#1308)
  - [ ] Searching `mus musculus` / `homo sapiens` in NCBITaxon returns the exact term first (#1312)
  - [ ] Confirm query plans use the new indexes (not seq scans) after `ANALYZE`

Note: this repo has no backend unit tests (`backend/src/test` doesn't exist) — verification is via the full-reload integration testcases pipeline. Applying these new indexes to the existing production DB (~200GB) will need a separate one-off `CREATE INDEX CONCURRENTLY` migration outside this PR, since schema.py changes only take effect on a fresh full reload.

🤖 Generated with [Claude Code](https://claude.com/claude-code)