### PR TITLE
fix: restore exact fuzzy autosuggest matching, cache results

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/JooqSupport.java
@@ -64,11 +64,11 @@ public final class JooqSupport {
     }
 
     public static Field<Double> similarity(Field<String> field, String value) {
-        return DSL.function("similarity", SQLDataType.DOUBLE, field, DSL.val(value));
+        return DSL.function("similarity", SQLDataType.DOUBLE, field, castAsText(DSL.val(value)));
     }
 
     public static Condition trigramMatch(Field<String> field, String value) {
-        return DSL.condition("{0} % {1}", field, DSL.val(value));
+        return DSL.condition("{0} % {1}", field, castAsText(DSL.val(value)));
     }
 
     public static Table<?> unnest(Field<String[]> arrayField, String tableAlias, String columnAlias) {

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
@@ -1,5 +1,8 @@
 package uk.ac.ebi.spot.ols.repository.search;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.Weigher;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.jooq.Condition;
@@ -19,6 +22,7 @@ import uk.ac.ebi.spot.ols.service.PostgresClient;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.*;
+import java.util.concurrent.ExecutionException;
 
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.INFORMATION_SCHEMA_COLUMNS;
 import static uk.ac.ebi.spot.ols.repository.postgres.JooqSupport.OLS_AUTOSUGGEST;
@@ -53,6 +57,26 @@ public class OlsSearchClient {
     private PostgresClient postgresClient;
 
     private volatile Set<String> availableFilterColumns;
+
+    /**
+     * No TTL: autosuggest data only changes via a full dataload + redeploy (new pod, fresh empty
+     * cache), so there's no live-reload path a time-based expiry would need to catch. A TTL here
+     * would only evict still-valid hot entries and force them back through the slow fuzzy query.
+     *
+     * <p>Bounded by weight (total cached label rows), not entry count: {@code rows} is caller-
+     * controlled up to {@code ols.search.max-rows} (1000), so a raw entry-count cap doesn't bound
+     * memory — a client requesting rows=1000 across many distinct prefixes/ontology filters could
+     * otherwise inflate a large maximumSize toward gigabytes. 3,000,000 rows at ~100 bytes/label is
+     * a ~300MB ceiling regardless of how requests are shaped, negligible against the backend pod's
+     * 10Gi/50Gi memory request/limit (see k8chart/ols4/templates/ols4-backend-deployment.yaml), and
+     * covers well over 100k distinct-prefix entries at the realistic rows≈10 traffic shape.
+     * recordStats() so this can be tuned from real hit-rate data instead of guessed.
+     */
+    private final Cache<SuggestCacheKey, List<String>> suggestCache = CacheBuilder.newBuilder()
+            .maximumWeight(3_000_000)
+            .weigher((Weigher<SuggestCacheKey, List<String>>) (key, value) -> value.size())
+            .recordStats()
+            .build();
 
     private Set<String> getAvailableFilterColumns() {
         if (availableFilterColumns == null) {
@@ -439,13 +463,36 @@ public class OlsSearchClient {
     }
 
     /**
-     * Suggest with ontology filtering.
+     * Suggest with optional ontology filtering. Results are cached (see {@link #suggestCache}):
+     * autocomplete traffic is progressive-typing-shaped, so short/common prefixes like "can" are
+     * requested by every user who goes on to type "cancer", and are the most expensive queries to
+     * run cold (large fuzzy trigram candidate sets). Benchmarking against the dev DB (9.5M rows)
+     * found no index tuning (GiST, siglen, gin_fuzzy_search_limit) that beats the plain GIN trigram
+     * index without either changing match semantics or risking incorrect/approximate results, so
+     * this stays an exact query and leans on caching for latency instead.
      */
     public List<String> suggestLabels(String prefix, List<String> ontologyIds, int start, int rows) {
         if (prefix == null || prefix.isBlank()) {
             return List.of();
         }
 
+        SuggestCacheKey key = new SuggestCacheKey(
+                prefix.toLowerCase(Locale.ROOT), normalizeOntologyIds(ontologyIds), start, rows);
+        try {
+            return suggestCache.get(key, () -> suggestLabelsUncached(prefix, ontologyIds, start, rows));
+        } catch (ExecutionException e) {
+            throw new RuntimeException("suggestLabels query failed", e.getCause());
+        }
+    }
+
+    private static List<String> normalizeOntologyIds(List<String> ontologyIds) {
+        if (ontologyIds == null || ontologyIds.isEmpty()) {
+            return List.of();
+        }
+        return ontologyIds.stream().sorted().distinct().toList();
+    }
+
+    private List<String> suggestLabelsUncached(String prefix, List<String> ontologyIds, int start, int rows) {
         Condition where = trigramMatch(STRING_VALUE, prefix);
         if (ontologyIds != null && !ontologyIds.isEmpty()) {
             where = where.and(ONTOLOGY_ID.in(ontologyIds));
@@ -471,6 +518,9 @@ public class OlsSearchClient {
         } catch (SQLException e) {
             throw new RuntimeException("suggestLabels query failed", e);
         }
+    }
+
+    private record SuggestCacheKey(String prefix, List<String> ontologyIds, int start, int rows) {
     }
 
     /**

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/service/PostgresClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/service/PostgresClient.java
@@ -86,7 +86,11 @@ public class PostgresClient {
         HikariConfig config = new HikariConfig();
         String url = "jdbc:postgresql://" + host + ":" + port + "/" + database;
         if (schema != null && !schema.isEmpty()) {
-            url += "?currentSchema=" + schema;
+            // currentSchema replaces search_path outright (it doesn't append to the default), so a
+            // non-public schema must list public explicitly or extension functions installed there
+            // by default (pg_trgm's similarity()/%, pgvector's <=>) stop resolving unqualified.
+            String searchPath = "public".equals(schema) ? schema : schema + ",public";
+            url += "?currentSchema=" + searchPath;
         }
         config.setJdbcUrl(url);
         config.setUsername(user);


### PR DESCRIPTION
## Summary

Fixes #1345 (OLS search slow, and specifically the correctness regression an earlier speed fix introduced).

- The unscoped `/api/suggest` path had been switched to a prefix-only `lower(string) LIKE 'x%'` B-tree lookup for speed. That's fast but silently drops non-prefix fuzzy matches — e.g. `cancer` no longer surfaces `liver cancer`. Reverted to the original exact `pg_trgm` `%`/`similarity()` query for both scoped and unscoped requests, restoring the original search contract.
- Added an in-process cache (Guava — already a dependency) around `suggestLabels`, keyed on `(query, ontologyIds, start, rows)`. Autocomplete traffic is progressive-typing-shaped (every user who types "cancer" also fires "can"), so this is where the real win is: cold queries stay at the DB's native ~700ms–1.5s (unchanged, since it's the same exact query), repeat queries drop to ~2ms.
- Fixed `ols.postgres.schema` (`PostgresClient.java`): the JDBC `currentSchema` param *replaces* `search_path` rather than appending to it, so `pg_trgm`'s `similarity()`/`%` and pgvector's `<=>` (installed in `public` by default) stopped resolving once a non-public schema was configured.

## Why not just tune the index?

Benchmarked against the dev DB (`EXPLAIN ANALYZE, BUFFERS` on `can` / `cancer` / `liver` / `liver cancer`, 9.5M rows) before touching any code:
- **GiST + KNN ordering** (default and tuned `siglen`) — mixed results, and it actively regressed the already-fast ontology-scoped path (114ms → 1373ms, a 12x hit) because the planner sometimes picked it over GIN with a much worse access pattern. Disqualified as net harmful.
- **`gin_fuzzy_search_limit`** — a 33x speedup on `can` (2973ms → 91ms), but diffing the actual returned top-10 against the unrestricted baseline showed it drops real matches (`Cana`, `CAN-032`, `CAN-296`, `CAN-508`). It's a documented lossy/approximate mechanism. Disqualified on correctness — breaks exactly the queries it was fixing.
- **`word_similarity`/`<%`** — different match semantics (word-level vs full-string threshold), risks silently changing results for untested queries. Not pursued.

No index tuning inside `pg_trgm` gives a uniform, correctness-preserving order-of-magnitude win here — that's inherent to trigram candidate generation being imprecise for short queries at this row count, not a missing knob. Caching is the lever with real leverage and zero correctness risk, given the traffic shape.

## Cache sizing

- **No TTL**: autosuggest data only changes via a full dataload + redeploy (new pod, fresh empty cache) — grepped the backend for any live-reload path, there isn't one. A TTL would only evict still-valid hot entries and force them back through the slow path for no reason.
- **Bounded by weight, not entry count**: `rows` is caller-controlled up to `ols.search.max-rows` (1000), so a raw `maximumSize` doesn't bound memory — a client could inflate a large size cap toward gigabytes by requesting big row counts across many distinct keys. Weighing by cached label-row count (`maximumWeight(3_000_000)`) gives a hard ~300MB ceiling regardless of how requests are shaped, negligible against the backend pod's 10Gi request / 50Gi limit (`k8chart/ols4/templates/ols4-backend-deployment.yaml`). `recordStats()` is on so this can be tuned from real hit-rate data if needed.

## Test plan

- [x] `mvn compile` (JDK 21) — clean
- [x] Ran the local backend against the dev Postgres DB (`spotolsexp`, 9.5M-row `ols_autosuggest`) and verified end-to-end:
  - `q=cancer&rows=500` includes `liver cancer` (all case variants) — correctness restored
  - Cold timing matches the direct-DB baseline (`cancer` 951ms, `liver` 1544ms, `liver cancer` 700ms, `flu` 737ms)
  - Repeat identical request ~2ms (cache hit)
  - Ontology-scoped (`q=cancer&ontology=efo`) still works, 255ms cold / 2ms warm
- [ ] Reviewer: confirm cache behavior under real prod traffic patterns / adjust `maximumWeight` if `recordStats()` shows a poor hit rate

🤖 Generated with [Claude Code](https://claude.com/claude-code)