### PR TITLE
Honor safe PostgreSQL search sorting

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClient.java
@@ -126,7 +126,7 @@ public class OlsSearchClient {
         try (Connection conn = postgresClient.getConnection()) {
             DSLContext dsl = postgresClient.dsl(conn);
             Condition where = query.buildCondition(getAvailableFilterColumns());
-            List<SortField<?>> orderBy = query.buildOrderBy();
+            List<SortField<?>> orderBy = query.buildOrderBy(pageable.getSort());
 
             Long count = includeTotal
                     ? Optional.ofNullable(dsl.selectCount()

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -5,6 +5,7 @@ import org.jooq.Field;
 import org.jooq.SortField;
 import org.jooq.impl.DSL;
 import org.jooq.impl.SQLDataType;
+import org.springframework.data.domain.Sort;
 
 import java.util.*;
 import java.util.Locale;
@@ -171,7 +172,29 @@ public class OlsSearchQuery {
     }
 
     public List<SortField<?>> buildOrderBy() {
-        return buildOrderBy(null);
+        return buildOrderBy((String) null);
+    }
+
+    public List<SortField<?>> buildOrderBy(Sort sort) {
+        if (sort == null || sort.isUnsorted()) {
+            return buildOrderBy();
+        }
+
+        List<SortField<?>> orderBy = new ArrayList<>();
+        for (Sort.Order order : sort) {
+            String column = COLUMN_MAP.get(order.getProperty());
+            ColumnType columnType = COLUMN_TYPES.get(order.getProperty());
+            if (column == null || columnType == ColumnType.TEXT_ARRAY) {
+                throw new IllegalArgumentException("Unsupported sort field: " + order.getProperty());
+            }
+
+            Field<?> sortField = columnType == ColumnType.BOOLEAN
+                    ? field(column, Boolean.class)
+                    : field(column, String.class);
+            orderBy.add(order.isAscending() ? sortField.asc() : sortField.desc());
+        }
+        orderBy.add(field("id", String.class).asc());
+        return orderBy;
     }
 
     public List<SortField<?>> buildOrderBy(String qualifier) {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuerySortTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuerySortTest.java
@@ -1,0 +1,35 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import org.jooq.SortOrder;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Sort;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class OlsSearchQuerySortTest {
+
+    @Test
+    void mapsApiSortFieldsAndAddsDeterministicTieBreaker() {
+        OlsSearchQuery query = new OlsSearchQuery();
+
+        var orderBy = query.buildOrderBy(Sort.by(Sort.Direction.DESC, "ontologyId"));
+
+        assertThat(orderBy).extracting(field -> field.getName())
+                .containsExactly("ontology_id", "id");
+        assertThat(orderBy).extracting(field -> field.getOrder())
+                .containsExactly(SortOrder.DESC, SortOrder.ASC);
+    }
+
+    @Test
+    void rejectsUnknownAndArraySortFields() {
+        OlsSearchQuery query = new OlsSearchQuery();
+
+        assertThatThrownBy(() -> query.buildOrderBy(Sort.by("notARealField")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported sort field: notARealField");
+        assertThatThrownBy(() -> query.buildOrderBy(Sort.by("label")))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Unsupported sort field: label");
+    }
+}


### PR DESCRIPTION
## Summary
- apply supported Pageable sort fields to PostgreSQL search queries
- reject unknown and array-backed fields instead of interpolating unsafe names
- preserve the existing deterministic default order

## Validation
- focused sort regression tests pass
- backend fast test suite passes with Java 17