### PR TITLE
Fix configured definition property handling

### DIFF
--- a/dataload/configs/ols.json
+++ b/dataload/configs/ols.json
@@ -9,6 +9,12 @@
       "reasoner": "EL"
     },
     {
+      "id": "iao",
+      "definition_property": [
+        "http://purl.obolibrary.org/obo/IAO_0000115"
+      ]
+    },
+    {
       "id": "phi",
       "preferredPrefix": "PHI",
       "title": "PHI-base Ontology",

--- a/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DefinitionAnnotator.java
+++ b/dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/DefinitionAnnotator.java
@@ -11,25 +11,29 @@ import java.util.*;
 import static uk.ac.ebi.ols.shared.DefinedFields.DEFINITION;
 
 public class DefinitionAnnotator {
+	private static final List<String> DEFAULT_DEFINITION_PROPERTIES = List.of(
+			"http://www.w3.org/2000/01/rdf-schema#comment",
+			"http://purl.obolibrary.org/obo/IAO_0000115",
+			"http://purl.org/dc/terms/description",
+			"http://purl.org/dc/elements/1.1/description"
+	);
 
 	public static Set<String> getDefinitionProperties(OntologyGraph graph) {
-
-		Set<String> definitionProperties = new TreeSet<>(
-				List.of(
-						"http://www.w3.org/2000/01/rdf-schema#comment",
-						"http://purl.obolibrary.org/obo/IAO_0000115",
-						"http://purl.org/dc/terms/description",
-						"http://purl.org/dc/elements/1.1/description"
-				)
-		);
-
 		Object configDefinitionProperties = graph.config.get("definition_property");
 
+		// An explicit ontology configuration is authoritative. The defaults are only
+		// a backward-compatible fallback for ontologies that omit the setting.
 		if(configDefinitionProperties instanceof Collection<?>) {
-			definitionProperties.addAll((Collection<String>) configDefinitionProperties);
+			Set<String> definitionProperties = new TreeSet<>();
+			for(Object property : (Collection<?>) configDefinitionProperties) {
+				if(property instanceof String) {
+					definitionProperties.add((String) property);
+				}
+			}
+			return definitionProperties;
 		}
 
-		return definitionProperties;
+		return new TreeSet<>(DEFAULT_DEFINITION_PROPERTIES);
 	}
 
 	public static void annotateDefinitions(OntologyGraph graph) {

--- a/dataload/rdf2json/src/test/java/uk/ac/ebi/rdf2json/DefinitionAnnotatorTest.java
+++ b/dataload/rdf2json/src/test/java/uk/ac/ebi/rdf2json/DefinitionAnnotatorTest.java
@@ -1,0 +1,106 @@
+package uk.ac.ebi.rdf2json;
+
+import org.junit.Test;
+import uk.ac.ebi.rdf2json.annotators.ConfigurablePropertyAnnotator;
+import uk.ac.ebi.rdf2json.annotators.DefinitionAnnotator;
+import uk.ac.ebi.rdf2json.properties.PropertyValue;
+import uk.ac.ebi.rdf2json.properties.PropertyValueList;
+import uk.ac.ebi.rdf2json.properties.PropertyValueLiteral;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class DefinitionAnnotatorTest {
+    private static final String COMMENT = "http://www.w3.org/2000/01/rdf-schema#comment";
+    private static final String IAO_DEFINITION = "http://purl.obolibrary.org/obo/IAO_0000115";
+
+    @Test
+    public void configuredDefinitionPropertiesOverrideDefaults() throws IOException {
+        OntologyGraph graph = graphWithDefinitionProperties(List.of(IAO_DEFINITION));
+        OntologyNode entity = addEntityWithDefinitionAndComment(graph);
+
+        DefinitionAnnotator.annotateDefinitions(graph);
+        ConfigurablePropertyAnnotator.annotateConfigurableProperties(graph);
+
+        assertEquals(List.of("Configured definition"), literalValues(entity, "definition"));
+        assertEquals(List.of(IAO_DEFINITION), literalValues(entity, "definitionProperty"));
+        assertTrue(entity.properties.hasProperty(COMMENT));
+    }
+
+    @Test
+    public void missingDefinitionPropertiesUseDefaults() throws IOException {
+        OntologyGraph graph = graphWithDefinitionProperties(null);
+        OntologyNode entity = addEntityWithDefinitionAndComment(graph);
+
+        DefinitionAnnotator.annotateDefinitions(graph);
+        ConfigurablePropertyAnnotator.annotateConfigurableProperties(graph);
+
+        assertEquals(List.of("Configured definition", "Comment"), literalValues(entity, "definition"));
+        assertEquals(List.of(IAO_DEFINITION, COMMENT), literalValues(entity, "definitionProperty"));
+    }
+
+    @Test
+    public void emptyDefinitionPropertiesDisableDefinitionCollation() throws IOException {
+        OntologyGraph graph = graphWithDefinitionProperties(List.of());
+        OntologyNode entity = addEntityWithDefinitionAndComment(graph);
+
+        DefinitionAnnotator.annotateDefinitions(graph);
+        ConfigurablePropertyAnnotator.annotateConfigurableProperties(graph);
+
+        assertNull(entity.properties.getPropertyValues("definition"));
+        assertNull(entity.properties.getPropertyValues("definitionProperty"));
+        assertTrue(entity.properties.hasProperty(COMMENT));
+        assertTrue(entity.properties.hasProperty(IAO_DEFINITION));
+        assertFalse(DefinitionAnnotator.getDefinitionProperties(graph).contains(COMMENT));
+    }
+
+    private OntologyGraph graphWithDefinitionProperties(Collection<String> definitionProperties) throws IOException {
+        Map<String, Object> config = new HashMap<>();
+        config.put("id", "test");
+        if(definitionProperties != null) {
+            config.put("definition_property", definitionProperties);
+        }
+        return new OntologyGraph(config, false, null, true, null);
+    }
+
+    private OntologyNode addEntityWithDefinitionAndComment(OntologyGraph graph) {
+        OntologyNode entity = new OntologyNode();
+        entity.uri = "http://example.org/entity";
+        entity.types.add(OntologyNode.NodeType.CLASS);
+        entity.properties.addProperty(IAO_DEFINITION, PropertyValueLiteral.fromString("Configured definition"));
+        entity.properties.addProperty(COMMENT, PropertyValueLiteral.fromString("Comment"));
+        graph.nodes.put(entity.uri, entity);
+        return entity;
+    }
+
+    private List<String> literalValues(OntologyNode entity, String predicate) {
+        List<PropertyValue> values = entity.properties.getPropertyValues(predicate);
+        List<String> result = new ArrayList<>();
+        if(values == null) {
+            return result;
+        }
+        for(PropertyValue value : values) {
+            addLiteralValues(value, result);
+        }
+        return result;
+    }
+
+    private void addLiteralValues(PropertyValue value, List<String> result) {
+        if(value instanceof PropertyValueList) {
+            for(PropertyValue nested : ((PropertyValueList) value).getPropertyValues()) {
+                addLiteralValues(nested, result);
+            }
+        } else if(value instanceof PropertyValueLiteral) {
+            result.add(((PropertyValueLiteral) value).getValue());
+        }
+    }
+}

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -30,6 +30,12 @@
       "ontology_purl": "https://purl.obolibrary.org/obo/mondo/mondo-international.owl"
     },
     {
+      "id": "iao",
+      "definition_property": [
+        "http://purl.obolibrary.org/obo/IAO_0000115"
+      ]
+    },
+    {
       "id": "evorao",
       "definition_property": [
         "http://www.w3.org/2004/02/skos/core#definition"


### PR DESCRIPTION
## Summary

- treat an explicit definition_property configuration as authoritative, using the default predicates only when the setting is absent
- configure IAO to use only IAO_0000115 for definitions
- add regression coverage for explicit, absent, and empty definition-property configurations

This keeps raw rdfs:comment annotations available while preventing them from being added to normalized definition and definitionProperty fields.

## Verification

- full Java 21 dataload Maven reactor passed
- local rdf2json runs succeeded against live IAO and BCIO ontologies
- IAO:0020020 retained 8 raw comments and BCIO:006005 retained 1 raw comment, with zero comments leaking into definition
- both reported entities emitted only IAO_0000115 as definitionProperty
- merged production-style configuration validated successfully

Closes #1295