### PR TITLE
Exclude facetFields from dynamic filters

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
@@ -17,6 +17,7 @@ public class DynamicQueryHelper {
             k = UriUtils.decode(k, "UTF-8");
 
             if(k.equals("lang") || k.equals("search") || k.equals("searchFields")
+                    || k.equals("facetFields")
                     || k.equals("boostFields") || k.equals("page") || k.equals("size") || k.equals("exactMatch")
                         || k.equals("includeObsoleteEntities")
                         || k.equals("excludeOntologyId")

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
@@ -21,4 +21,15 @@ class DynamicQueryHelperTest {
                 Map.of("ontologyId", List.of("efo")),
                 DynamicQueryHelper.filterProperties(properties));
     }
+
+    @Test
+    void excludesFacetFieldsFromDynamicFilters() {
+        Map<String, Collection<String>> properties = new LinkedHashMap<>();
+        properties.put("facetFields", List.of("ontologyId type"));
+        properties.put("ontologyId", List.of("efo"));
+
+        assertEquals(
+                Map.of("ontologyId", List.of("efo")),
+                DynamicQueryHelper.filterProperties(properties));
+    }
 }


### PR DESCRIPTION
## Summary
- treat the named facetFields query parameter as reserved
- keep it out of the dynamic-property map before repository delegation
- add a focused regression test

## Verification
- Java 17 targeted DynamicQueryHelperTest (red before fix, green after)
- Java 17 full backend unit/WIT suite: 80 tests passed

This is the minimal production fix discovered while preparing layered V2EntityController coverage. The repository already ignored facetFields later, but the controller helper leaked it across the dynamic-filter seam.