### PR TITLE
fix(dataload): remediate reporting image dependencies

### DIFF
--- a/dataload/reporting/pom.xml
+++ b/dataload/reporting/pom.xml
@@ -25,6 +25,27 @@
             <artifactId>github-api</artifactId>
             <version>1.323</version>
         </dependency>
+        <!-- Keep github-api's shaded transitive dependencies on fixed versions. -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <version>2.18.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.18.8</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <version>2.18.8</version>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.14.0</version>
+        </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>


### PR DESCRIPTION
## Summary
- Override the vulnerable transitive Jackson dependencies pulled by `github-api:1.323` with `2.18.8`.
- Override `commons-io` with `2.14.0`.
- Remediates the dependencies bundled into the shaded reporting JAR in the `ols4-dataload` image.

Resolves the current Trivy findings: [#22132](https://github.com/EBISPOT/ols4/security/code-scanning/22132), [#20339](https://github.com/EBISPOT/ols4/security/code-scanning/20339), [#20337](https://github.com/EBISPOT/ols4/security/code-scanning/20337), and [#6096](https://github.com/EBISPOT/ols4/security/code-scanning/6096).

## Validation
- `env JAVA_HOME=/Users/haideri/Library/Java/JavaVirtualMachines/ms-17.0.15/Contents/Home mvn -B -ntp -f dataload/reporting/pom.xml clean package`
- Maven build succeeded and confirmed Jackson `2.18.8` and Commons IO `2.14.0` in the shaded JAR.
- `git diff --check` passed.
- A new `ols4-dataload:dev` image must be published before the container scan can refresh GitHub alerts.