### PR TITLE
Add V2 ontology backend testing pilot

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,8 +8,63 @@ on:
   pull_request:
 
 jobs:
+  backend-unit-web:
+    name: Backend Unit & Web Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run backend unit and web integration tests
+        run: mvn -B -ntp -pl backend -am test
+
+      - name: Upload backend unit and web test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-unit-web-reports
+          path: |
+            backend/target/surefire-reports/
+            backend/target/site/jacoco/
+          if-no-files-found: ignore
+
+  backend-postgres-integration:
+    name: Backend PostgreSQL Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+          cache: maven
+
+      - name: Run backend database integration tests
+        run: mvn -B -ntp -pl backend -am -Pintegration-tests-only verify
+
+      - name: Upload backend integration and coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backend-postgres-integration-reports
+          path: |
+            backend/target/failsafe-reports/
+            backend/target/site/jacoco/
+          if-no-files-found: ignore
+
   test-api:
     name: Build & Test API
+    needs:
+      - backend-unit-web
+      - backend-postgres-integration
     runs-on: ubuntu-latest
     steps:
       - name: Free up disk space on GH actions runner

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -177,6 +177,9 @@
           <includes>
             <include>**/*IT.java</include>
           </includes>
+          <excludes>
+            <exclude>**/*WIT.java</exclude>
+          </excludes>
         </configuration>
         <executions>
           <execution>
@@ -195,6 +198,16 @@
           <execution>
             <goals>
               <goal>prepare-agent</goal>
+            </goals>
+            <configuration>
+              <append>true</append>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unit-report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
           <execution>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -137,6 +137,16 @@
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>junit-jupiter</artifactId>
+      <scope>test</scope>
+    </dependency>
       <dependency>
           <groupId>javax.annotation</groupId>
           <artifactId>javax.annotation-api</artifactId>
