### PR TITLE
Add SSTIM (Sensory Stimulation Ontology)

### DIFF
--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -2095,6 +2095,41 @@
     {
       "id": "cmpo",
       "ontology_purl": "file:///nfs/production/parkinso/spot/ols4/prod-postgres/local_ontologies/cmpo.owl"
+    },
+    {
+      "id": "sstim",
+      "creator": [
+        "Renato Fabbri"
+      ],
+      "is_foundary": false,
+      "preferredPrefix": "sstim",
+      "title": "Sensory Stimulation Ontology",
+      "uri": "https://w3id.org/sstim",
+      "description": "An OWL 2 ontology with a multilingual SKOS vocabulary (English, Italian, Portuguese, Spanish) and SHACL shapes for describing sensory stimulation: techniques, protocols, implementations, exposure conditions, observations, safety metadata, and evidence-qualified claims across auditory, visual, haptic and other modalities. It models parameters, provenance and evidence status, and asserts no clinical efficacy.",
+      "homepage": "https://labiosyncare.github.io/ontology/docs/",
+      "mailing_list": "renato.fabbri@gmail.com",
+      "label_property": [
+        "http://www.w3.org/2000/01/rdf-schema#label",
+        "http://www.w3.org/2004/02/skos/core#prefLabel"
+      ],
+      "definition_property": [
+        "http://www.w3.org/2004/02/skos/core#definition"
+      ],
+      "synonym_property": [
+        "http://www.w3.org/2004/02/skos/core#altLabel"
+      ],
+      "hierarchical_property": [
+        "http://www.w3.org/2000/01/rdf-schema#subClassOf",
+        "http://www.w3.org/2004/02/skos/core#broader"
+      ],
+      "base_uri": [
+        "https://w3id.org/sstim#",
+        "https://w3id.org/sstim/vocab#",
+        "https://w3id.org/sstim/exposure#",
+        "https://w3id.org/sstim/ecosystem#"
+      ],
+      "oboSlims": false,
+      "ontology_purl": "https://labiosyncare.github.io/ontology/0.15.0/sstim-namespace.ttl"
     }
   ]
 }

--- a/ebi_ontologies.json
+++ b/ebi_ontologies.json
@@ -2106,7 +2106,7 @@
       "title": "Sensory Stimulation Ontology",
       "uri": "https://w3id.org/sstim",
       "description": "An OWL 2 ontology with a multilingual SKOS vocabulary (English, Italian, Portuguese, Spanish) and SHACL shapes for describing sensory stimulation: techniques, protocols, implementations, exposure conditions, observations, safety metadata, and evidence-qualified claims across auditory, visual, haptic and other modalities. It models parameters, provenance and evidence status, and asserts no clinical efficacy.",
-      "homepage": "https://labiosyncare.github.io/ontology/docs/",
+      "homepage": "https://w3c-cg.github.io/sstim/ontology/docs/",
       "mailing_list": "renato.fabbri@gmail.com",
       "label_property": [
         "http://www.w3.org/2000/01/rdf-schema#label",
@@ -2129,7 +2129,7 @@
         "https://w3id.org/sstim/ecosystem#"
       ],
       "oboSlims": false,
-      "ontology_purl": "https://labiosyncare.github.io/ontology/0.15.0/sstim-namespace.ttl"
+      "ontology_purl": "https://w3c-cg.github.io/sstim/ontology/0.16.0/sstim-namespace.ttl"
     }
   ]
 }


### PR DESCRIPTION
Adds SSTIM, the Sensory Stimulation Ontology, as one entry in
`ebi_ontologies.json`. Append-only, no other entries touched.

**What it is.** An OWL 2 ontology with a multilingual SKOS vocabulary and SHACL
shapes for describing sensory stimulation — techniques, protocols,
implementations, exposure conditions, observations, safety metadata and
evidence-qualified claims, across auditory, visual, haptic and other modalities.
It models parameters, provenance and evidence status, and asserts no clinical
efficacy.

- Ontology IRI: https://w3id.org/sstim (content-negotiates Turtle / JSON-LD / RDF-XML)
- Documentation: https://w3c-cg.github.io/sstim/ontology/docs/
- Source: https://github.com/w3c-cg/sstim
- Licence: CC BY 4.0
- Concept DOI: https://doi.org/10.5281/zenodo.21286974

**Content of the release being ingested (0.16.0):** 11,506 triples — 164
SSTIM OWL classes, 158 object properties, 143 datatype properties, and 551 SKOS
concepts across 68 concept schemes.

**Notes on the config entry**

- `ontology_purl` points at the **frozen 0.16.0 snapshot** rather than a
  "latest" URL. Releases are frozen byte-identical under a version IRI, and the
  unversioned working artifact is not advertised as a release. I will open a
  small follow-up PR to bump this on each release. Happy to switch to a rolling
  released URL instead if you would prefer fewer PRs — just say which you want.
- `reasoner` is omitted, as it is for most entries. The ontology is in the OWL
  2 DL profile (checked with `robot validate-profile`) and consistent under
  HermiT, JFact and Openllet, but its class hierarchy is asserted rather than
  inferred, so nothing is gained by reasoning at load time.
- `base_uri` lists four namespaces because SSTIM is modular.
- `synonym_property` is `skos:altLabel`. Current alternate-label coverage is
  limited, but the field is valid and intentionally declared for present and
  future synonyms.
- `label_property` includes both `rdfs:label` and `skos:prefLabel` — OWL
  classes and properties carry the former, SKOS concepts the latter.

Verified before updating this PR: the W3C-CG `ontology_purl` returns HTTP 200
as `text/turtle`, is 788,555 bytes, has SHA-256
`522abc802f2366356899ddedc5b2e548d5918368185fd84b178c6004398037b1`,
and parses to 11,506 triples. It is byte-identical to the preserved legacy
publication.

SSTIM is already catalogued in BARTOC (node 21154), FAIRsharing (record 8494)
and BioPortal, and registered at prefix.cc. Related W3C work: the Sensory
Stimulation Vocabulary Community Group.
