### PR TITLE
Fix V2 ontology dynamic parameter binding

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import uk.ac.ebi.spot.ols.controller.api.v2.helpers.DynamicQueryHelper;
 import uk.ac.ebi.spot.ols.controller.api.v2.responses.V2PagedAndFacetedResponse;
@@ -68,7 +69,7 @@ public class V2OntologyController {
             @Parameter(name = "includeObsoleteEntities",
                     description = "A boolean parameter to specify if obsolete entities should be included or not. Default value is false.") boolean includeObsoleteEntities,
             @RequestParam
-            @Parameter(hidden = true) Map<String, Collection<String>> searchProperties,
+            @Parameter(hidden = true) MultiValueMap<String, String> searchProperties,
             @RequestParam(value = "lang", required = false, defaultValue = "en") String lang,
             @ParameterObject JsonTransformOptions outputOpts
     ) throws ResourceNotFoundException, IOException {
@@ -76,7 +77,7 @@ public class V2OntologyController {
         Map<String,Collection<String>> properties = new HashMap<>();
         if(!includeObsoleteEntities)
             properties.put(IS_OBSOLETE.getText(), List.of("false"));
-        properties.putAll(searchProperties);
+        searchProperties.forEach((name, values) -> properties.put(name, List.copyOf(values)));
 
         return new ResponseEntity<>(
                 new V2PagedAndFacetedResponse<V2Entity>(

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerDynamicParametersTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerDynamicParametersTest.java
@@ -1,0 +1,62 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class V2OntologyControllerDynamicParametersTest {
+
+    @Test
+    void bindsRepeatedAndUriNamedDynamicParameters() throws Exception {
+        RecordingOntologyRepository repository = new RecordingOntologyRepository();
+        V2OntologyController controller = new V2OntologyController();
+        controller.ontologyRepository = repository;
+
+        MockMvc mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+
+        mockMvc.perform(get("/api/v2/ontologies")
+                        .param("domain", "biology", "health")
+                        .param("http://example.org/category", "experimental"))
+                .andExpect(status().isOk());
+
+        assertThat(repository.properties.get("domain"))
+                .containsExactly("biology", "health");
+        assertThat(repository.properties.get("http://example.org/category"))
+                .containsExactly("experimental");
+    }
+
+    private static class RecordingOntologyRepository extends OntologyRepository {
+        private Map<String, Collection<String>> properties;
+
+        @Override
+        public OlsFacetedResultsPage<JsonElement> find(
+                Pageable pageable,
+                String lang,
+                String search,
+                String searchFields,
+                String boostFields,
+                boolean exactMatch,
+                Map<String, Collection<String>> properties,
+                JsonTransformOptions outputOpts) throws IOException {
+            this.properties = properties;
+            return new OlsFacetedResultsPage<>(List.of(), Map.of(), pageable, 0);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- preserve repeated query-parameter values in V2 ontology requests
- preserve URI-shaped dynamic property names
- keep reserved controller parameters out of dynamic filters

## Validation
- focused regression test passes
- backend fast test suite passes with Java 17