### PR TITLE
Preserve API client error statuses

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/exception/GlobalExceptionHandler.java
@@ -1,8 +1,10 @@
 package uk.ac.ebi.spot.ols.controller.api.exception;
 
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.core.Ordered;
 import org.springframework.core.annotation.Order;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -35,10 +37,14 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(Exception.class)
     @ResponseBody
     public ResponseEntity<ErrorResponse> handleAllExceptions(Exception ex) {
-        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        HttpStatusCode status = HttpStatus.INTERNAL_SERVER_ERROR;
         if (ex instanceof ResourceNotFoundException) {
             status = HttpStatus.NOT_FOUND;
         } else if (ex instanceof BadRequestException || ex instanceof IllegalArgumentException) {
+            status = HttpStatus.BAD_REQUEST;
+        } else if (ex instanceof org.springframework.web.ErrorResponse springError) {
+            status = springError.getStatusCode();
+        } else if (ex instanceof TypeMismatchException) {
             status = HttpStatus.BAD_REQUEST;
         }
 

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerClientErrorTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerClientErrorTest.java
@@ -1,0 +1,48 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+class V2OntologyControllerClientErrorTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        V2OntologyController controller = new V2OntologyController();
+        controller.ontologyRepository = new OntologyRepository();
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/v2/ontologies"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405));
+    }
+
+    @Test
+    void returnsBadRequestForMalformedBooleanParameter() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("exactMatch", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400));
+    }
+}


### PR DESCRIPTION
## Summary
- preserve Spring client-error status codes in the global API exception handler
- map malformed typed request parameters to HTTP 400
- retain stable JSON error status and message fields

## Validation
- focused controller error-contract regression tests pass
- backend fast test suite passes with Java 17