### PR TITLE
Exclude sort from dynamic filters

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelper.java
@@ -18,7 +18,8 @@ public class DynamicQueryHelper {
 
             if(k.equals("lang") || k.equals("search") || k.equals("searchFields")
                     || k.equals("facetFields")
-                    || k.equals("boostFields") || k.equals("page") || k.equals("size") || k.equals("exactMatch")
+                    || k.equals("boostFields") || k.equals("page") || k.equals("size") || k.equals("sort")
+                    || k.equals("exactMatch")
                         || k.equals("includeObsoleteEntities")
                         || k.equals("excludeOntologyId")
                         || k.equals("resolveReferences")

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/helpers/DynamicQueryHelperTest.java
@@ -32,4 +32,15 @@ class DynamicQueryHelperTest {
                 Map.of("ontologyId", List.of("efo")),
                 DynamicQueryHelper.filterProperties(properties));
     }
+
+    @Test
+    void excludesSortFromDynamicFilters() {
+        Map<String, Collection<String>> properties = new LinkedHashMap<>();
+        properties.put("sort", List.of("iri,desc"));
+        properties.put("ontologyId", List.of("efo"));
+
+        assertEquals(
+                Map.of("ontologyId", List.of("efo")),
+                DynamicQueryHelper.filterProperties(properties));
+    }
 }


### PR DESCRIPTION
## Summary
- treat Spring Pageable's sort query parameter as reserved
- prevent sorted V2 requests from also creating an unavailable dynamic filter
- add a focused regression test

## Verification
- Java 17 targeted DynamicQueryHelperTest (red before fix, green after)
- Java 17 full backend unit/WIT suite: 81 tests passed

This is the minimal production fix discovered by the V2EntityController WIT reserved-parameter matrix.