@@ -148,9 +158,75 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/Test*.java</include>
+            <include>**/*Test.java</include>
+            <include>**/*Tests.java</include>
+            <include>**/*TestCase.java</include>
+            <include>**/*WIT.java</include>
+          </includes>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <configuration>
+          <includes>
+            <include>**/*IT.java</include>
+          </includes>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.15</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>verify</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>integration-tests-only</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerIT.java
@@ -1,0 +1,85 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V2OntologyControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.RepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createRepository(POSTGRES);
+
+        V2OntologyController controller = new V2OntologyController();
+        controller.ontologyRepository = repositoryHandle.repository();
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsActiveOntologiesThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.numElements").value(3))
+                .andExpect(jsonPath("$.totalElements").value(3))
+                .andExpect(jsonPath("$.elements[0].ontologyId").value("duo"))
+                .andExpect(jsonPath("$.elements[1].ontologyId").value("efo"))
+                .andExpect(jsonPath("$.elements[2].ontologyId").value("efo-atlas"));
+    }
+
+    @Test
+    void groupsOntologiesByTagThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies/by-tag"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.biomedical.length()").value(2))
+                .andExpect(jsonPath("$.clinical[0].ontologyId").value("duo"));
+    }
+
+    @Test
+    void groupsOntologiesByDomainThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies/by-domain"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.information[0].ontologyId").value("duo"))
+                .andExpect(jsonPath("$.biology.length()").value(3));
+    }
+
+    @Test
+    void getsOntologyByIdThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies/efo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ontologyId").value("efo"))
+                .andExpect(jsonPath("$.title").value("Experimental Factor Ontology"));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerTest.java
@@ -1,0 +1,187 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import uk.ac.ebi.spot.ols.controller.api.exception.ResourceNotFoundException;
+import uk.ac.ebi.spot.ols.model.v2.V2Entity;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class V2OntologyControllerTest {
+
+    private V2OntologyController controller;
+    private RecordingOntologyRepository repository;
+
+    @BeforeEach
+    void setUp() {
+        repository = new RecordingOntologyRepository();
+        controller = new V2OntologyController();
+        controller.ontologyRepository = repository;
+    }
+
+    @Test
+    void listExcludesObsoleteOntologiesAndForwardsSupportedParameters() throws Exception {
+        Pageable pageable = PageRequest.of(2, 7);
+        JsonTransformOptions outputOptions = new JsonTransformOptions();
+        outputOptions.resolveReferences = true;
+        MultiValueMap<String, String> requestProperties = new LinkedMultiValueMap<>();
+        requestProperties.put("lang", List.of("fr"));
+        requestProperties.put("page", List.of("2"));
+        requestProperties.put("domain", List.of("biology", "health"));
+
+        var response = controller.getOntologies(
+                pageable,
+                "factor",
+                "title ontologyId",
+                "title^10",
+                true,
+                false,
+                requestProperties,
+                "fr",
+                outputOptions);
+
+        assertEquals(HttpStatus.OK, ((org.springframework.http.ResponseEntity<?>) response).getStatusCode());
+        assertSame(pageable, repository.pageable);
+        assertEquals("fr", repository.lang);
+        assertEquals("factor", repository.search);
+        assertEquals("title ontologyId", repository.searchFields);
+        assertEquals("title^10", repository.boostFields);
+        assertTrue(repository.exactMatch);
+        assertEquals(
+                Map.of(
+                        "isObsolete", List.of("false"),
+                        "domain", List.of("biology", "health")),
+                repository.properties);
+        assertSame(outputOptions, repository.outputOptions);
+    }
+
+    @Test
+    void listIncludesObsoleteOntologiesWhenRequested() throws Exception {
+        controller.getOntologies(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                null,
+                false,
+                true,
+                new LinkedMultiValueMap<>(),
+                "en",
+                new JsonTransformOptions());
+
+        assertFalse(repository.properties.containsKey("isObsolete"));
+    }
+
+    @Test
+    void groupsOntologiesByTag() throws Exception {
+        Map<String, List<V2Entity>> grouped = Map.of("experimental", List.of(entity("efo-test")));
+        repository.groupedResult = grouped;
+
+        var response = controller.getOntologiesByTag("en", new JsonTransformOptions());
+
+        assertEquals("tags", repository.groupedField);
+        assertSame(grouped, response.getBody());
+    }
+
+    @Test
+    void groupsOntologiesByDomain() throws Exception {
+        Map<String, List<V2Entity>> grouped = Map.of("biology", List.of(entity("efo-test")));
+        repository.groupedResult = grouped;
+
+        var response = controller.getOntologiesByDomain("en", new JsonTransformOptions());
+
+        assertEquals("domain", repository.groupedField);
+        assertSame(grouped, response.getBody());
+    }
+
+    @Test
+    void returnsOntologyWhenItExists() throws Exception {
+        V2Entity ontology = entity("efo-test");
+        repository.entityById = ontology;
+
+        var response = controller.getOntology("efo-test", "en", new JsonTransformOptions());
+
+        assertEquals(HttpStatus.OK, ((org.springframework.http.ResponseEntity<?>) response).getStatusCode());
+        assertSame(ontology, response.getBody());
+        assertEquals("efo-test", repository.ontologyId);
+    }
+
+    @Test
+    void throwsNotFoundWhenOntologyDoesNotExist() {
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getOntology("missing", "en", new JsonTransformOptions()));
+    }
+
+    private static V2Entity entity(String ontologyId) {
+        return new V2Entity(JsonParser.parseString("{\"ontologyId\":\"" + ontologyId + "\"}"));
+    }
+
+    private static class RecordingOntologyRepository extends OntologyRepository {
+        private Pageable pageable;
+        private String lang;
+        private String search;
+        private String searchFields;
+        private String boostFields;
+        private boolean exactMatch;
+        private Map<String, Collection<String>> properties;
+        private JsonTransformOptions outputOptions;
+        private String groupedField;
+        private Map<String, List<V2Entity>> groupedResult = Map.of();
+        private String ontologyId;
+        private V2Entity entityById;
+
+        @Override
+        public OlsFacetedResultsPage<JsonElement> find(
+                Pageable pageable,
+                String lang,
+                String search,
+                String searchFields,
+                String boostFields,
+                boolean exactMatch,
+                Map<String, Collection<String>> properties,
+                JsonTransformOptions outputOptions) {
+            this.pageable = pageable;
+            this.lang = lang;
+            this.search = search;
+            this.searchFields = searchFields;
+            this.boostFields = boostFields;
+            this.exactMatch = exactMatch;
+            this.properties = properties;
+            this.outputOptions = outputOptions;
+            return new OlsFacetedResultsPage<>(List.of(), Map.of(), pageable, 0);
+        }
+
+        @Override
+        public Map<String, List<V2Entity>> getGroupedByField(
+                String fieldName,
+                String lang,
+                JsonTransformOptions outputOptions) {
+            this.groupedField = fieldName;
+            return groupedResult;
+        }
+
+        @Override
+        public V2Entity getById(String ontologyId, String lang, JsonTransformOptions outputOptions) {
+            this.ontologyId = ontologyId;
+            return entityById;
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerWIT.java
@@ -1,0 +1,406 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.model.v2.V2Entity;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.mockito.ArgumentCaptor;
+
+@WebMvcTest(V2OntologyController.class)
+@ContextConfiguration(classes = {
+        V2OntologyController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V2OntologyControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OntologyRepository ontologyRepository;
+
+    @BeforeEach
+    void stubListResponse() throws Exception {
+        when(ontologyRepository.find(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyBoolean(),
+                anyMap(),
+                any()))
+                .thenReturn(ontologyPage());
+    }
+
+    @Test
+    void returnsDefaultOntologyListContract() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.numElements").value(1))
+                .andExpect(jsonPath("$.totalPages").value(1))
+                .andExpect(jsonPath("$.totalElements").value(1))
+                .andExpect(jsonPath("$.elements[0].ontologyId").value("efo-test"))
+                .andExpect(jsonPath("$.elements[0].title").value("Experimental Factor Ontology"))
+                .andExpect(jsonPath("$.facetFieldsToCounts.domain.biology").value(1));
+
+        ListCall call = captureListCall();
+        assertEquals(0, call.pageable().getPageNumber());
+        assertEquals(20, call.pageable().getPageSize());
+        assertEquals("en", call.lang());
+        assertNull(call.search());
+        assertNull(call.searchFields());
+        assertNull(call.boostFields());
+        assertFalse(call.exactMatch());
+        assertEquals(Map.of("isObsolete", List.of("false")), call.properties());
+        assertFalse(call.outputOptions().resolveReferences);
+        assertFalse(call.outputOptions().manchesterSyntax);
+    }
+
+    @Test
+    void bindsPageAndSize() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("page", "2").param("size", "7"))
+                .andExpect(status().isOk());
+
+        ListCall call = captureListCall();
+        assertEquals(2, call.pageable().getPageNumber());
+        assertEquals(7, call.pageable().getPageSize());
+    }
+
+    @Test
+    void bindsSortDirection() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("sort", "ontologyId,desc"))
+                .andExpect(status().isOk());
+
+        assertEquals(
+                "ontologyId: DESC",
+                captureListCall().pageable().getSort().toString());
+    }
+
+    @Test
+    void bindsSearch() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("search", "factor"))
+                .andExpect(status().isOk());
+
+        assertEquals("factor", captureListCall().search());
+    }
+
+    @Test
+    void bindsSearchFields() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("searchFields", "title ontologyId"))
+                .andExpect(status().isOk());
+
+        assertEquals("title ontologyId", captureListCall().searchFields());
+    }
+
+    @Test
+    void bindsBoostFields() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("boostFields", "title^10 ontologyId^5"))
+                .andExpect(status().isOk());
+
+        assertEquals("title^10 ontologyId^5", captureListCall().boostFields());
+    }
+
+    @Test
+    void bindsExactMatch() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("exactMatch", "true"))
+                .andExpect(status().isOk());
+
+        assertTrue(captureListCall().exactMatch());
+    }
+
+    @Test
+    void includesObsoleteOntologiesWhenRequested() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("includeObsoleteEntities", "true"))
+                .andExpect(status().isOk());
+
+        assertFalse(captureListCall().properties().containsKey("isObsolete"));
+    }
+
+    @Test
+    void bindsLanguage() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("lang", "fr"))
+                .andExpect(status().isOk());
+
+        assertEquals("fr", captureListCall().lang());
+    }
+
+    @Test
+    void bindsTransformOptions() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies")
+                        .param("resolveReferences", "true")
+                        .param("manchesterSyntax", "true"))
+                .andExpect(status().isOk());
+
+        JsonTransformOptions options = captureListCall().outputOptions();
+        assertTrue(options.resolveReferences);
+        assertTrue(options.manchesterSyntax);
+    }
+
+    @Test
+    void forwardsRepeatedDynamicPropertyValues() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("domain", "biology", "health"))
+                .andExpect(status().isOk());
+
+        assertEquals(List.of("biology", "health"), captureListCall().properties().get("domain"));
+    }
+
+    @Test
+    void forwardsUriNamedDynamicProperty() throws Exception {
+        String property = "http://example.org/category";
+
+        mockMvc.perform(get("/api/v2/ontologies").param(property, "experimental"))
+                .andExpect(status().isOk());
+
+        assertEquals(List.of("experimental"), captureListCall().properties().get(property));
+    }
+
+    @Test
+    void reservedParametersDoNotBecomeDynamicProperties() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies")
+                        .param("page", "1")
+                        .param("size", "5")
+                        .param("search", "factor")
+                        .param("searchFields", "title")
+                        .param("boostFields", "title^10")
+                        .param("exactMatch", "true")
+                        .param("includeObsoleteEntities", "true")
+                        .param("lang", "fr")
+                        .param("resolveReferences", "true")
+                        .param("manchesterSyntax", "true")
+                        .param("model", "test")
+                        .param("includeTotal", "false")
+                        .param("excludeOntologyId", "other"))
+                .andExpect(status().isOk());
+
+        assertTrue(captureListCall().properties().isEmpty());
+    }
+
+    @Test
+    void combinesSearchFieldsAndExactMatch() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies")
+                        .param("search", "Experimental Factor Ontology")
+                        .param("searchFields", "title")
+                        .param("exactMatch", "true"))
+                .andExpect(status().isOk());
+
+        ListCall call = captureListCall();
+        assertEquals("Experimental Factor Ontology", call.search());
+        assertEquals("title", call.searchFields());
+        assertTrue(call.exactMatch());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "-1, 20, 0, 20",
+            "0, 0, 0, 20",
+            "0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundaries(
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies")
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        ListCall call = captureListCall();
+        assertEquals(expectedPage, call.pageable().getPageNumber());
+        assertEquals(expectedSize, call.pageable().getPageSize());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "page, not-a-number",
+            "size, not-a-number"
+    })
+    void usesPaginationDefaultsForNonNumericValues(String parameter, String value) throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param(parameter, value))
+                .andExpect(status().isOk());
+
+        ListCall call = captureListCall();
+        assertEquals(0, call.pageable().getPageNumber());
+        assertEquals(20, call.pageable().getPageSize());
+    }
+
+    @Test
+    void returnsOntologiesGroupedByTag() throws Exception {
+        when(ontologyRepository.getGroupedByField(any(), any(), any()))
+                .thenReturn(Map.of("experimental", List.of(entity("efo-test"))));
+
+        mockMvc.perform(get("/api/v2/ontologies/by-tag"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.experimental[0].ontologyId").value("efo-test"));
+
+        verify(ontologyRepository).getGroupedByField("tags", "en", new JsonTransformOptionsMatcher(false, false));
+    }
+
+    @Test
+    void returnsOntologiesGroupedByDomainWithOptions() throws Exception {
+        when(ontologyRepository.getGroupedByField(any(), any(), any()))
+                .thenReturn(Map.of("biology", List.of(entity("efo-test"))));
+
+        mockMvc.perform(get("/api/v2/ontologies/by-domain")
+                        .param("lang", "fr")
+                        .param("resolveReferences", "true")
+                        .param("manchesterSyntax", "true"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.biology[0].ontologyId").value("efo-test"));
+
+        verify(ontologyRepository).getGroupedByField("domain", "fr", new JsonTransformOptionsMatcher(true, true));
+    }
+
+    @Test
+    void returnsOntologyById() throws Exception {
+        when(ontologyRepository.getById(any(), any(), any())).thenReturn(entity("efo-test"));
+
+        mockMvc.perform(get("/api/v2/ontologies/efo-test").param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ontologyId").value("efo-test"));
+
+        verify(ontologyRepository).getById("efo-test", "fr", new JsonTransformOptionsMatcher(false, false));
+    }
+
+    @Test
+    void returnsStableNotFoundContract() throws Exception {
+        when(ontologyRepository.getById(any(), any(), any())).thenReturn(null);
+
+        mockMvc.perform(get("/api/v2/ontologies/missing"))
+                .andExpect(status().isNotFound())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(404))
+                .andExpect(jsonPath("$.message").value("The requested resource was not found."));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethod() throws Exception {
+        mockMvc.perform(post("/api/v2/ontologies"))
+                .andExpect(status().isMethodNotAllowed());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "exactMatch, not-a-boolean",
+            "includeObsoleteEntities, not-a-boolean"
+    })
+    void rejectsMalformedTypedParameters(String parameter, String value) throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param(parameter, value))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    private ListCall captureListCall() throws Exception {
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        ArgumentCaptor<String> lang = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> search = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> searchFields = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> boostFields = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> exactMatch = ArgumentCaptor.forClass(Boolean.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Map<String, Collection<String>>> properties =
+                ArgumentCaptor.forClass((Class<Map<String, Collection<String>>>) (Class<?>) Map.class);
+        ArgumentCaptor<JsonTransformOptions> outputOptions = ArgumentCaptor.forClass(JsonTransformOptions.class);
+
+        verify(ontologyRepository).find(
+                pageable.capture(),
+                lang.capture(),
+                search.capture(),
+                searchFields.capture(),
+                boostFields.capture(),
+                exactMatch.capture(),
+                properties.capture(),
+                outputOptions.capture());
+
+        return new ListCall(
+                pageable.getValue(),
+                lang.getValue(),
+                search.getValue(),
+                searchFields.getValue(),
+                boostFields.getValue(),
+                exactMatch.getValue(),
+                properties.getValue(),
+                outputOptions.getValue());
+    }
+
+    private static OlsFacetedResultsPage<com.google.gson.JsonElement> ontologyPage() {
+        return new OlsFacetedResultsPage<>(
+                List.of(JsonParser.parseString("""
+                        {"ontologyId":"efo-test","title":"Experimental Factor Ontology"}
+                        """)),
+                Map.of("domain", Map.of("biology", 1L)),
+                PageRequest.of(0, 20),
+                1);
+    }
+
+    private static V2Entity entity(String ontologyId) {
+        return new V2Entity(JsonParser.parseString("{\"ontologyId\":\"" + ontologyId + "\"}"));
+    }
+
+    private record ListCall(
+            Pageable pageable,
+            String lang,
+            String search,
+            String searchFields,
+            String boostFields,
+            boolean exactMatch,
+            Map<String, Collection<String>> properties,
+            JsonTransformOptions outputOptions) {
+    }
+
+    private static class JsonTransformOptionsMatcher extends JsonTransformOptions {
+        private final boolean expectedResolveReferences;
+        private final boolean expectedManchesterSyntax;
+
+        private JsonTransformOptionsMatcher(boolean resolveReferences, boolean manchesterSyntax) {
+            this.expectedResolveReferences = resolveReferences;
+            this.expectedManchesterSyntax = manchesterSyntax;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other instanceof JsonTransformOptions options
+                    && options.resolveReferences == expectedResolveReferences
+                    && options.manchesterSyntax == expectedManchesterSyntax;
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerWIT.java
@@ -147,11 +147,27 @@ class V2OntologyControllerWIT {
     }
 
     @Test
+    void bindsExplicitFalseExactMatch() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("exactMatch", "false"))
+                .andExpect(status().isOk());
+
+        assertFalse(captureListCall().exactMatch());
+    }
+
+    @Test
     void includesObsoleteOntologiesWhenRequested() throws Exception {
         mockMvc.perform(get("/api/v2/ontologies").param("includeObsoleteEntities", "true"))
                 .andExpect(status().isOk());
 
         assertFalse(captureListCall().properties().containsKey("isObsolete"));
+    }
+
+    @Test
+    void excludesObsoleteOntologiesWhenExplicitlyRequested() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("includeObsoleteEntities", "false"))
+                .andExpect(status().isOk());
+
+        assertEquals(List.of("false"), captureListCall().properties().get("isObsolete"));
     }
 
     @Test
@@ -180,6 +196,14 @@ class V2OntologyControllerWIT {
                 .andExpect(status().isOk());
 
         assertEquals(List.of("biology", "health"), captureListCall().properties().get("domain"));
+    }
+
+    @Test
+    void forwardsCommaSeparatedDynamicPropertyValues() throws Exception {
+        mockMvc.perform(get("/api/v2/ontologies").param("domain", "biology,health"))
+                .andExpect(status().isOk());
+
+        assertEquals(List.of("biology,health"), captureListCall().properties().get("domain"));
     }
 
     @Test
@@ -293,11 +317,14 @@ class V2OntologyControllerWIT {
     void returnsOntologyById() throws Exception {
         when(ontologyRepository.getById(any(), any(), any())).thenReturn(entity("efo-test"));
 
-        mockMvc.perform(get("/api/v2/ontologies/efo-test").param("lang", "fr"))
+        mockMvc.perform(get("/api/v2/ontologies/efo-test")
+                        .param("lang", "fr")
+                        .param("resolveReferences", "true")
+                        .param("manchesterSyntax", "true"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.ontologyId").value("efo-test"));
 
-        verify(ontologyRepository).getById("efo-test", "fr", new JsonTransformOptionsMatcher(false, false));
+        verify(ontologyRepository).getById("efo-test", "fr", new JsonTransformOptionsMatcher(true, true));
     }
 
     @Test
@@ -314,7 +341,10 @@ class V2OntologyControllerWIT {
     @Test
     void rejectsUnsupportedHttpMethod() throws Exception {
         mockMvc.perform(post("/api/v2/ontologies"))
-                .andExpect(status().isMethodNotAllowed());
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
     }
 
     @ParameterizedTest
@@ -326,7 +356,35 @@ class V2OntologyControllerWIT {
         mockMvc.perform(get("/api/v2/ontologies").param(parameter, value))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.status").value(400));
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "/api/v2/ontologies/by-tag, resolveReferences",
+            "/api/v2/ontologies/by-domain, manchesterSyntax",
+            "/api/v2/ontologies/efo-test, resolveReferences"
+    })
+    void rejectsMalformedTransformOptions(String path, String parameter) throws Exception {
+        mockMvc.perform(get(path).param(parameter, "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void rejectsUnsupportedSortFieldWithStableErrorContract() throws Exception {
+        when(ontologyRepository.find(
+                any(), any(), any(), any(), any(), anyBoolean(), anyMap(), any()))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: notARealField"));
+
+        mockMvc.perform(get("/api/v2/ontologies").param("sort", "notARealField,asc"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: notARealField"));
     }
 
     private ListCall captureListCall() throws Exception {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/OntologyRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/OntologyRepositoryIT.java
@@ -1,0 +1,254 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class OntologyRepositoryIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.RepositoryHandle repositoryHandle;
+    private static OntologyRepository repository;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createRepository(POSTGRES);
+        repository = repositoryHandle.repository();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsActiveOntologiesInDeterministicOrder() throws Exception {
+        OlsFacetedResultsPage<JsonElement> page = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("isObsolete", List.of("false")));
+
+        assertThat(ontologyIds(page)).containsExactly("duo", "efo", "efo-atlas");
+        assertThat(page.getTotalElements()).isEqualTo(3);
+    }
+
+    @Test
+    void canIncludeObsoleteOntologies() throws Exception {
+        OlsFacetedResultsPage<JsonElement> page = find(
+                PageRequest.of(0, 20), null, null, false, Map.of());
+
+        assertThat(ontologyIds(page))
+                .containsExactly("duo", "efo", "efo-atlas", "legacy-efo");
+    }
+
+    @Test
+    void paginatesWithStableTotals() throws Exception {
+        OlsFacetedResultsPage<JsonElement> page = find(
+                PageRequest.of(1, 2),
+                null,
+                null,
+                false,
+                Map.of("isObsolete", List.of("false")));
+
+        assertThat(ontologyIds(page)).containsExactly("efo-atlas");
+        assertThat(page.getTotalElements()).isEqualTo(3);
+        assertThat(page.getTotalPages()).isEqualTo(2);
+    }
+
+    @Test
+    void appliesSupportedSortAndRejectsUnknownSortFields() throws Exception {
+        OlsFacetedResultsPage<JsonElement> descending = find(
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "ontologyId")),
+                null,
+                null,
+                false,
+                Map.of());
+
+        assertThat(ontologyIds(descending))
+                .containsExactly("legacy-efo", "efo-atlas", "efo", "duo");
+        assertThatThrownBy(() -> find(
+                PageRequest.of(0, 20, Sort.by("notARealField")),
+                null,
+                null,
+                false,
+                Map.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported sort field");
+    }
+
+    @Test
+    void supportsFreeTextAndFieldRestrictedExactSearch() throws Exception {
+        OlsFacetedResultsPage<JsonElement> freeText = find(
+                PageRequest.of(0, 20),
+                "permissions",
+                null,
+                false,
+                Map.of("isObsolete", List.of("false")));
+        OlsFacetedResultsPage<JsonElement> exactLabel = find(
+                PageRequest.of(0, 20),
+                "Experimental Factor Ontology",
+                "label",
+                true,
+                Map.of("isObsolete", List.of("false")));
+        OlsFacetedResultsPage<JsonElement> restrictedMiss = find(
+                PageRequest.of(0, 20),
+                "permissions",
+                "label",
+                false,
+                Map.of("isObsolete", List.of("false")));
+
+        assertThat(ontologyIds(freeText)).containsExactly("duo");
+        assertThat(ontologyIds(exactLabel)).containsExactly("efo");
+        assertThat(restrictedMiss).isEmpty();
+    }
+
+    @Test
+    void appliesExplicitBoostFieldsToRanking() throws Exception {
+        OlsFacetedResultsPage<JsonElement> baseline = repository.find(
+                PageRequest.of(0, 20),
+                "en",
+                "experimental",
+                null,
+                null,
+                false,
+                Map.of("isObsolete", List.of("false")),
+                new JsonTransformOptions());
+        OlsFacetedResultsPage<JsonElement> boosted = repository.find(
+                PageRequest.of(0, 20),
+                "en",
+                "experimental",
+                null,
+                "definition^1000",
+                false,
+                Map.of("isObsolete", List.of("false")),
+                new JsonTransformOptions());
+
+        assertThat(ontologyIds(baseline).get(0)).isNotEqualTo("duo");
+        assertThat(ontologyIds(boosted).get(0)).isEqualTo("duo");
+    }
+
+    @Test
+    void filtersKnownAndUriNamedDynamicProperties() throws Exception {
+        OlsFacetedResultsPage<JsonElement> byDomain = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("domain", List.of("information")));
+        OlsFacetedResultsPage<JsonElement> byUri = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("http://example.org/category", List.of("derived")));
+        OlsFacetedResultsPage<JsonElement> unknown = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("unknown-property", List.of("anything")));
+
+        assertThat(ontologyIds(byDomain)).containsExactly("duo");
+        assertThat(ontologyIds(byUri)).containsExactly("efo-atlas");
+        assertThat(unknown).isEmpty();
+    }
+
+    @Test
+    void treatsRepeatedAndCommaSeparatedDynamicValuesAsAlternatives() throws Exception {
+        OlsFacetedResultsPage<JsonElement> repeated = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("domain", List.of("biology", "information")));
+        OlsFacetedResultsPage<JsonElement> commaSeparated = find(
+                PageRequest.of(0, 20),
+                null,
+                null,
+                false,
+                Map.of("domain", List.of("biology,information")));
+
+        assertThat(ontologyIds(repeated))
+                .containsExactly("duo", "efo", "efo-atlas", "legacy-efo");
+        assertThat(ontologyIds(commaSeparated))
+                .containsExactly("duo", "efo", "efo-atlas", "legacy-efo");
+    }
+
+    @Test
+    void groupsOntologiesByTagsAndDomains() throws Exception {
+        Map<String, List<uk.ac.ebi.spot.ols.model.v2.V2Entity>> byTag =
+                repository.getGroupedByField("tags", "en", new JsonTransformOptions());
+        Map<String, List<uk.ac.ebi.spot.ols.model.v2.V2Entity>> byDomain =
+                repository.getGroupedByField("domain", "en", new JsonTransformOptions());
+
+        assertThat(byTag.keySet()).contains("biomedical", "experimental", "clinical", "atlas");
+        assertThat(byTag.get("biomedical"))
+                .extracting(entity -> entity.any().get("ontologyId"))
+                .containsExactlyInAnyOrder("duo", "efo");
+        assertThat(byDomain.keySet()).contains("biology", "information");
+    }
+
+    @Test
+    void getsExistingOntologyAndReturnsNullForMissingOntology() {
+        var existing = repository.getById("efo", "en", new JsonTransformOptions());
+        var missing = repository.getById("missing", "en", new JsonTransformOptions());
+
+        assertThat(existing.any().get("title"))
+                .isEqualTo("Experimental Factor Ontology");
+        assertThat(missing).isNull();
+    }
+
+    @Test
+    void validatesLanguageAndOntologyIdentifiers() {
+        assertThatThrownBy(() -> repository.getById("efo", "en_US", new JsonTransformOptions()))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repository.getById("efo/unsafe", "en", new JsonTransformOptions()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static OlsFacetedResultsPage<JsonElement> find(
+            PageRequest pageable,
+            String search,
+            String searchFields,
+            boolean exactMatch,
+            Map<String, Collection<String>> properties) throws Exception {
+        return repository.find(
+                pageable,
+                "en",
+                search,
+                searchFields,
+                null,
+                exactMatch,
+                properties,
+                new JsonTransformOptions());
+    }
+
+    private static List<String> ontologyIds(OlsFacetedResultsPage<JsonElement> page) {
+        return page.getContent().stream()
+                .map(element -> element.getAsJsonObject().get("ontologyId").getAsString())
+                .toList();
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -1,0 +1,180 @@
+package uk.ac.ebi.spot.ols.testsupport;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.service.PostgresClient;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.zip.GZIPOutputStream;
+
+public final class PostgresIntegrationTestSupport {
+
+    private static final String IMAGE = "pgvector/pgvector:0.8.0-pg17";
+    private static final List<String> FILTER_PROPERTIES = List.of(
+            "tags",
+            "domain",
+            "http://example.org/category");
+
+    private PostgresIntegrationTestSupport() {
+    }
+
+    public static PostgreSQLContainer<?> newContainer() {
+        return new PostgreSQLContainer<>(
+                DockerImageName.parse(IMAGE).asCompatibleSubstituteFor("postgres"))
+                .withDatabaseName("ols4_test")
+                .withUsername("ols")
+                .withPassword("ols-test");
+    }
+
+    public static void initializeDatabase(PostgreSQLContainer<?> container) {
+        try (Connection connection = container.createConnection("")) {
+            executeProductionSchema(connection);
+            loadFixture(connection);
+        } catch (IOException | InterruptedException | SQLException e) {
+            throw new IllegalStateException("Failed to initialize the disposable OLS PostgreSQL database", e);
+        }
+    }
+
+    public static RepositoryHandle createRepository(PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = new PostgresClient();
+        ReflectionTestUtils.setField(postgresClient, "host", container.getHost());
+        ReflectionTestUtils.setField(postgresClient, "port", container.getMappedPort(5432));
+        ReflectionTestUtils.setField(postgresClient, "database", container.getDatabaseName());
+        ReflectionTestUtils.setField(postgresClient, "user", container.getUsername());
+        ReflectionTestUtils.setField(postgresClient, "password", container.getPassword());
+        ReflectionTestUtils.setField(postgresClient, "schema", "public");
+        ReflectionTestUtils.setField(postgresClient, "maxPoolSize", 3);
+        ReflectionTestUtils.setField(postgresClient, "minIdle", 0);
+        postgresClient.init();
+
+        OlsSearchClient searchClient = new OlsSearchClient();
+        ReflectionTestUtils.setField(searchClient, "postgresClient", postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        OntologyRepository repository = new OntologyRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
+        return new RepositoryHandle(repository, postgresClient);
+    }
+
+    private static void executeProductionSchema(Connection connection)
+            throws IOException, InterruptedException, SQLException {
+        Path repositoryRoot = Path.of(System.getProperty("maven.multiModuleProjectDirectory", ".."));
+        Path schemaGenerator = repositoryRoot.resolve("dataload/create_postgres_schema.py").normalize();
+        if (!Files.isRegularFile(schemaGenerator)) {
+            throw new IllegalStateException("Production schema generator not found: " + schemaGenerator);
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder();
+        processBuilder.command().add("python3");
+        processBuilder.command().add(schemaGenerator.toString());
+        for (String property : FILTER_PROPERTIES) {
+            processBuilder.command().add("--filter-property");
+            processBuilder.command().add(property);
+        }
+        Process process = processBuilder.start();
+        String sql;
+        String error;
+        try (InputStream stdout = process.getInputStream(); InputStream stderr = process.getErrorStream()) {
+            sql = new String(stdout.readAllBytes(), StandardCharsets.UTF_8);
+            error = new String(stderr.readAllBytes(), StandardCharsets.UTF_8);
+        }
+        int exitCode = process.waitFor();
+        if (exitCode != 0) {
+            throw new IllegalStateException(
+                    "Production schema generator exited with " + exitCode + ": " + error);
+        }
+
+        try (Statement statement = connection.createStatement()) {
+            statement.execute(sql);
+        }
+    }
+
+    private static void loadFixture(Connection connection) throws IOException, SQLException {
+        JsonObject fixture;
+        try (InputStream stream = PostgresIntegrationTestSupport.class.getResourceAsStream(
+                "/fixtures/ontologies/ontology-fixture.json")) {
+            if (stream == null) {
+                throw new IllegalStateException("Ontology integration fixture is missing");
+            }
+            fixture = JsonParser.parseReader(
+                    new java.io.InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+        }
+
+        String sql = """
+                INSERT INTO ols_entities (
+                    id, type, iri, ontology_id, _json, is_obsolete, label, definition,
+                    search_type, is_defining_ontology, filter_tags, filter_domain,
+                    "filter_http://example.org/category")
+                VALUES (?, 'ontology', ?, ?, ?, ?, ?, ?, 'ontology', TRUE, ?, ?, ?)
+                """;
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            for (JsonElement element : fixture.getAsJsonArray("records")) {
+                JsonObject record = element.getAsJsonObject();
+                statement.setString(1, record.get("id").getAsString());
+                statement.setString(2, record.get("iri").getAsString());
+                statement.setString(3, record.get("ontologyId").getAsString());
+                statement.setBytes(4, gzip(record.getAsJsonObject("json").toString()));
+                statement.setBoolean(5, record.get("isObsolete").getAsBoolean());
+                statement.setArray(6, textArray(connection, record.getAsJsonArray("label")));
+                statement.setArray(7, textArray(connection, record.getAsJsonArray("definition")));
+                statement.setArray(8, textArray(connection, record.getAsJsonArray("tags")));
+                statement.setArray(9, textArray(connection, record.getAsJsonArray("domain")));
+                statement.setArray(10, textArray(
+                        connection,
+                        record.getAsJsonArray("http://example.org/category")));
+                statement.addBatch();
+            }
+            statement.executeBatch();
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("ANALYZE ols_entities");
+        }
+    }
+
+    private static java.sql.Array textArray(Connection connection, JsonArray values) throws SQLException {
+        String[] strings = new String[values.size()];
+        for (int i = 0; i < values.size(); i++) {
+            strings[i] = values.get(i).getAsString();
+        }
+        return connection.createArrayOf("text", strings);
+    }
+
+    private static byte[] gzip(String json) throws IOException {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(bytes)) {
+            gzip.write(json.getBytes(StandardCharsets.UTF_8));
+        }
+        return bytes.toByteArray();
+    }
+
+    public record RepositoryHandle(
+            OntologyRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+}

--- a/backend/src/test/resources/fixtures/ontologies/README.md
+++ b/backend/src/test/resources/fixtures/ontologies/README.md
@@ -1,0 +1,16 @@
+# Ontology integration fixture
+
+This four-record fixture is deliberately small and deterministic. It derives stable metadata from
+the repository's EFO, localized-label, DUO, and obsolete-entity test material, but it is not a
+production snapshot.
+
+- `efo` is the representative active EFO ontology.
+- `efo-atlas` is a deliberately synthetic EFO-derived record used for pagination and overlapping
+  filters.
+- `duo` provides distinct information-domain and data-use search terms.
+- `legacy-efo` is deliberately obsolete.
+
+The wrapper fields map directly to PostgreSQL search/filter columns. The nested `json` object is
+the compressed API document returned by the repository. To update the fixture, edit both views of
+a record together and run `mvn -pl backend verify`; schema creation continues to come from
+`dataload/create_postgres_schema.py`.

--- a/backend/src/test/resources/fixtures/ontologies/ontology-fixture.json
+++ b/backend/src/test/resources/fixtures/ontologies/ontology-fixture.json
@@ -1,0 +1,88 @@
+{
+  "records": [
+    {
+      "id": "ontology:efo",
+      "ontologyId": "efo",
+      "iri": "http://www.ebi.ac.uk/efo",
+      "isObsolete": false,
+      "label": ["Experimental Factor Ontology"],
+      "definition": ["An ontology for variables in biomedical studies."],
+      "tags": ["biomedical", "experimental"],
+      "domain": ["biology"],
+      "http://example.org/category": ["curated"],
+      "json": {
+        "type": ["ontology"],
+        "ontologyId": "efo",
+        "iri": "http://www.ebi.ac.uk/efo",
+        "title": "Experimental Factor Ontology",
+        "description": "An ontology for variables in biomedical studies.",
+        "isObsolete": false,
+        "tags": ["biomedical", "experimental"],
+        "domain": ["biology"]
+      }
+    },
+    {
+      "id": "ontology:efo-atlas",
+      "ontologyId": "efo-atlas",
+      "iri": "http://www.ebi.ac.uk/efo/atlas-fixture",
+      "isObsolete": false,
+      "label": ["Atlas Experimental Vocabulary"],
+      "definition": ["An EFO-derived fixture for tissue atlas studies."],
+      "tags": ["atlas", "experimental"],
+      "domain": ["biology"],
+      "http://example.org/category": ["derived"],
+      "json": {
+        "type": ["ontology"],
+        "ontologyId": "efo-atlas",
+        "iri": "http://www.ebi.ac.uk/efo/atlas-fixture",
+        "title": "Atlas Experimental Vocabulary",
+        "description": "An EFO-derived fixture for tissue atlas studies.",
+        "isObsolete": false,
+        "tags": ["atlas", "experimental"],
+        "domain": ["biology"]
+      }
+    },
+    {
+      "id": "ontology:duo",
+      "ontologyId": "duo",
+      "iri": "http://purl.obolibrary.org/obo/duo.owl",
+      "isObsolete": false,
+      "label": ["Data Use Ontology"],
+      "definition": ["An ontology for experimental data use permissions and conditions."],
+      "tags": ["biomedical", "clinical"],
+      "domain": ["information"],
+      "http://example.org/category": ["curated"],
+      "json": {
+        "type": ["ontology"],
+        "ontologyId": "duo",
+        "iri": "http://purl.obolibrary.org/obo/duo.owl",
+        "title": "Data Use Ontology",
+        "description": "An ontology for experimental data use permissions and conditions.",
+        "isObsolete": false,
+        "tags": ["biomedical", "clinical"],
+        "domain": ["information"]
+      }
+    },
+    {
+      "id": "ontology:legacy-efo",
+      "ontologyId": "legacy-efo",
+      "iri": "http://www.ebi.ac.uk/efo/legacy-fixture",
+      "isObsolete": true,
+      "label": ["Legacy Experimental Ontology"],
+      "definition": ["An obsolete fixture retained to test compatibility filters."],
+      "tags": ["experimental"],
+      "domain": ["biology"],
+      "http://example.org/category": ["archived"],
+      "json": {
+        "type": ["ontology"],
+        "ontologyId": "legacy-efo",
+        "iri": "http://www.ebi.ac.uk/efo/legacy-fixture",
+        "title": "Legacy Experimental Ontology",
+        "description": "An obsolete fixture retained to test compatibility filters.",
+        "isObsolete": true,
+        "tags": ["experimental"],
+        "domain": ["biology"]
+      }
+    }
+  ]
+}

--- a/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/backend/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-subclass

--- a/docs/adr/0001-adopt-layered-backend-testing.md
+++ b/docs/adr/0001-adopt-layered-backend-testing.md
@@ -1,0 +1,23 @@
+---
+status: accepted
+date: 2026-08-24
+---
+
+# Adopt layered backend testing with disposable PostgreSQL
+
+OLS4 backend controller coverage will combine direct unit tests (`*Test`), Spring MVC Web Integration Tests (`*WIT`), repository and thin controller Integration Tests (`*IT`) against disposable pgvector PostgreSQL, and the existing `test_api.sh` system regression suite. CI will not connect to an internal or production database: database tests generate their schema through the production schema generator and load a small committed fixture, trading some Docker runtime and fixture maintenance for deterministic, isolated tests that exercise the real PostgreSQL query path.
+
+## Considered options
+
+- **Internal or production database:** rejected because CI access would require sensitive credentials and network connectivity, and changing production data would make results non-deterministic.
+- **Mocks only:** rejected because mocks cannot validate PostgreSQL search, filtering, sorting, faceting, or ranking semantics.
+- **System regression only:** rejected because the complete dataload and API comparison is too slow and broad to provide focused controller feedback.
+
+## Consequences
+
+- Every controller should receive parameter and stable HTTP-contract coverage without requiring every possible parameter combination.
+- PostgreSQL-specific behavior is tested with a small disposable database; full ontology loading remains the responsibility of the system regression suite.
+- V1 and V2 remain equally important, while V1 tests must preserve backward-compatible behavior.
+- JaCoCo initially records a baseline without enforcing a repository-wide threshold.
+
+See [OLS4 Backend Testing Strategy](../backend-testing-strategy.md) for the detailed testing vocabulary, responsibilities, fixture policy, Maven lifecycle, and rollout plan.

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -6,6 +6,8 @@
 
 **Initial pilot:** `V2OntologyController`
 
+**Decision record:** [ADR 0001 — Adopt layered backend testing with disposable PostgreSQL](adr/0001-adopt-layered-backend-testing.md)
+
 ## Purpose
 
 OLS4 currently has only a small number of backend tests. This strategy establishes a repeatable way to protect the HTTP contracts of both API versions, support safe refactoring, and exercise PostgreSQL behaviour without connecting CI to an internal or production database.

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -1,0 +1,271 @@
+# OLS4 Backend Testing Strategy
+
+**Status:** Approved baseline
+
+**Date:** 2026-08-24
+
+**Initial pilot:** `V2OntologyController`
+
+## Purpose
+
+OLS4 currently has only a small number of backend tests. This strategy establishes a repeatable way to protect the HTTP contracts of both API versions, support safe refactoring, and exercise PostgreSQL behaviour without connecting CI to an internal or production database.
+
+V1 and V2 are equally important:
+
+- V1 remains heavily used and must not receive breaking changes.
+- V2 is the encouraged API and can evolve, but intentional contract changes must still be explicit and tested.
+
+Coverage is a diagnostic. The primary measure of success is meaningful protection of routes, parameters, stable response fields, errors, and database behaviour.
+
+## Testing vocabulary
+
+| Name | Naming convention | Purpose |
+|---|---|---|
+| Unit test | `*Test` | Exercise one class directly with mocked collaborators. |
+| Web Integration Test | `*WIT` | Exercise real Spring MVC routing, binding, defaults, exception handling, and serialization with backend collaborators mocked. |
+| Integration Test | `*IT` | Exercise real repository/search behaviour against disposable PostgreSQL. |
+| Full-stack controller integration | Controller `*IT` | Exercise a small number of real controller-to-database paths against disposable PostgreSQL. |
+| System regression | Existing `test_api.sh` suite | Exercise the complete dataload and deployed API comparison against committed expected output. |
+
+These layers complement rather than replace one another.
+
+## Test responsibilities
+
+### Unit tests
+
+Controller unit tests cover decisions owned by the controller, including:
+
+- Filters added or removed by controller logic.
+- Dynamic-property filtering before repository delegation.
+- Exact collaborator arguments.
+- Response wrapping and status selection.
+- Found and missing-resource branches.
+- Selection of grouping fields such as `tags` and `domain`.
+
+Unit tests do not try to reproduce Spring request binding or database behaviour.
+
+### Web Integration Tests
+
+WITs use the real Spring MVC layer and real controller while replacing repositories and other backend collaborators with mocks. They protect:
+
+- Routes and HTTP methods.
+- Query and path parameter binding.
+- Optional-parameter defaults.
+- Repeated and encoded query parameters.
+- Pagination binding.
+- Response status, media type, and JSON serialization.
+- Global exception handling and stable error fields.
+- The stable portion of each endpoint's JSON contract.
+
+A WIT produces the actual controller HTTP response. The repository mock supplies deterministic input data; it does not replace the controller, Spring MVC, or serialization.
+
+### Repository Integration Tests
+
+Repository ITs use the real `OntologyRepository`, `OlsSearchClient`, PostgreSQL driver, jOOQ query construction, and a disposable pgvector PostgreSQL database. They protect:
+
+- Full-text and exact search behaviour.
+- `searchFields` and `boostFields` behaviour.
+- Dynamic filters, including repeated and comma-separated values.
+- Obsolete-record filtering.
+- Pagination, deterministic ordering, and supported sorting.
+- Tag and domain faceting/grouping.
+- Language and identifier validation owned below the controller.
+- Found and missing records.
+
+### Full-stack controller Integration Tests
+
+Controller ITs use the real Spring application path and real disposable database. They provide a thin wiring proof for each controller route. Exhaustive parameter coverage remains in WITs, and exhaustive database semantics remain in repository ITs.
+
+For the `V2OntologyController` pilot, the full-stack suite contains one representative happy path for each of its four routes.
+
+### System regression tests
+
+The existing `test_api.sh` suite continues to own full OWL-to-dataload-to-database-to-API regression coverage. The new Maven suites must not rerun the complete dataload for every controller test.
+
+## Parameter testing standard
+
+Every declared or intentionally supported parameter must have direct test evidence. This does not require testing every possible combination.
+
+For a controller, the matrix includes:
+
+1. One request proving defaults when optional parameters are omitted.
+2. One focused valid-value test for every declared parameter.
+3. Parameterized malformed-value tests for typed parameters.
+4. Boundary tests for pagination and other bounded values.
+5. Single, repeated, and comma-separated dynamic-property values where supported.
+6. URI-based and encoded dynamic-property names where supported.
+7. Proof that reserved parameters do not leak into dynamic filters.
+8. A small number of meaningful interactions, such as `search + searchFields + exactMatch`.
+9. Route-specific required path parameters, missing resources, and invalid identifiers.
+
+For `V2OntologyController`, this includes:
+
+- `page`
+- `size`
+- `sort`
+- `search`
+- `searchFields`
+- `boostFields`
+- `exactMatch`
+- `includeObsoleteEntities`
+- dynamic search properties
+- `lang`
+- `resolveReferences`
+- `manchesterSyntax`
+- the required `onto` path segment
+
+`resolveReferences` and `manchesterSyntax` receive WIT binding and forwarding coverage in this pilot. Their transformation semantics belong to focused transformer/repository tests and are not duplicated in full-stack controller tests.
+
+Malformed typed parameters should return HTTP 400 with stable error fields. Unsupported behaviour must be rejected or removed from the published contract rather than silently producing misleading results.
+
+## Assertion policy
+
+Tests assert stable contract fields, not complete JSON snapshots.
+
+Representative stable fields include:
+
+- HTTP status and content type.
+- `page`, `numElements`, `totalPages`, and `totalElements`.
+- Selected `ontologyId`, `title`, and grouping keys.
+- Selected facet counts.
+- Error `status` and `message`.
+
+Full JSON comparison remains the responsibility of the existing system regression suite. Time-varying fields, implementation-only metadata, and unrelated linked content should not make focused controller tests brittle.
+
+## Disposable database strategy
+
+PR CI must never connect to an internal or production database. Even read-only production-backed tests would be non-deterministic, require sensitive network access and credentials, and risk coupling merge availability to production state.
+
+Repository and controller ITs use Testcontainers with the same database image used by OLS4:
+
+```text
+pgvector/pgvector:0.8.0-pg17
+```
+
+The database lifecycle is:
+
+1. Start a disposable pgvector PostgreSQL container.
+2. Generate the schema through the production `dataload/create_postgres_schema.py` path.
+3. Load a small committed, readable fixture.
+4. Run integration tests.
+5. Destroy the container.
+
+The test suite must not maintain an independent handwritten schema. Dynamic filter columns required by the fixture, including `tags` and `domain`, must be declared through the production schema generator.
+
+## Fixture policy
+
+The controller pilot uses four ontology records:
+
+1. An active EFO-derived ontology.
+2. A second active EFO-derived ontology for pagination, sorting, searching, and overlapping groups.
+3. An active DUO-derived ontology with a different domain.
+4. An obsolete ontology.
+
+Together they provide:
+
+- More than one page at a deliberately small page size.
+- Deterministic ordering and sorting.
+- Search terms distributed across different fields.
+- Overlapping and distinct tags.
+- More than one domain.
+- Active and obsolete records.
+- Known and missing ontology identifiers.
+
+Existing sources should be reused where practical:
+
+- `testcases/hierarchical-properties/efo.*`
+- `testcases/iri-labels/efo-iri-labels.*`
+- `testcases/localized-labels/label.*`
+- `testcases/duo.*`
+- `testcases/defined-fields/IsObsoleteSimple.*`
+- selected stable values from `testcases_expected_output_api/v2/ontologies.json`
+
+The backend fixture lives under backend test resources rather than adding a new generic JSON config under `testcases/`, because `test_api.sh` automatically loads every testcase JSON configuration.
+
+Existing `.pgbin` outputs can be used as reference material. The fast integration suite should not blindly combine independently generated `.pgbin` files whose dynamic column layouts may differ.
+
+Fixture changes must be intentional, reviewable, and documented. Production snapshots are not test fixtures.
+
+## Maven lifecycle and local development
+
+Maven test discovery is explicit:
+
+- Surefire runs standard `*Test` classes.
+- Surefire is additionally configured to run `*WIT` classes.
+- Failsafe runs `*IT` classes during `integration-test` and `verify`.
+
+Expected developer commands:
+
+```bash
+# Unit tests and Web Integration Tests; Docker is not required.
+mvn -B -ntp -pl backend -am test
+
+# Complete backend suite, including disposable-database Integration Tests.
+mvn -B -ntp -pl backend -am verify
+```
+
+Java 17 is required. Invoking the integration suite without an available Docker runtime must fail clearly rather than silently skipping database tests.
+
+## Continuous integration
+
+GitHub Actions adds two required backend gates before the existing expensive dataload/API job:
+
+```text
+Unit + WIT ─────────┐
+                    ├─→ existing Docker/dataload/API regression
+Database IT ────────┘
+```
+
+The gates should run in parallel where possible. Maven dependency caching should be enabled. The existing backend Docker build may continue packaging with tests skipped because dedicated CI jobs have already executed them.
+
+JaCoCo initially publishes coverage without a repository-wide failure threshold. After the pilot and at least one corresponding V1 controller, the team should use the measured baseline to choose meaningful thresholds.
+
+## Defect workflow
+
+The testing pilot must not silently codify behaviour that contradicts the intended contract.
+
+When a test exposes a current defect:
+
+1. Confirm the intended contract from documentation, known clients, existing production behaviour, and team decisions.
+2. Create a separate branch and PR from current `dev`.
+3. Put the smallest regression test and production fix in that bug-fix PR.
+4. Keep unrelated production refactoring out of the testing-framework PR.
+5. Merge the bug fix, then rebase the broader testing PR onto updated `dev`.
+
+Two likely pilot findings require explicit validation:
+
+- Spring `Pageable` exposes `sort`, but current repository ordering does not appear to consume it and the query parameter may leak into dynamic filters.
+- Some malformed Spring-bound parameters may currently be handled as HTTP 500 instead of HTTP 400.
+
+## Controller definition of done
+
+A controller is covered when:
+
+- Its direct unit-test class covers controller-owned decisions.
+- Its WIT covers every route and every supported parameter.
+- Stable success and error contract fields are asserted.
+- Applicable repository behaviour has PostgreSQL IT coverage.
+- A thin full-stack controller IT covers each route's representative happy path.
+- Discovered defects have regression tests in separate bug-fix PRs.
+- All tests run automatically in their CI gates.
+- JaCoCo reports the resulting coverage.
+
+## Rollout
+
+1. Complete the `V2OntologyController` pilot.
+2. Review usefulness, runtime, failure clarity, and fixture maintainability.
+3. Apply the approach to `V1OntologyController`.
+4. Continue by alternating corresponding V1 and V2 controller families, prioritized by traffic and contract risk.
+5. Establish coverage thresholds from the resulting representative baseline.
+
+Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
+
+## Out of scope for the pilot
+
+- Connecting GitHub-hosted CI to production or internal databases.
+- Running the complete dataload inside every Maven integration test.
+- Full-JSON snapshot assertions in unit, WIT, or repository IT suites.
+- Refactoring production controller or repository code solely to make the pilot aesthetically cleaner.
+- Testing every Cartesian combination of query parameters.
+- Introducing a repository-wide coverage threshold before a meaningful baseline exists.
+- Building production smoke monitoring.

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -74,7 +74,7 @@ Repository ITs use the real `OntologyRepository`, `OlsSearchClient`, PostgreSQL 
 
 ### Full-stack controller Integration Tests
 
-Controller ITs use the real Spring application path and real disposable database. They provide a thin wiring proof for each controller route. Exhaustive parameter coverage remains in WITs, and exhaustive database semantics remain in repository ITs.
+Controller ITs use the real Spring MVC controller path, real repository stack, and real disposable database. They provide a thin wiring proof for each controller route. Exhaustive parameter coverage remains in WITs, and exhaustive database semantics remain in repository ITs.
 
 For the `V2OntologyController` pilot, the full-stack suite contains one representative happy path for each of its four routes.
 
@@ -116,7 +116,7 @@ For `V2OntologyController`, this includes:
 
 `resolveReferences` and `manchesterSyntax` receive WIT binding and forwarding coverage in this pilot. Their transformation semantics belong to focused transformer/repository tests and are not duplicated in full-stack controller tests.
 
-Malformed typed parameters should return HTTP 400 with stable error fields. Unsupported behaviour must be rejected or removed from the published contract rather than silently producing misleading results.
+Malformed boolean and other controller-bound typed parameters return HTTP 400 with stable error fields. OLS4's existing pageable resolver deliberately treats non-numeric page/size values as omitted and clamps negative or oversized values; the WIT records that compatibility behaviour explicitly. Unsupported behaviour must be rejected or removed from the published contract rather than silently producing misleading results.
 
 ## Assertion policy
 
@@ -202,9 +202,14 @@ mvn -B -ntp -pl backend -am test
 
 # Complete backend suite, including disposable-database Integration Tests.
 mvn -B -ntp -pl backend -am verify
+
+# Database Integration Tests only; used by the dedicated CI gate.
+mvn -B -ntp -pl backend -am -Pintegration-tests-only verify
 ```
 
 Java 17 is required. Invoking the integration suite without an available Docker runtime must fail clearly rather than silently skipping database tests.
+
+On Rancher Desktop for macOS, local execution may also require `DOCKER_HOST` to point at `~/.rd/docker.sock`, `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock`, and `-Dapi.version=1.44`. GitHub-hosted Linux runners use their standard Docker socket and do not need those overrides.
 
 ## Continuous integration
 

--- a/docs/backend-testing-v2-ontology-controller-plan.md
+++ b/docs/backend-testing-v2-ontology-controller-plan.md
@@ -29,8 +29,8 @@ Paths may be adjusted slightly during implementation if existing package convent
 | Create | `backend/src/test/java/uk/ac/ebi/spot/ols/repository/OntologyRepositoryIT.java` | Real PostgreSQL repository/search tests. |
 | Create | `backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerIT.java` | Thin controller-to-database route tests. |
 | Create | `backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java` | Shared Testcontainers, schema, and fixture setup. |
-| Create | `backend/src/test/resources/fixtures/v2-ontology-controller/ontologies.json` | Readable four-ontology database fixture. |
-| Create | `backend/src/test/resources/fixtures/v2-ontology-controller/README.md` | Fixture provenance and regeneration notes. |
+| Create | `backend/src/test/resources/fixtures/ontologies/ontology-fixture.json` | Readable four-ontology database fixture. |
+| Create | `backend/src/test/resources/fixtures/ontologies/README.md` | Fixture provenance and regeneration notes. |
 | Modify | `.github/workflows/build-test.yml` | Add unit/WIT and database-IT gates before system regression. |
 | Maintain | `docs/backend-testing-strategy.md` | Record any implementation-driven clarification without weakening agreed contracts. |
 
@@ -146,7 +146,7 @@ Add boundary cases for:
 - [ ] Zero or negative size.
 - [ ] Size above the configured maximum.
 
-Each malformed input should produce HTTP 400 with stable `status` and `message` fields. If current behaviour differs, follow the defect workflow rather than weakening the assertion.
+Malformed booleans and rejected sort fields should produce HTTP 400 with stable `status` and `message` fields. The existing pageable resolver treats non-numeric page/size values as omitted and normalizes negative, zero, and oversized values; these cases are asserted as an intentional compatibility contract rather than changed globally.
 
 ## Task 6: Cover grouped and single-ontology routes in WIT
 
@@ -231,7 +231,7 @@ Assert query results and stable transformed fields; do not assert query implemen
 
 ## Task 10: Add thin `V2OntologyControllerIT`
 
-Start the Spring test application against the disposable database and issue real MVC requests.
+Exercise the real Spring MVC controller and repository path against the disposable database.
 
 - [ ] `GET /api/v2/ontologies` returns the expected default active records and page metadata.
 - [ ] `GET /api/v2/ontologies/by-tag` returns a representative stable grouping.
@@ -308,3 +308,14 @@ mvn -B -ntp -pl backend -am verify
 ## Next controller
 
 After reviewing the pilot, apply the same framework to `V1OntologyController`, then alternate corresponding V1 and V2 controller families based on traffic and contract risk.
+
+## Implemented pilot baseline
+
+Verified locally on 2026-08-24 with Java 17 and a Rancher Desktop Docker runtime:
+
+- Surefire: 58 unit and Web Integration Tests, including 33 `V2OntologyControllerWIT` cases; approximately 15.6 seconds for the reactor test command.
+- Failsafe: 15 PostgreSQL Integration Tests across `OntologyRepositoryIT` (11) and `V2OntologyControllerIT` (4); approximately 12.4 to 14.8 seconds after the container image was cached.
+- Complete `verify`: all 73 tests passed in approximately 20.5 seconds.
+- JaCoCo whole-backend baseline after complete `verify`: 15.3% line coverage and 15.7% branch coverage. No failure threshold is configured for the pilot.
+- Fast and database-only gates each passed twice, and `mvn test` did not start Docker-backed tests.
+- The full `test_api.sh` dataload/system regression was not run locally; the unchanged CI job remains responsible for it after the two new backend gates pass.

--- a/docs/backend-testing-v2-ontology-controller-plan.md
+++ b/docs/backend-testing-v2-ontology-controller-plan.md
@@ -1,0 +1,310 @@
+# V2OntologyController Testing Pilot — Implementation Plan
+
+**Date:** 2026-08-24
+
+**Strategy:** `docs/backend-testing-strategy.md`
+
+## Goal
+
+Implement the first complete controller testing pilot for `V2OntologyController`, establishing reusable unit, Web Integration Test, PostgreSQL Integration Test, full-stack controller Integration Test, Maven, fixture, coverage, and CI conventions for the rest of the OLS4 backend.
+
+## Constraints
+
+- Branch the testing work from current `dev`.
+- Do not connect tests to an internal or production database.
+- Do not perform unrelated production refactoring.
+- Preserve the existing `test_api.sh` system regression suite.
+- When a test exposes a defect, create a separate bug-fix PR from `dev` containing the minimal regression test and fix.
+- Use Java 17 for backend Maven work.
+
+## Intended file map
+
+Paths may be adjusted slightly during implementation if existing package conventions require it.
+
+| Action | Path | Responsibility |
+|---|---|---|
+| Modify | `backend/pom.xml` | Surefire, Failsafe, Testcontainers, and JaCoCo configuration. |
+| Create | `backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerTest.java` | Direct controller unit tests. |
+| Create | `backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerWIT.java` | Spring MVC contract and parameter tests. |
+| Create | `backend/src/test/java/uk/ac/ebi/spot/ols/repository/OntologyRepositoryIT.java` | Real PostgreSQL repository/search tests. |
+| Create | `backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2OntologyControllerIT.java` | Thin controller-to-database route tests. |
+| Create | `backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java` | Shared Testcontainers, schema, and fixture setup. |
+| Create | `backend/src/test/resources/fixtures/v2-ontology-controller/ontologies.json` | Readable four-ontology database fixture. |
+| Create | `backend/src/test/resources/fixtures/v2-ontology-controller/README.md` | Fixture provenance and regeneration notes. |
+| Modify | `.github/workflows/build-test.yml` | Add unit/WIT and database-IT gates before system regression. |
+| Maintain | `docs/backend-testing-strategy.md` | Record any implementation-driven clarification without weakening agreed contracts. |
+
+## Task 1: Establish a verified baseline
+
+- [ ] Record the current branch, `dev` merge-base, and working-tree state.
+- [ ] Preserve unrelated tracked and untracked work.
+- [ ] Run the existing backend tests with Java 17:
+
+```bash
+mvn -B -ntp -pl backend -am test
+```
+
+- [ ] Record current test count, duration, and failures.
+- [ ] Confirm Docker is available before starting Testcontainers work.
+- [ ] Confirm the current OpenAPI representation of `V2OntologyController`, especially the automatically exposed `sort` parameter.
+
+Expected baseline from the design investigation: 11 existing backend tests pass when Maven uses Java 17. Re-verify rather than treating that number as permanent.
+
+## Task 2: Configure the Maven test lifecycle
+
+Modify `backend/pom.xml`.
+
+- [ ] Add a Testcontainers version/BOM compatible with Java 17 and the current Spring Boot version.
+- [ ] Add the PostgreSQL Testcontainers module and required JUnit integration dependencies with test scope.
+- [ ] Configure Surefire so it retains its normal patterns and also includes `**/*WIT.java`.
+- [ ] Configure Failsafe so `**/*IT.java` runs in `integration-test`/`verify`.
+- [ ] Configure JaCoCo to generate reports without an initial coverage failure threshold.
+- [ ] Ensure `mvn test` does not start Docker-backed ITs.
+- [ ] Ensure `mvn verify` runs unit tests, WITs, and ITs.
+- [ ] Provide a Failsafe-only CI invocation/profile if needed to avoid rerunning unit/WIT tests in the separate database job.
+
+Verification:
+
+```bash
+mvn -B -ntp -pl backend -am test
+mvn -B -ntp -pl backend -am verify
+```
+
+Add a temporary discovery assertion or inspect Maven reports during implementation to prove `*WIT` and `*IT` are not silently skipped. Remove any temporary class before committing.
+
+## Task 3: Add direct controller unit tests
+
+Create `V2OntologyControllerTest` using JUnit 5 and Mockito without starting Spring.
+
+Cover controller-owned decisions:
+
+- [ ] `getOntologies` adds `isObsolete=false` when `includeObsoleteEntities` is false.
+- [ ] `getOntologies` does not add that filter when obsolete ontologies are included.
+- [ ] Reserved request parameters are removed before repository delegation.
+- [ ] Genuine dynamic properties and their multiple values are preserved.
+- [ ] Search, search fields, boost fields, exact-match flag, language, pageable, and transform options are delegated unchanged.
+- [ ] Repository page results are mapped into `V2PagedAndFacetedResponse` and `V2Entity` values.
+- [ ] `/by-tag` delegates using exactly the `tags` grouping field.
+- [ ] `/by-domain` delegates using exactly the `domain` grouping field.
+- [ ] `getOntology` returns the repository entity when found.
+- [ ] `getOntology` throws the custom `ResourceNotFoundException` when the repository returns null.
+
+Do not assert Spring defaults here; direct method invocation does not apply Spring binding defaults.
+
+## Task 4: Add the Web Integration Test harness
+
+Create `V2OntologyControllerWIT` as a focused Spring MVC slice around the real controller.
+
+- [ ] Load `V2OntologyController` and the real global exception advice.
+- [ ] Replace `OntologyRepository` with Spring's current test mock-bean mechanism.
+- [ ] Use deterministic `V2Entity` and `OlsFacetedResultsPage` builders/helpers.
+- [ ] Assert response status, content type, stable JSON fields, and repository arguments.
+- [ ] Avoid complete JSON snapshots.
+
+The baseline list response should assert stable fields such as:
+
+```text
+page
+numElements
+totalPages
+totalElements
+elements[*].ontologyId
+facetFieldsToCounts
+```
+
+## Task 5: Cover every list parameter in WIT
+
+For `GET /api/v2/ontologies`, add focused cases for:
+
+- [ ] All omitted parameters: `page=0`, `size=20`, `exactMatch=false`, `includeObsoleteEntities=false`, `lang=en`, and both transform flags false.
+- [ ] `page` and `size` supplied with valid values.
+- [ ] Supported `sort` field and direction.
+- [ ] `search`.
+- [ ] `searchFields`.
+- [ ] `boostFields`.
+- [ ] `exactMatch=true` and explicit `false`.
+- [ ] `includeObsoleteEntities=true` and explicit `false`.
+- [ ] Non-default `lang`.
+- [ ] `resolveReferences=true` binding and forwarding.
+- [ ] `manchesterSyntax=true` binding and forwarding.
+- [ ] A normal dynamic property.
+- [ ] Repeated dynamic-property values.
+- [ ] Comma-separated dynamic-property values where repository semantics support them.
+- [ ] URI-based/encoded dynamic-property keys.
+- [ ] Reserved parameters do not become dynamic filters.
+- [ ] A meaningful `search + searchFields + exactMatch` interaction.
+
+Add parameterized malformed cases for:
+
+- [ ] Non-numeric `page` and `size`.
+- [ ] Invalid boolean values.
+- [ ] Unsupported sort field or direction, according to the final sort contract.
+
+Add boundary cases for:
+
+- [ ] Negative page.
+- [ ] Zero or negative size.
+- [ ] Size above the configured maximum.
+
+Each malformed input should produce HTTP 400 with stable `status` and `message` fields. If current behaviour differs, follow the defect workflow rather than weakening the assertion.
+
+## Task 6: Cover grouped and single-ontology routes in WIT
+
+### `/by-tag`
+
+- [ ] Default language and transform options.
+- [ ] Explicit language and transform flags are bound and forwarded.
+- [ ] Stable group key and `ontologyId` fields are serialized.
+- [ ] Invalid typed parameters return HTTP 400.
+
+### `/by-domain`
+
+- [ ] Default language and transform options.
+- [ ] Explicit language and transform flags are bound and forwarded.
+- [ ] Stable group key and `ontologyId` fields are serialized.
+- [ ] Invalid typed parameters return HTTP 400.
+
+### `/{onto}`
+
+- [ ] Existing ontology returns HTTP 200 and stable fields.
+- [ ] Missing ontology returns HTTP 404 with stable error fields.
+- [ ] Invalid ontology identifier returns HTTP 400 once repository validation is exercised by the appropriate layer.
+- [ ] Default and explicit language values are forwarded.
+- [ ] Transform flags are bound and forwarded without duplicating transformer semantics.
+
+Also assert unsupported HTTP methods produce the intended method-not-allowed response if that behaviour is part of the published Spring contract.
+
+## Task 7: Build the disposable PostgreSQL test harness
+
+Create shared test support for repository and controller ITs.
+
+- [ ] Start `pgvector/pgvector:0.8.0-pg17` through Testcontainers.
+- [ ] Register the container's dynamic host, port, database, username, and password with the Spring test context.
+- [ ] Generate schema SQL through `dataload/create_postgres_schema.py` rather than maintaining a test-only schema.
+- [ ] Declare required dynamic filter columns, including `tags` and `domain`.
+- [ ] Execute the generated extensions, table, index, and post-load sections against the container.
+- [ ] Load the small fixture using the same compressed JSON representation expected by `OlsSearchClient`.
+- [ ] Keep data immutable during read-only repository tests, or reset it deterministically if a test mutates state.
+- [ ] Fail clearly when the IT lifecycle is invoked without Docker.
+
+The harness should not require a live production database, production credentials, a full Nextflow run, or a production snapshot.
+
+## Task 8: Create and document the fixture
+
+Create a readable four-record fixture under backend test resources.
+
+- [ ] Derive stable ontology metadata from existing EFO and DUO testcase material.
+- [ ] Include two active EFO-derived records, one active DUO-derived record, and one obsolete record.
+- [ ] Include overlapping and distinct tags.
+- [ ] Include at least two domains.
+- [ ] Distribute search terms across fields so `searchFields`, exact matching, and boosting can be distinguished.
+- [ ] Choose stable identifiers whose lexical order makes default ordering explicit.
+- [ ] Include enough records to produce multiple pages with a deliberately small test page size.
+- [ ] Document source files, deliberate deviations, and regeneration steps in the fixture README.
+- [ ] Do not add a generic JSON config under `testcases/`, where `test_api.sh` would automatically pick it up.
+
+Use selected existing expected API values as an oracle, not as a full snapshot assertion.
+
+## Task 9: Add `OntologyRepositoryIT`
+
+Exercise the real repository and PostgreSQL query path.
+
+- [ ] Default list query returns active ontology records in deterministic order.
+- [ ] Obsolete filtering excludes and includes the intended records.
+- [ ] Pagination returns correct page content and totals.
+- [ ] Supported sorting changes order correctly.
+- [ ] Free-text search returns the intended records.
+- [ ] Exact and non-exact search differ where expected.
+- [ ] `searchFields` restricts matching to the requested fields.
+- [ ] `boostFields` changes ranking in a deliberately distinguishable fixture case.
+- [ ] Known dynamic properties filter correctly.
+- [ ] Repeated and comma-separated filter values have the intended semantics.
+- [ ] Unknown dynamic properties return zero matches rather than unrelated data.
+- [ ] URI-named dynamic filters resolve to the correct generated column.
+- [ ] Tag grouping returns stable keys and memberships.
+- [ ] Domain grouping returns stable keys and memberships.
+- [ ] Existing ontology ID returns the correct entity.
+- [ ] Missing ontology ID returns no entity.
+- [ ] Invalid language and ontology identifiers raise the intended validation error.
+
+Assert query results and stable transformed fields; do not assert query implementation details unless needed for a regression.
+
+## Task 10: Add thin `V2OntologyControllerIT`
+
+Start the Spring test application against the disposable database and issue real MVC requests.
+
+- [ ] `GET /api/v2/ontologies` returns the expected default active records and page metadata.
+- [ ] `GET /api/v2/ontologies/by-tag` returns a representative stable grouping.
+- [ ] `GET /api/v2/ontologies/by-domain` returns a representative stable grouping.
+- [ ] `GET /api/v2/ontologies/{onto}` returns a representative stable ontology.
+
+Do not repeat the complete WIT parameter matrix. Do not add full-stack semantic assertions for `resolveReferences` or `manchesterSyntax` in this pilot.
+
+## Task 11: Resolve contract defects through separate PRs
+
+### Sort investigation
+
+- [ ] Demonstrate current behaviour with the smallest failing regression test.
+- [ ] Confirm supported fields and directions.
+- [ ] If broken, create a separate branch from `dev` and fix sorting without permitting unsafe arbitrary SQL fields.
+- [ ] Ensure `sort` is removed from dynamic-property handling.
+- [ ] Merge the fix and rebase the testing pilot.
+
+### Malformed-parameter investigation
+
+- [ ] Demonstrate whether Spring binding failures currently become HTTP 500.
+- [ ] If broken, create a separate branch from `dev`.
+- [ ] Map relevant binding/type mismatch exceptions to HTTP 400 with stable error fields.
+- [ ] Merge the fix and rebase the testing pilot.
+
+Do not combine these fixes merely because the testing pilot discovered both.
+
+## Task 12: Add CI gates
+
+Modify `.github/workflows/build-test.yml`.
+
+- [ ] Add a Java 17 unit/WIT job running the backend Maven test phase.
+- [ ] Add a Java 17 database-IT job with Docker/Testcontainers access.
+- [ ] Enable Maven dependency caching.
+- [ ] Keep the two backend jobs parallel where possible.
+- [ ] Make the existing `test-api` job depend on both backend jobs.
+- [ ] Upload Surefire, Failsafe, and JaCoCo reports on failure or as appropriate for the repository.
+- [ ] Retain the existing dataload, Docker Compose, and API regression behaviour.
+
+Do not rely on the backend Dockerfile's `mvn package -DskipTests` step as test execution.
+
+## Task 13: Verification and review
+
+- [ ] Run unit and WIT suites twice to detect order dependence.
+- [ ] Run the complete verify lifecycle twice with Docker.
+- [ ] Confirm all four test-class suffixes are discovered by their intended plugin.
+- [ ] Confirm ITs use the disposable container address, not environment-default PostgreSQL settings.
+- [ ] Confirm no production or internal credentials appear in code, fixtures, logs, or workflow files.
+- [ ] Confirm stable-field assertions do not snapshot volatile response content.
+- [ ] Review total runtime and identify avoidable repeated container/schema initialization.
+- [ ] Run the existing `test_api.sh` workflow or rely on the full CI job when local resources make it impractical, recording what was and was not run locally.
+- [ ] Run `graphify update .` after code changes and verify only intended graph updates are included.
+
+Primary verification commands:
+
+```bash
+mvn -B -ntp -pl backend -am test
+mvn -B -ntp -pl backend -am verify
+```
+
+## Pilot completion checklist
+
+- [ ] `V2OntologyControllerTest` covers controller-owned decisions.
+- [ ] `V2OntologyControllerWIT` covers all routes and supported parameters.
+- [ ] `OntologyRepositoryIT` covers real PostgreSQL semantics used by the controller.
+- [ ] `V2OntologyControllerIT` proves all four routes through the real database wiring.
+- [ ] Stable success and error fields are asserted.
+- [ ] Surefire, Failsafe, Testcontainers, and JaCoCo are configured and verified.
+- [ ] GitHub CI runs fast backend and database gates before system regression.
+- [ ] Any discovered defects were fixed through separate PRs from `dev`.
+- [ ] The complete suite is deterministic and independent of production data.
+- [ ] Runtime and coverage baseline are recorded for the V1 rollout decision.
+
+## Next controller
+
+After reviewing the pilot, apply the same framework to `V1OntologyController`, then alternate corresponding V1 and V2 controller families based on traffic and contract risk.


### PR DESCRIPTION
## Summary
- establish Unit, Web Integration Test, PostgreSQL Integration Test, and controller Integration Test conventions for V2OntologyController
- cover every supported controller parameter with stable-field assertions
- load a deterministic four-record ontology fixture through the production PostgreSQL schema generator
- configure Surefire, Failsafe, Testcontainers, JaCoCo, and two Java 17 CI gates ahead of the existing system regression job
- document the reusable backend testing strategy and measured pilot baseline

## Depends on
- #1359
- #1360
- #1361
- #1362
- #1363

This PR is intentionally draft until the independently reviewable defect fixes above land and this branch is rebased onto dev.

## Validation
- unit and WIT gate: 58 tests passed repeatedly without Docker
- PostgreSQL IT gate: 15 tests passed repeatedly against disposable pgvector PostgreSQL
- complete Maven verify: 73 tests passed
- workflow YAML parses successfully
- graphify knowledge graph refreshed

The existing full test_api.sh dataload/system regression was not run locally and remains the downstream CI gate.