### PR TITLE
fix(dataload): add ontology IRI to SSSOM metadata

### DIFF
--- a/dataload/extras/json2sssom/src/main/java/JSON2SSSOM.java
+++ b/dataload/extras/json2sssom/src/main/java/JSON2SSSOM.java
@@ -226,9 +226,10 @@ public class JSON2SSSOM {
                     String mappingSetOntologyFullName = mappingSetOntologyTitle == null || mappingSetOntologyTitle.isBlank()
                             ? mappingSetOntologyName
                             : mappingSetOntologyTitle + " (" + mappingSetOntologyName + ")";
+                    String ontologyIri = getStringProperty(ontologyProperties, "iri");
 
-                    writeExtractFile(yaml, outputFilePath, ontologyId, mappingSetOntologyName, mappingSetOntologyFullName, mappingDate, false, current);
-                    writeExtractFile(yaml, outputFilePath, ontologyId, mappingSetOntologyName, mappingSetOntologyFullName, mappingDate, true, obsolete);
+                    writeExtractFile(yaml, outputFilePath, ontologyId, mappingSetOntologyName, mappingSetOntologyFullName, ontologyIri, mappingDate, false, current);
+                    writeExtractFile(yaml, outputFilePath, ontologyId, mappingSetOntologyName, mappingSetOntologyFullName, ontologyIri, mappingDate, true, obsolete);
 
                     reader.endObject();
                 }
@@ -246,6 +247,7 @@ public class JSON2SSSOM {
             String ontologyId,
             String mappingSetOntologyName,
             String mappingSetOntologyFullName,
+            String ontologyIri,
             String mappingDate,
             boolean obsolete,
             SssomExtract extract) throws IOException {
@@ -268,6 +270,9 @@ public class JSON2SSSOM {
         yamlHeaderOther.put("local_id", localId);
         yamlHeaderOther.put("prefix", mappingSetOntologyName);
         yamlHeaderOther.put("ontology", mappingSetOntologyFullName);
+        if (ontologyIri != null && !ontologyIri.isBlank()) {
+            yamlHeaderOther.put("ontology_iri", ontologyIri);
+        }
         yamlHeader.put("other", yamlHeaderOther);
         yamlHeader.put("local_name", localName);
         yamlHeader.put("curie_map", extract.curieMap.curiePrefixToNamespace);

--- a/dataload/extras/json2sssom/src/test/java/JSON2SSSOMTest.java
+++ b/dataload/extras/json2sssom/src/test/java/JSON2SSSOMTest.java
@@ -27,6 +27,7 @@ public class JSON2SSSOMTest {
                 "  \"ontologies\": [\n" +
                 "    {\n" +
                 "      \"ontologyId\": \"apo\",\n" +
+                "      \"iri\": \"http://purl.obolibrary.org/obo/apo.owl\",\n" +
                 "      \"preferredPrefix\": \"APO\",\n" +
                 "      \"title\": \"Ascomycete Phenotype Ontology\",\n" +
                 "      \"classes\": [],\n" +
@@ -52,7 +53,7 @@ public class JSON2SSSOMTest {
         assertTrue(sssom.contains("# mapping_set_title: OLS extracted APO mappings\n"));
         assertTrue(sssom.contains("# mapping_set_description: These mappings were extracted during the OLS dataload from APO\n"));
         assertTrue(sssom.contains("# mapping_date: '2026-04-30'\n") || sssom.contains("# mapping_date: 2026-04-30\n"));
-        assertTrue(sssom.contains("# other:\n#   local_id: apo.ols\n#   prefix: APO\n#   ontology: Ascomycete Phenotype Ontology (APO)\n# local_name: apo.ols.sssom.tsv\n"));
+        assertTrue(sssom.contains("# other:\n#   local_id: apo.ols\n#   prefix: APO\n#   ontology: Ascomycete Phenotype Ontology (APO)\n#   ontology_iri: http://purl.obolibrary.org/obo/apo.owl\n# local_name: apo.ols.sssom.tsv\n"));
         assertFalse(sssom.contains("mapping_set_source"));
     }
 


### PR DESCRIPTION
## Summary

- Add the ontology IRI to the SSSOM `other.ontology_iri` metadata field for current and obsolete extracts.
- Cover the APO metadata output with a regression test.

## Tests

- `env JAVA_HOME=/Users/haideri/Library/Java/JavaVirtualMachines/ms-17.0.15/Contents/Home /opt/homebrew/bin/mvn -q test`

Closes #1243