### PR TITLE
Fix localization of mixed ontology metadata arrays

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
@@ -163,6 +163,10 @@ public class LocalizationTransform {
 
     public static JsonElement localizeValueWithFallbacks(JsonElement v, String lang) {
 
+        if(v.isJsonArray()) {
+            return localizeArrayWithFallbacks(v.getAsJsonArray(), lang);
+        }
+
         // 1. First try the explicitly requested language
         JsonElement localized = transform(v, lang);
 
@@ -183,6 +187,59 @@ public class LocalizationTransform {
         return localized;
     }
 
+    private static JsonElement localizeArrayWithFallbacks(JsonArray arr, String lang) {
+
+        // Language-independent values (for example URI strings) must not make a
+        // language lookup appear successful and prevent literal fallback.
+        String selectedLanguage = lang;
+        JsonArray localizedValues = localizeLanguageDependentValues(arr, selectedLanguage);
+
+        if(localizedValues.size() == 0) {
+            selectedLanguage = "";
+            localizedValues = localizeLanguageDependentValues(arr, selectedLanguage);
+        }
+
+        if(localizedValues.size() == 0) {
+            selectedLanguage = "en";
+        }
+
+        JsonArray res = new JsonArray(arr.size());
+        for(JsonElement element : arr) {
+            JsonElement localized = isLanguageDependentValue(element)
+                    ? transform(element, selectedLanguage)
+                    : transform(element, lang);
+
+            if(localized != null) {
+                res.add(localized);
+            }
+        }
+
+        return res.size() > 0 ? res : null;
+    }
+
+    private static JsonArray localizeLanguageDependentValues(JsonArray arr, String lang) {
+        return JsonCollectionHelper.map(
+                arr,
+                element -> isLanguageDependentValue(element) ? transform(element, lang) : null);
+    }
+
+    private static boolean isLanguageDependentValue(JsonElement value) {
+        if(!value.isJsonObject()) {
+            return false;
+        }
+
+        JsonObject obj = value.getAsJsonObject();
+        List<String> types = JsonHelper.getStrings(obj, "type");
+
+        if(types.contains("literal")) {
+            return true;
+        }
+
+        return types.contains("reification")
+                && obj.has("value")
+                && isLanguageDependentValue(obj.get("value"));
+    }
+
     public static JsonObject localizeLinkedEntities(JsonObject linkedEntities, String lang) {
         JsonObject res = new JsonObject();
         for(String entityIri : linkedEntities.keySet()) {
@@ -199,10 +256,3 @@ public class LocalizationTransform {
     }
 
 }
-
-
-
-
-
-
-

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
@@ -53,13 +53,16 @@ public class LocalizationTransform {
         // Attempt to localize all of the keys into the requested language.
 
         JsonObject res = new JsonObject();
+        List<String> types = JsonHelper.getStrings(obj, "type");
+        boolean localizeMixedStringArrays = types.contains("ontology");
 
         for (String k : obj.keySet()) {
 
             if(k.equals("linkedEntities")) {
                 res.add(k, localizeLinkedEntities(obj.get(k).getAsJsonObject(), lang));
             } else {
-                JsonElement localized = localizeValueWithFallbacks( obj.get(k), lang );
+                JsonElement localized = localizeValueWithFallbacks(
+                        obj.get(k), lang, localizeMixedStringArrays);
 
                 if(localized != null)
                     res.add(k, localized);
@@ -162,8 +165,17 @@ public class LocalizationTransform {
     }
 
     public static JsonElement localizeValueWithFallbacks(JsonElement v, String lang) {
+        return localizeValueWithFallbacks(v, lang, false);
+    }
 
-        if(v.isJsonArray() && requiresMixedStringArrayFallback(v.getAsJsonArray())) {
+    private static JsonElement localizeValueWithFallbacks(
+            JsonElement v,
+            String lang,
+            boolean localizeMixedStringArrays) {
+
+        if(localizeMixedStringArrays
+                && v.isJsonArray()
+                && requiresMixedStringArrayFallback(v.getAsJsonArray())) {
             return localizeArrayWithFallbacks(v.getAsJsonArray(), lang);
         }
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransform.java
@@ -163,7 +163,7 @@ public class LocalizationTransform {
 
     public static JsonElement localizeValueWithFallbacks(JsonElement v, String lang) {
 
-        if(v.isJsonArray()) {
+        if(v.isJsonArray() && requiresMixedStringArrayFallback(v.getAsJsonArray())) {
             return localizeArrayWithFallbacks(v.getAsJsonArray(), lang);
         }
 
@@ -185,6 +185,18 @@ public class LocalizationTransform {
         }
 
         return localized;
+    }
+
+    private static boolean requiresMixedStringArrayFallback(JsonArray arr) {
+        boolean hasLanguageDependentValue = false;
+        boolean hasLanguageIndependentStringValue = false;
+
+        for(JsonElement element : arr) {
+            hasLanguageDependentValue |= isLanguageDependentValue(element);
+            hasLanguageIndependentStringValue |= isLanguageIndependentStringValue(element);
+        }
+
+        return hasLanguageDependentValue && hasLanguageIndependentStringValue;
     }
 
     private static JsonElement localizeArrayWithFallbacks(JsonArray arr, String lang) {
@@ -238,6 +250,23 @@ public class LocalizationTransform {
         return types.contains("reification")
                 && obj.has("value")
                 && isLanguageDependentValue(obj.get("value"));
+    }
+
+    private static boolean isLanguageIndependentStringValue(JsonElement value) {
+        if(value.isJsonPrimitive()) {
+            return value.getAsJsonPrimitive().isString();
+        }
+
+        if(!value.isJsonObject()) {
+            return false;
+        }
+
+        JsonObject obj = value.getAsJsonObject();
+        List<String> types = JsonHelper.getStrings(obj, "type");
+
+        return types.contains("reification")
+                && obj.has("value")
+                && isLanguageIndependentStringValue(obj.get("value"));
     }
 
     public static JsonObject localizeLinkedEntities(JsonObject linkedEntities, String lang) {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
@@ -164,6 +164,32 @@ class LocalizationTransformTest {
     }
 
     @Test
+    void entityMixedStringArraysKeepExistingFallbackBehavior() {
+        JsonElement entity = json("""
+                {
+                  "type": ["entity", "property"],
+                  "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+                    "http://example.org/resource-one",
+                    "http://example.org/resource-two",
+                    {"type": ["literal"], "value": "http://example.org/default-literal"}
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["entity", "property"],
+                  "http://www.w3.org/2000/01/rdf-schema#seeAlso": [
+                    "http://example.org/resource-one",
+                    "http://example.org/resource-two"
+                  ]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(entity, "en"));
+    }
+
+    @Test
     void allLanguagesStillBypassesLocalization() {
         JsonElement ontology = json("""
                 {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
@@ -1,0 +1,163 @@
+package uk.ac.ebi.spot.ols.repository.transforms;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class LocalizationTransformTest {
+
+    @Test
+    void languageInvariantValuesDoNotPreventDefaultLiteralFallback() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "value": "Adrien Barton"},
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "value": "Anoosha Sehar"}
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "value": "Adrien Barton"},
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "value": "Anoosha Sehar"}
+                  ]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(ontology, "en"));
+    }
+
+    @Test
+    void requestedLanguageStillTakesPrecedenceOverDefaultLiterals() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "value": "Default name"},
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "lang": "fr", "value": "Nom francais"}
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    "https://orcid.org/0000-0002-3410-4655",
+                    "Nom francais"
+                  ]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(ontology, "fr"));
+    }
+
+    @Test
+    void defaultLiteralsStillTakePrecedenceOverEnglishFallback() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "lang": "en", "value": "English name"},
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "value": "Default name"}
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "value": "Default name"}
+                  ]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(ontology, "fr"));
+    }
+
+    @Test
+    void englishFallbackIsUsedWhenRequestedAndDefaultLiteralsAreMissing() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "lang": "en", "value": "English name"},
+                    "https://orcid.org/0000-0002-3410-4655"
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    "English name",
+                    "https://orcid.org/0000-0002-3410-4655"
+                  ]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(ontology, "fr"));
+    }
+
+    @Test
+    void apiTransformReturnsMixedUriAndDefaultLiteralValues() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "value": "Adrien Barton"},
+                    {"type": ["literal"], "value": "Anoosha Sehar"}
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    "https://orcid.org/0000-0002-3410-4655",
+                    "Adrien Barton",
+                    "Anoosha Sehar"
+                  ]
+                }
+                """);
+
+        assertEquals(
+                expected,
+                JsonTransformer.transformJson(ontology, "en", new JsonTransformOptions()));
+    }
+
+    @Test
+    void allLanguagesStillBypassesLocalization() {
+        JsonElement ontology = json("""
+                {
+                  "type": ["ontology"],
+                  "contributor": [
+                    {"type": ["literal"], "value": "Default name"},
+                    "https://orcid.org/0000-0002-3410-4655",
+                    {"type": ["literal"], "lang": "fr", "value": "Nom francais"}
+                  ]
+                }
+                """);
+
+        assertEquals(ontology, LocalizationTransform.transform(ontology, "all"));
+    }
+
+    private static JsonElement json(String value) {
+        return JsonParser.parseString(value);
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/transforms/LocalizationTransformTest.java
@@ -142,6 +142,28 @@ class LocalizationTransformTest {
     }
 
     @Test
+    void nonStringInvariantValuesDoNotTriggerMixedStringArrayFallback() {
+        JsonElement entity = json("""
+                {
+                  "type": ["entity", "individual"],
+                  "searchableAnnotationValues": [
+                    {"type": ["literal"], "value": "1234"},
+                    false
+                  ]
+                }
+                """);
+
+        JsonElement expected = json("""
+                {
+                  "type": ["entity", "individual"],
+                  "searchableAnnotationValues": [false]
+                }
+                """);
+
+        assertEquals(expected, LocalizationTransform.transform(entity, "en"));
+    }
+
+    @Test
     void allLanguagesStillBypassesLocalization() {
         JsonElement ontology = json("""
                 {

--- a/dataload.sh
+++ b/dataload.sh
@@ -88,8 +88,8 @@ docker run \
   -e NXF_TEMP="$TMP_DIR/NXF_TEMP" \
   -e NXF_CACHE_DIR="$TMP_DIR/NXF_CACHE_DIR" \
   -e OLS4_CURATIONS_PATH="${OLS4_CURATIONS_PATH:-}" \
+  -e OLS_ORCID_NAME_FIXTURE="${OLS_ORCID_NAME_FIXTURE:-}" \
   ghcr.io/ebispot/ols4-nextflow:dev \
   bash -c "cd \"$OLS_HOME\" && nextflow run \"$OLS_HOME/dataload/nextflow/ols_dataload.nf\" \
     -c \"$OLS_NF_CONFIG\" -resume"
-
 

--- a/dataload/nextflow/local_nextflow.config
+++ b/dataload/nextflow/local_nextflow.config
@@ -1,7 +1,7 @@
 process.container = System.getenv('OLS4_DATALOAD_IMAGE')
 docker.enabled = true
 // Ensure tasks run with the host UID:GID to avoid permission issues in mounted work dirs
-docker.runOptions = "--shm-size=2g -u ${System.getenv('HOST_UID')}:${System.getenv('HOST_GID')} -v ${System.getenv('OLS_HOME')}:${System.getenv('OLS_HOME')} -v ${System.getenv('OLS_EMBEDDINGS_PATH')}:${System.getenv('OLS_EMBEDDINGS_PATH')} -e OPENAI_API_KEY -e PGHOST -e PGPORT -e PGDATABASE -e PGUSER -e PGPASSWORD"
+docker.runOptions = "--shm-size=2g -u ${System.getenv('HOST_UID')}:${System.getenv('HOST_GID')} -v ${System.getenv('OLS_HOME')}:${System.getenv('OLS_HOME')} -v ${System.getenv('OLS_EMBEDDINGS_PATH')}:${System.getenv('OLS_EMBEDDINGS_PATH')} -e OPENAI_API_KEY -e PGHOST -e PGPORT -e PGDATABASE -e PGUSER -e PGPASSWORD -e OLS_ORCID_NAME_FIXTURE"
 
 params.embed_image = System.getenv('OLS4_EMBED_IMAGE') ?: ''
 

--- a/test_api.sh
+++ b/test_api.sh
@@ -3,6 +3,7 @@
 export OLS4_CONFIG=$(find testcases | grep json | paste -sd, -)
 export OLS4_DATALOAD_ARGS="--loadLocalFiles"
 export BUILDKIT_PROGRESS=plain
+export OLS_ORCID_NAME_FIXTURE="${OLS_ORCID_NAME_FIXTURE:-$(pwd)/dev-testing/orcid-name-fixture.json}"
 
 rm -rf testcases_output_api/*
 mkdir -p testcases_output_api
@@ -43,5 +44,4 @@ HOST_UID=$(id -u) HOST_GID=$(id -g) docker compose down -t 120 -v
 
 echo API test exit code: $EXIT_CODE
 exit $EXIT_CODE
-
 


### PR DESCRIPTION
## Summary

- localize ontology-level language-dependent literals independently from invariant string values such as URI strings
- retain requested language, default literal, then English fallback precedence
- preserve the original array order and `lang=all` behavior
- leave class, property, individual, linked-entity, and synthetic search-field localization unchanged
- propagate the committed deterministic ORCID fixture through the API-test Nextflow containers
- add regression coverage for mixed URI/literal arrays, each fallback path, synthetic searchable annotations, and entity mixed-string arrays

## Why

When ontology metadata contains both URI values and untagged literals, the URI values survive every language transform. That previously made the requested-language result appear non-empty and prevented fallback to the untagged literals. For FoodOn, `/api/v2/ontologies/foodon?lang=en` therefore returned only the two ORCID URIs and omitted ten contributor names.

The fallback decision is now made only from language-dependent values for ontology objects whose arrays mix literals with invariant strings. Invariant strings are retained alongside the selected literal language. Other entity types keep their existing localization semantics.

Closes #1313

## Impact on other ontologies

This restores invariant/default ontology metadata in other mixed string arrays, including FBBI and OHD contributors, ENVO creators, and UBERON sources. Classes, properties, individuals, linked entities, arrays containing only language-dependent literals, and arrays mixed with boolean/numeric primitives keep the existing language filtering semantics.

## Verification

- `env JAVA_HOME=/Users/haideri/Library/Java/JavaVirtualMachines/ms-17.0.15/Contents/Home mvn -pl backend -am test`
  - 8 tests, 0 failures
- regression tests first reproduced both observed API changes:
  - synthetic searchable annotations: `["1234", false]` instead of `[false]`
  - entity `rdfs:seeAlso`: an untagged literal was added beside invariant URI values
- `bash -n test_api.sh dataload.sh test_dataload.sh`
- local backend health check returned HTTP 200
- FoodOn returned all 12 contributors for `lang=en`, `lang=fr`, and `lang=all`
- cross-ontology live API checks passed for FBBI, OHD, ENVO, UBERON, MSIO, NCRO, OAE, and OPMI
- supplied ontology-list snapshots showed 113 affected objects and 328 added strings, all confined to `searchableAnnotationValues`; the fallback is now scoped away from those synthetic fields
- CI follow-up isolated remaining `gitissue502` failures to missing ORCID fixture propagation; the existing committed fixture is now passed host → Nextflow → linker task, without regenerating golden files