### PR TITLE
Fix repeated dynamic filter values

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/helpers/DynamicFilterParser.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/helpers/DynamicFilterParser.java
@@ -3,8 +3,9 @@ package uk.ac.ebi.spot.ols.repository.helpers;
 import uk.ac.ebi.spot.ols.repository.search.SearchType;
 import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class DynamicFilterParser {
@@ -27,9 +28,13 @@ public class DynamicFilterParser {
                 }
                 continue;
             }
-            for(String v : properties.get(k)) {
+            List<String> values = new ArrayList<>();
+            for (String value : properties.get(k)) {
+                values.addAll(List.of(value.split(",")));
+            }
+            if (!values.isEmpty()) {
                 String filterKey = k.replace(":", "__");
-                query.addFilter(filterKey, Arrays.asList( v.split(",") ), SearchType.CASE_INSENSITIVE_TOKENS);
+                query.addFilter(filterKey, values, SearchType.CASE_INSENSITIVE_TOKENS);
             }
         }
     }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/helpers/DynamicFilterParserTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/helpers/DynamicFilterParserTest.java
@@ -1,0 +1,48 @@
+package uk.ac.ebi.spot.ols.repository.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.search.SearchType;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DynamicFilterParserTest {
+
+    @Test
+    void combinesRepeatedAndCommaSeparatedValuesIntoOneAlternativeFilter() {
+        RecordingQuery query = new RecordingQuery();
+
+        DynamicFilterParser.addDynamicFiltersToQuery(
+                query,
+                Map.of("domain", List.of("biology,health", "information")));
+
+        assertThat(query.filters).containsExactly(
+                new RecordedFilter(
+                        "domain",
+                        List.of("biology", "health", "information"),
+                        SearchType.CASE_INSENSITIVE_TOKENS));
+    }
+
+    private static class RecordingQuery extends OlsSearchQuery {
+        private final List<RecordedFilter> filters = new ArrayList<>();
+
+        @Override
+        public void addFilter(
+                String propertyName,
+                Collection<String> propertyValues,
+                SearchType searchType) {
+            filters.add(new RecordedFilter(propertyName, List.copyOf(propertyValues), searchType));
+        }
+    }
+
+    private record RecordedFilter(
+            String propertyName,
+            List<String> values,
+            SearchType searchType) {
+    }
+}


### PR DESCRIPTION
## Summary
- combine repeated and comma-separated dynamic filter values
- apply alternative values as one OR filter instead of mutually exclusive filters
- retain a minimal parser regression test

## Validation
- focused dynamic-filter regression test passes
- backend fast test suite passes with Java 17