### PR TITLE
Stabilize autocomplete search under broad prefixes

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2EntityController.java
@@ -79,6 +79,10 @@ public class V2EntityController {
             @Parameter(name = "excludeOntologyId",
                     description = "Exclude entities from specific ontologies. Provide a comma-separated list of ontology IDs.",
                     example = "ncit,snomed") String excludeOntologyIds,
+            @RequestParam(value = "includeTotal", required = false, defaultValue = "true")
+            @Parameter(name = "includeTotal",
+                    description = "Whether to calculate the exact total number of matching entities. " +
+                            "Set to false for result-only clients such as autocomplete; totalElements then only covers the returned page boundary.") boolean includeTotal,
             @RequestParam
             @Parameter(hidden = true) MultiValueMap<String,String> searchProperties,
             @RequestParam(value = "lang", required = false, defaultValue = "en") String lang,
@@ -96,7 +100,9 @@ public class V2EntityController {
 
         return new ResponseEntity<>(
                 new V2PagedAndFacetedResponse<V2Entity>(
-                    entityRepository.find(pageable, lang, search, searchFields, boostFields, facetFields, exactMatch, excludeOntologyIdsList, DynamicQueryHelper.filterProperties(properties), outputOpts) .map(V2Entity::new)
+                    entityRepository.find(pageable, lang, search, searchFields, boostFields, facetFields,
+                            exactMatch, excludeOntologyIdsList, DynamicQueryHelper.filterProperties(properties),
+                            outputOpts, includeTotal).map(V2Entity::new)
                         ),
                     HttpStatus.OK);
     }
@@ -205,5 +211,4 @@ public class V2EntityController {
                 HttpStatus.OK);
     }
 }
