### PR TITLE
Apply explicit PostgreSQL boost fields

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/helpers/SearchFieldsParser.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/helpers/SearchFieldsParser.java
@@ -35,14 +35,8 @@ public class SearchFieldsParser {
     public static void addBoostFieldsToQuery(OlsSearchQuery query, String boostFields) {
 
         if(boostFields == null) {
-            query.addBoostField("type", "ontology", 10, SearchType.WHOLE_FIELD);
-            query.addBoostField(IS_DEFINING_ONTOLOGY.getText(), "true", 1000, SearchType.WHOLE_FIELD);
-            query.addBoostField(LABEL.getText(), query.getSearchText(), 1000, SearchType.WHOLE_FIELD);
-            query.addBoostField(LABEL.getText(), query.getSearchText(), 500, SearchType.EDGES);
-            query.addBoostField("curie", query.getSearchText(), 500, SearchType.EDGES);
-            query.addBoostField("shortForm", query.getSearchText(), 500, SearchType.EDGES);
-            query.addBoostField(SYNONYM.getText(), query.getSearchText(), 500, SearchType.WHOLE_FIELD);
-//            query.addBoostField("synonym", query.getSearchText(), 100, SearchType.EDGES);
+            // Default PostgreSQL ranking is implemented directly by OlsSearchQuery.
+            return;
         } else {
             for (ParsedField field : parseFieldsString(boostFields)) {
                 query.addBoostField(field.property, field.value, field.weight, SearchType.CASE_INSENSITIVE_TOKENS);
@@ -82,14 +76,13 @@ public class SearchFieldsParser {
 
                 // weighted
 
-                String property = propertyAndWeight[0];
                 int weight = Integer.parseInt(propertyAndWeight[1]);
 
                 String[] propertyAndMaybeValue = propertyAndWeight[0].split(":");
                 if(propertyAndMaybeValue.length == 2) {
-                    parsed.add(new ParsedField(propertyAndMaybeValue[0], propertyAndMaybeValue[1], 1));
+                    parsed.add(new ParsedField(propertyAndMaybeValue[0], propertyAndMaybeValue[1], weight));
                 } else {
-                    parsed.add(new ParsedField(propertyAndMaybeValue[0], null, 1));
+                    parsed.add(new ParsedField(propertyAndMaybeValue[0], null, weight));
                 }
 
             } else {

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -33,6 +33,7 @@ public class OlsSearchQuery {
     List<SearchFilter> excludeFilters = new ArrayList<>();
     List<String> facetFields = new ArrayList<>();
     List<String> searchFields = null;
+    List<BoostField> boostFields = new ArrayList<>();
 
     enum ColumnType { TEXT, BOOLEAN, TEXT_ARRAY }
 
@@ -193,7 +194,7 @@ public class OlsSearchQuery {
         if (searchText == null || searchText.isBlank()) {
             return null;
         }
-        return DSL.function(
+        Field<Double> rank = DSL.function(
                 "ts_rank_cd",
                 SQLDataType.DOUBLE,
                 field(qualifier, "ts_search", Object.class),
@@ -207,6 +208,28 @@ public class OlsSearchQuery {
                 // exact matches whose case differs from the query rank purely on ts_rank_cd and can
                 // end up buried many pages deep. See GitHub issue #1312.
                 .plus(DSL.when(arrayContainsCaseInsensitive(field(qualifier, "label", String[].class), searchText.toLowerCase(Locale.ROOT)), 1000.0).otherwise(0.0));
+
+        for (BoostField boost : boostFields) {
+            Condition matches = buildBoostCondition(qualifier, boost);
+            rank = rank.plus(DSL.when(matches, (double) boost.weight).otherwise(0.0));
+        }
+        return rank;
+    }
+
+    private Condition buildBoostCondition(String qualifier, BoostField boost) {
+        String column = COLUMN_MAP.get(boost.propertyName);
+        ColumnType columnType = COLUMN_TYPES.get(boost.propertyName);
+        if (column == null || columnType == null) {
+            throw new IllegalArgumentException("Unsupported boost field: " + boost.propertyName);
+        }
+
+        String value = boost.propertyValue == null ? searchText : boost.propertyValue;
+        if (columnType == ColumnType.BOOLEAN) {
+            return field(qualifier, column, Boolean.class).eq(Boolean.parseBoolean(value));
+        }
+        return tsvectorMatches(
+                field(qualifier, column, Object.class),
+                toTsQuery(buildPrefixTsQueryString(value)));
     }
 
     /**
@@ -418,6 +441,23 @@ public class OlsSearchQuery {
      * Compatibility shim: boost fields are handled by the ORDER BY scoring.
      */
     public void addBoostField(String propertyName, String propertyValue, int weight, SearchType searchType) {
-        // No-op: boosting is built into buildOrderBy()
+        if (weight <= 0) {
+            throw new IllegalArgumentException("Boost weight must be positive: " + weight);
+        }
+        boostFields.add(new BoostField(propertyName, propertyValue, weight, searchType));
+    }
+
+    static class BoostField {
+        String propertyName;
+        String propertyValue;
+        int weight;
+        SearchType searchType;
+
+        BoostField(String propertyName, String propertyValue, int weight, SearchType searchType) {
+            this.propertyName = propertyName;
+            this.propertyValue = propertyValue;
+            this.weight = weight;
+            this.searchType = searchType;
+        }
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/helpers/SearchFieldsParserBoostTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/helpers/SearchFieldsParserBoostTest.java
@@ -1,0 +1,44 @@
+package uk.ac.ebi.spot.ols.repository.helpers;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.search.SearchType;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SearchFieldsParserBoostTest {
+
+    @Test
+    void preservesExplicitBoostWeights() {
+        RecordingQuery query = new RecordingQuery();
+
+        SearchFieldsParser.addBoostFieldsToQuery(query, "definition^1000 label^25");
+
+        assertThat(query.boosts).containsExactly(
+                new RecordedBoost("definition", null, 1000, SearchType.CASE_INSENSITIVE_TOKENS),
+                new RecordedBoost("label", null, 25, SearchType.CASE_INSENSITIVE_TOKENS));
+    }
+
+    private static class RecordingQuery extends OlsSearchQuery {
+        private final List<RecordedBoost> boosts = new ArrayList<>();
+
+        @Override
+        public void addBoostField(
+                String propertyName,
+                String propertyValue,
+                int weight,
+                SearchType searchType) {
+            boosts.add(new RecordedBoost(propertyName, propertyValue, weight, searchType));
+        }
+    }
+
+    private record RecordedBoost(
+            String propertyName,
+            String propertyValue,
+            int weight,
+            SearchType searchType) {
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQueryBoostTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQueryBoostTest.java
@@ -1,0 +1,24 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import org.jooq.SQLDialect;
+import org.jooq.impl.DSL;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OlsSearchQueryBoostTest {
+
+    @Test
+    void addsExplicitFieldMatchBonusToRank() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("experimental");
+        query.addBoostField("definition", null, 1000, SearchType.CASE_INSENSITIVE_TOKENS);
+
+        String sql = DSL.using(SQLDialect.POSTGRES).renderInlined(query.buildRankExpression(null));
+
+        assertThat(sql)
+                .contains("ols_tsvector(\"definition\")")
+                .contains("experimental:*")
+                .contains("cast(1E3 as double precision)");
+    }
+}


### PR DESCRIPTION
## Summary
- parse explicit boost fields and weights
- include safe field-specific ranking contributions in PostgreSQL search
- reject unsupported boost fields and non-positive weights

## Validation
- focused parser and ranking regression tests pass
- backend fast test suite passes with Java 17