-
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
@@ -23,6 +23,7 @@ public class DynamicQueryHelper {
                         || k.equals("resolveReferences")
                         || k.equals("manchesterSyntax")
                         || k.equals("model")
+                        || k.equals("includeTotal")
                         )
                 continue;
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/EntityRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/EntityRepository.java
@@ -32,6 +32,16 @@ public class EntityRepository {
     public OlsFacetedResultsPage<JsonElement> find(
             Pageable pageable, String lang, String search, String searchFields, String boostFields, String facetFields, boolean exactMatch, Collection<String> excludeOntologyIds, Map<String, Collection<String>> properties, JsonTransformOptions outputOpts) throws IOException {
 
+        return find(pageable, lang, search, searchFields, boostFields, facetFields, exactMatch,
+                excludeOntologyIds, properties, outputOpts, true);
+    }
+
+    public OlsFacetedResultsPage<JsonElement> find(
+            Pageable pageable, String lang, String search, String searchFields, String boostFields,
+            String facetFields, boolean exactMatch, Collection<String> excludeOntologyIds,
+            Map<String, Collection<String>> properties, JsonTransformOptions outputOpts,
+            boolean includeTotal) throws IOException {
+
         Validation.validateLang(lang);
 
         OlsSearchQuery query = new OlsSearchQuery();
@@ -53,7 +63,7 @@ public class EntityRepository {
         SearchFieldsParser.addFacetFieldsToQuery(query, facetFields);
         DynamicFilterParser.addDynamicFiltersToQuery(query, properties);
 
-        return searchClient.searchPaginated(query, pageable)
+        return searchClient.searchPaginated(query, pageable, includeTotal)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
                 ;
     }
@@ -148,5 +158,4 @@ public class EntityRepository {
 
 
 }
-
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
@@ -87,16 +87,28 @@ public class OlsSearchClient {
      * Paginated search with faceting support.
      */
     public OlsFacetedResultsPage<JsonElement> searchPaginated(OlsSearchQuery query, Pageable pageable) {
+        return searchPaginated(query, pageable, true);
+    }
+
+    /**
+     * Paginated search with optional total counting. When totals are omitted, the returned total is
+     * limited to the current page boundary; this mode is intended for clients such as autocomplete
+     * that only consume the result elements.
+     */
+    public OlsFacetedResultsPage<JsonElement> searchPaginated(
+            OlsSearchQuery query, Pageable pageable, boolean includeTotal) {
         try (Connection conn = postgresClient.getConnection()) {
             DSLContext dsl = postgresClient.dsl(conn);
             Condition where = query.buildCondition(getAvailableFilterColumns());
             List<SortField<?>> orderBy = query.buildOrderBy();
 
-            long count = Optional.ofNullable(dsl.selectCount()
+            Long count = includeTotal
+                    ? Optional.ofNullable(dsl.selectCount()
                             .from(OLS_ENTITIES)
                             .where(where)
                             .fetchOne(0, Long.class))
-                    .orElse(0L);
+                            .orElse(0L)
+                    : null;
 
             logger.debug("search condition: {}", where);
 
@@ -110,12 +122,14 @@ public class OlsSearchClient {
 
             List<JsonElement> results = readJsonResults(records);
 
+            long total = count != null ? count : pageable.getOffset() + results.size();
+
             Map<String, Map<String, Long>> facetFieldToCounts = new LinkedHashMap<>();
             for (String facetField : query.facetFields) {
                 facetFieldToCounts.put(facetField, executeFacetQuery(dsl, facetField, query));
             }
 
-            return new OlsFacetedResultsPage<>(results, facetFieldToCounts, pageable, count);
+            return new OlsFacetedResultsPage<>(results, facetFieldToCounts, pageable, total);
         } catch (SQLException e) {
             throw new RuntimeException("Search query failed", e);
         }

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -259,9 +259,9 @@ public class OlsSearchQuery {
      * definition. This builds an ad-hoc ols_tsvector(column) @@ tsquery per requested field instead,
      * OR'd together, mirroring buildExactFieldCondition()'s column resolution. See GitHub issue #1308.
      *
-     * Backed by per-field GIN expression indexes (idx_ent_label_fts, idx_ent_synonym_fts) so the
-     * restricted match stays index-accelerated for the fields callers actually request in practice.
-     * Fields without such an index still match correctly, just via a slower scan.
+     * Backed by per-field GIN expression indexes for label, synonym, curie, short_form, and iri so
+     * the default field-restricted query stays index-accelerated. Dynamic fields without such an
+     * index still match correctly, just via a slower scan.
      */
     private Condition buildFieldRestrictedTsCondition(String qualifier, Set<String> availableFilterColumns) {
         Field<Object> tsQuery = buildTsQuery();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.spot.ols.controller.api.v2.helpers;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class DynamicQueryHelperTest {
+
+    @Test
+    void excludesIncludeTotalFromDynamicFilters() {
+        Map<String, Collection<String>> properties = new LinkedHashMap<>();
+        properties.put("includeTotal", List.of("false"));
+        properties.put("ontologyId", List.of("efo"));
+
+        assertEquals(
+                Map.of("ontologyId", List.of("efo")),
+                DynamicQueryHelper.filterProperties(properties));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/EntityRepositoryTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/EntityRepositoryTest.java
@@ -1,0 +1,77 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+class EntityRepositoryTest {
+
+    @Test
+    void forwardsIncludeTotalFalseToSearchClient() throws Exception {
+        Pageable pageable = PageRequest.of(0, 5);
+        RecordingSearchClient searchClient = new RecordingSearchClient();
+
+        EntityRepository repository = new EntityRepository();
+        repository.searchClient = searchClient;
+
+        repository.find(
+                pageable,
+                "en",
+                "liver",
+                null,
+                null,
+                null,
+                false,
+                null,
+                Map.of(),
+                new JsonTransformOptions(),
+                false);
+
+        assertFalse(searchClient.includeTotal);
+    }
+
+    @Test
+    void includesTotalByDefaultForExistingCallers() throws Exception {
+        Pageable pageable = PageRequest.of(0, 5);
+        RecordingSearchClient searchClient = new RecordingSearchClient();
+
+        EntityRepository repository = new EntityRepository();
+        repository.searchClient = searchClient;
+
+        repository.find(
+                pageable,
+                "en",
+                "liver",
+                null,
+                null,
+                null,
+                false,
+                null,
+                Map.of(),
+                new JsonTransformOptions());
+
+        assertEquals(Boolean.TRUE, searchClient.includeTotal);
+    }
+
+    private static class RecordingSearchClient extends OlsSearchClient {
+        private Boolean includeTotal;
+
+        @Override
+        public OlsFacetedResultsPage<JsonElement> searchPaginated(
+                OlsSearchQuery query, Pageable pageable, boolean includeTotal) {
+            this.includeTotal = includeTotal;
+            return new OlsFacetedResultsPage<>(List.of(), Map.of(), pageable, 0);
+        }
+    }
+}

--- a/dataload/create_postgres_schema.py
+++ b/dataload/create_postgres_schema.py
@@ -130,10 +130,13 @@ CREATE INDEX idx_ent_synonym_lower ON ols_entities USING gin (ols_lower_array(sy
 -- Per-field full-text indexes, used by buildFieldRestrictedTsCondition() (JooqSupport.tsvectorMatches)
 -- to keep non-exact searchFields/queryFields-restricted queries index-accelerated instead of matching
 -- against the blanket ts_search column, which spans every field regardless of what was requested.
--- Scoped to label/synonym for now (the reported case) -- extend to other fields if they see real
--- queryFields usage. See GitHub issue #1308.
+-- Every field used by the default field-restricted query branch needs its own expression index;
+-- PostgreSQL can combine them for OR conditions. See GitHub issue #1308.
 CREATE INDEX idx_ent_label_fts ON ols_entities USING gin (ols_tsvector(label));
 CREATE INDEX idx_ent_synonym_fts ON ols_entities USING gin (ols_tsvector(synonym));
+CREATE INDEX idx_ent_curie_fts ON ols_entities USING gin (ols_tsvector(curie));
+CREATE INDEX idx_ent_short_form_fts ON ols_entities USING gin (ols_tsvector(short_form));
+CREATE INDEX idx_ent_iri_fts ON ols_entities USING gin (ols_tsvector(iri));
 CREATE INDEX idx_ent_related_to ON ols_entities USING gin (related_to);
 CREATE INDEX idx_ent_fts ON ols_entities USING gin (ts_search);
 CREATE INDEX idx_ent_trgm_suggest ON ols_entities USING gin (label_for_suggest gin_trgm_ops);

--- a/dataload/tests/test_create_postgres_schema.py
+++ b/dataload/tests/test_create_postgres_schema.py
@@ -1,0 +1,18 @@
+import unittest
+
+from dataload.create_postgres_schema import ENTITY_INDEX_SQL
+
+
+class EntityIndexSqlTest(unittest.TestCase):
+
+    def test_field_restricted_full_text_indexes_are_persistent(self):
+        for column in ("label", "synonym", "curie", "short_form", "iri"):
+            self.assertIn(
+                f"CREATE INDEX idx_ent_{column}_fts ON ols_entities "
+                f"USING gin (ols_tsvector({column}));",
+                ENTITY_INDEX_SQL,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/frontend/src/app/api.ts
+++ b/frontend/src/app/api.ts
@@ -46,9 +46,10 @@ export class Page<T> {
 export async function getPaginated<ResType>(
   path: string,
   reqParams?: ReqParams,
-  apiUrl?: string
+  apiUrl?: string,
+  init?: RequestInit
 ): Promise<Page<ResType>> {
-  const res = await get<any>(path, reqParams, apiUrl);
+  const res = await get<any>(path, reqParams, apiUrl, init);
 
   return new Page<ResType>(
 	res.page || 0,
@@ -60,8 +61,13 @@ export async function getPaginated<ResType>(
   );
 }
 
-export async function get<ResType>(path: string, reqParams?:ReqParams, apiUrl?: string): Promise<ResType> {
-  return request(path, reqParams, undefined, apiUrl);
+export async function get<ResType>(
+  path: string,
+  reqParams?: ReqParams,
+  apiUrl?: string,
+  init?: RequestInit
+): Promise<ResType> {
+  return request(path, reqParams, init, apiUrl);
 }
 
 export async function post<ReqType, ResType = any>(

--- a/frontend/src/components/SearchBox.tsx
+++ b/frontend/src/components/SearchBox.tsx
@@ -3,14 +3,15 @@ import { Fragment, useCallback, useEffect, useRef, useState } from "react";
 import { Link, useNavigate, useSearchParams } from "react-router-dom";
 import { get, getPaginated } from "../app/api";
 import { theme } from "../app/mui";
-import { randomString, thingFromJsonProperties, highlightMatch } from "../app/util";
+import { thingFromJsonProperties, highlightMatch } from "../app/util";
 import Entity from "../model/Entity";
 import Ontology from "../model/Ontology";
 import { Suggest } from "../model/Suggest";
 import Thing from "../model/Thing";
 import Model from "../model/Model";
 
-let curSearchToken: any = null;
+const AUTOCOMPLETE_MIN_QUERY_LENGTH = 3;
+const AUTOCOMPLETE_DEBOUNCE_MS = 300;
 
 interface SearchBoxEntry {
   linkUrl: string;
@@ -120,7 +121,7 @@ export default function SearchBox({
     return () => {
       mounted.current = false;
     };
-  });
+  }, []);
 
   useEffect(() => {
 
@@ -133,90 +134,109 @@ export default function SearchBox({
   }, []);
     
 
-  const cancelPromisesRef = useRef(false);
   useEffect(() => {
     // Clear previous results immediately when search params change
     setJumpTo([]);
     setAutocomplete(null);
 
-    if (!query.trim()) {
+    const trimmedQuery = query.trim();
+    if (trimmedQuery.length < AUTOCOMPLETE_MIN_QUERY_LENGTH) {
       setLoading(false);
       setArrowKeySelectedN(undefined);
       return;
     }
-    
+
+    const abortController = new AbortController();
+    const requestInit = { signal: abortController.signal };
+
     async function loadSuggestions() {
       setLoading(true);
       setArrowKeySelectedN(undefined);
 
-      const searchToken = randomString();
-      curSearchToken = searchToken;
-
       // Use llm_search endpoint if embedding model is selected
       const isEmbeddingSearch = selectedModel && selectedModel !== 'lexical';
-      
-      const entitiesPromise = isEmbeddingSearch
-        ? getPaginated<any>(
-            `api/v2/entities/llm_search?${new URLSearchParams({
-              q: query,
-              size: "5",
-              model: selectedModel,
-              ...(ontologyId ? { ontologyId } : {}),
-            })}`
-          )
-        : getPaginated<any>(
-            `api/v2/entities?${new URLSearchParams({
-              search: query,
-              size: "5",
-              lang: "en",
-              exactMatch: exact.toString(),
-              includeObsoleteEntities: obsolete.toString(),
-              ...(ontologyId ? { ontologyId } : {}),
-              ...((canonical ? { isDefiningOntology: true } : {}) as any),
-            })}`
-          );
 
-      const [entities, ontologies, autocomplete] = await Promise.all([
-        entitiesPromise,
-        searchForOntologies && !isEmbeddingSearch
+      try {
+        const entitiesPromise = isEmbeddingSearch
           ? getPaginated<any>(
-              `api/v2/ontologies?${new URLSearchParams({
-                search: query,
+              `api/v2/entities/llm_search?${new URLSearchParams({
+                q: trimmedQuery,
+                size: "5",
+                model: selectedModel,
+                ...(ontologyId ? { ontologyId } : {}),
+              })}`,
+              undefined,
+              undefined,
+              requestInit
+            )
+          : getPaginated<any>(
+              `api/v2/entities?${new URLSearchParams({
+                search: trimmedQuery,
                 size: "5",
                 lang: "en",
                 exactMatch: exact.toString(),
-                includeObsoleteEntities: obsolete.toString()
-              })}`
-            )
-          : null,
-        showSuggestions && !isEmbeddingSearch
-          ? get<Suggest>(
-              `api/suggest?${new URLSearchParams({
-                q: query,
-                exactMatch: exact.toString(),
                 includeObsoleteEntities: obsolete.toString(),
-              })}`
-            )
-          : null,
-      ]);
-      if (cancelPromisesRef.current && !mounted.current) return;
+                includeTotal: "false",
+                ...(ontologyId ? { ontologyId } : {}),
+                ...((canonical ? { isDefiningOntology: true } : {}) as any),
+              })}`,
+              undefined,
+              undefined,
+              requestInit
+            );
 
-      if (searchToken === curSearchToken) {
+        const [entities, ontologies, autocomplete] = await Promise.all([
+          entitiesPromise,
+          searchForOntologies && !isEmbeddingSearch
+            ? getPaginated<any>(
+                `api/v2/ontologies?${new URLSearchParams({
+                  search: trimmedQuery,
+                  size: "5",
+                  lang: "en",
+                  exactMatch: exact.toString(),
+                  includeObsoleteEntities: obsolete.toString()
+                })}`,
+                undefined,
+                undefined,
+                requestInit
+              )
+            : null,
+          showSuggestions && !isEmbeddingSearch
+            ? get<Suggest>(
+                `api/suggest?${new URLSearchParams({
+                  q: trimmedQuery,
+                  exactMatch: exact.toString(),
+                  includeObsoleteEntities: obsolete.toString(),
+                })}`,
+                undefined,
+                undefined,
+                requestInit
+              )
+            : null,
+        ]);
+
+        if (abortController.signal.aborted || !mounted.current) return;
+
         setJumpTo([
           ...entities.elements.map((obj) => thingFromJsonProperties(obj)),
           ...(ontologies?.elements.map((obj) => new Ontology(obj)) || []),
         ]);
         setAutocomplete(autocomplete);
         setLoading(false);
+      } catch (error) {
+        if (abortController.signal.aborted) return;
+        console.error("Failed to load search suggestions", error);
+        if (mounted.current) setLoading(false);
       }
     }
 
-    loadSuggestions();
+    const debounceTimer = window.setTimeout(loadSuggestions, AUTOCOMPLETE_DEBOUNCE_MS);
 
     return () => {
-      cancelPromisesRef.current = true;
+      window.clearTimeout(debounceTimer);
+      abortController.abort();
     };
-  }, [query, exact, obsolete, canonical, selectedModel]);
+  }, [query, exact, obsolete, canonical, selectedModel, ontologyId, searchForOntologies, showSuggestions]);
 
   let autocompleteToShow = autocomplete?.response.docs.slice(0, 5) || [];
   let autocompleteElements = autocompleteToShow.map(
@@ -268,7 +288,7 @@ export default function SearchBox({
             linkUrl,
             li: (
               <li
-                key={randomString()}
+                key={jumpToEntry.getIri()}
                 className={
                   "py-1 px-3 leading-7 hover:bg-link-light hover:cursor-pointer" +
                   (arrowKeySelectedN === i + autocompleteElements.length


### PR DESCRIPTION
## Summary

- require at least three characters and debounce autocomplete requests by 300 ms
- abort stale entity, ontology, and suggestion requests when the query changes
- add an opt-in includeTotal=false path for entity autocomplete while preserving exact totals by default
- persist the curie, short_form, and iri full-text GIN indexes in PostgreSQL schema generation
- add focused backend and schema regression tests

## Why

Broad one- and two-character prefixes matched very large portions of the entity table. SearchBox issued requests on every keystroke, and the entities endpoint ran an exact COUNT(*) before returning five autocomplete results. This amplified database load and led to very slow responses during production traffic.

This keeps the default combined ts_search behavior; it does not force fixed searchFields.

## Testing

- env JAVA_HOME=/Users/haideri/Library/Java/JavaVirtualMachines/ms-17.0.15/Contents/Home mvn -pl backend -am test
- python3 -m unittest dataload.tests.test_create_postgres_schema
- npm run build
- git diff --check