### PR TITLE
Add layered V1 property controller tests

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerIT.java
@@ -1,0 +1,150 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.MessageResolver;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.core.AnnotationLinkRelationProvider;
+import org.springframework.hateoas.server.core.DelegatingLinkRelationProvider;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1PropertyControllerIT {
+
+    private static final URI PROPERTY_URI = URI.create(
+            "/api/properties/http%253A%252F%252Fexample.org%252FEFO_0100");
+    private static final URI DEFINING_PROPERTY_URI = URI.create(
+            "/api/properties/findByIdAndIsDefiningOntology/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_0100");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1PropertyRepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializePropertyDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createV1PropertyRepository(POSTGRES);
+
+        V1PropertyController controller = new V1PropertyController();
+        ReflectionTestUtils.setField(
+                controller, "propertyRepository", repositoryHandle.repository());
+        controller.termAssembler = new V1PropertyAssembler();
+
+        HateoasPageableHandlerMethodArgumentResolver pageableResolver =
+                new HateoasPageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(1000);
+        PagedResourcesAssemblerArgumentResolver assemblerResolver =
+                new PagedResourcesAssemblerArgumentResolver(pageableResolver);
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(pageableResolver, assemblerResolver)
+                .setMessageConverters(halMessageConverter())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsPropertiesThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/properties"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(4))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/DUO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[1].label").value("has specimen"))
+                .andExpect(jsonPath("$._embedded.properties[1].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$._embedded.properties[1].is_obsolete").value(false))
+                .andExpect(jsonPath("$._embedded.properties[3].iri")
+                        .value("http://example.org/EFO_0199"))
+                .andExpect(jsonPath("$._embedded.properties[3].is_defining_ontology").value(false))
+                .andExpect(jsonPath("$._embedded.properties[3].is_obsolete").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedPropertyThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(PROPERTY_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[0].label").value("has specimen"))
+                .andExpect(jsonPath("$._embedded.properties[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$._embedded.properties[0].is_obsolete").value(false));
+    }
+
+    @Test
+    void listsOnlyDefiningOntologyPropertiesThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/DUO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$._embedded.properties[1].iri")
+                        .value("http://example.org/EFO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[1].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$._embedded.properties[2].iri")
+                        .value("http://example.org/EFO_0101"))
+                .andExpect(jsonPath("$._embedded.properties[2].is_defining_ontology").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedDefiningOntologyPropertyThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(DEFINING_PROPERTY_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$._embedded.properties[0].is_obsolete").value(false))
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+    }
+
+    private static MappingJackson2HttpMessageConverter halMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jackson2HalModule());
+        objectMapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(
+                new DelegatingLinkRelationProvider(
+                        new AnnotationLinkRelationProvider(),
+                        new EvoInflectorLinkRelationProvider()),
+                CurieProvider.NONE,
+                MessageResolver.DEFAULTS_ONLY));
+
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaTypes.HAL_JSON));
+        return converter;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerTest.java
@@ -1,0 +1,172 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Property;
+import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1PropertyControllerTest {
+
+    private V1PropertyController controller;
+    private V1PropertyRepository repository;
+    private V1PropertyAssembler propertyAssembler;
+    private PagedResourcesAssembler<V1Property> resourcesAssembler;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        repository = mock(V1PropertyRepository.class);
+        propertyAssembler = mock(V1PropertyAssembler.class);
+        resourcesAssembler = mock(PagedResourcesAssembler.class);
+        pageable = PageRequest.of(1, 7);
+        controller = new V1PropertyController();
+        ReflectionTestUtils.setField(controller, "propertyRepository", repository);
+        controller.termAssembler = propertyAssembler;
+    }
+
+    @Test
+    void listsAllPropertiesWhenNoIdentifierIsSupplied() {
+        PageImpl<V1Property> properties = page(property("http://example.org/EFO_0100"));
+        PagedModel<EntityModel<V1Property>> assembled = PagedModel.empty();
+        when(repository.findAll("fr", pageable)).thenReturn(properties);
+        when(resourcesAssembler.toModel(properties, propertyAssembler)).thenReturn(assembled);
+
+        var response = controller.getAllProperties(
+                null, null, null, "fr", pageable, resourcesAssembler);
+
+        assertEquals(HttpStatus.OK, ((ResponseEntity<?>) response).getStatusCode());
+        assertSame(assembled, response.getBody());
+        verify(repository).findAll("fr", pageable);
+        verify(resourcesAssembler).toModel(properties, propertyAssembler);
+    }
+
+    @Test
+    void selectsIriBeforeShortFormAndOboId() {
+        when(repository.findAllByIri("the-iri", "en", pageable))
+                .thenReturn(page(property("the-iri")));
+
+        controller.getAllProperties(
+                "the-iri", "EFO_0100", "EFO:0100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIri("the-iri", "en", pageable);
+        verify(repository, never()).findAllByShortForm("EFO_0100", "en", pageable);
+        verify(repository, never()).findAllByOboId("EFO:0100", "en", pageable);
+    }
+
+    @Test
+    void selectsShortFormThenOboIdWhenHigherPriorityIdentifiersAreAbsent() {
+        when(repository.findAllByShortForm("EFO_0100", "en", pageable))
+                .thenReturn(page(property("http://example.org/EFO_0100")));
+
+        controller.getAllProperties(
+                null, "EFO_0100", "EFO:0100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByShortForm("EFO_0100", "en", pageable);
+        verify(repository, never()).findAllByOboId("EFO:0100", "en", pageable);
+
+        when(repository.findAllByOboId("EFO:0101", "en", pageable))
+                .thenReturn(page(property("http://example.org/EFO_0101")));
+        controller.getAllProperties(
+                null, null, "EFO:0101",
+                "en", pageable, resourcesAssembler);
+        verify(repository).findAllByOboId("EFO:0101", "en", pageable);
+    }
+
+    @Test
+    void pathRouteDecodesTheIriBeforeUsingTheListDecision() {
+        when(repository.findAllByIri("http://example.org/EFO_0100", "en", pageable))
+                .thenReturn(page(property("http://example.org/EFO_0100")));
+
+        controller.getPropertiesByIri(
+                "http%3A%2F%2Fexample.org%2FEFO_0100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIri(
+                "http://example.org/EFO_0100", "en", pageable);
+    }
+
+    @Test
+    void definingOntologyListUsesTheDefiningRepositoryVariants() {
+        when(repository.findAllByIriAndIsDefiningOntology("the-iri", "en", pageable))
+                .thenReturn(page(property("the-iri")));
+
+        controller.getPropertiesByIdAndIsDefiningOntology(
+                "the-iri", "EFO_0100", "EFO:0100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIriAndIsDefiningOntology("the-iri", "en", pageable);
+        verify(repository, never()).findAllByShortFormAndIsDefiningOntology(
+                "EFO_0100", "en", pageable);
+        verify(repository, never()).findAllByOboIdAndIsDefiningOntology(
+                "EFO:0100", "en", pageable);
+    }
+
+    @Test
+    void listsAllDefiningOntologyPropertiesWhenNoIdentifierIsSupplied() {
+        when(repository.findAllByIsDefiningOntology("fr", pageable))
+                .thenReturn(page(property("http://example.org/EFO_0100")));
+
+        controller.getPropertiesByIdAndIsDefiningOntology(
+                null, null, null, "fr", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIsDefiningOntology("fr", pageable);
+    }
+
+    @Test
+    void definingOntologyPathDecodesTheIri() {
+        when(repository.findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_0100", "fr", pageable))
+                .thenReturn(page(property("http://example.org/EFO_0100")));
+
+        controller.getPropertiesByIriAndIsDefiningOntology(
+                "http%3A%2F%2Fexample.org%2FEFO_0100",
+                "fr", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_0100", "fr", pageable);
+    }
+
+    @Test
+    void advertisesTheV1PropertiesCollectionFromTheApiRoot() {
+        RepositoryLinksResource resource = new RepositoryLinksResource();
+
+        RepositoryLinksResource processed = controller.process(resource);
+
+        assertSame(resource, processed);
+        assertTrue(processed.hasLink("properties"));
+        assertEquals("/api/properties", processed.getRequiredLink("properties").getHref());
+    }
+
+    private PageImpl<V1Property> page(V1Property... properties) {
+        return new PageImpl<>(List.of(properties), pageable, properties.length);
+    }
+
+    private static V1Property property(String iri) {
+        V1Property property = new V1Property();
+        property.iri = iri;
+        return property;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1PropertyControllerWIT.java
@@ -1,0 +1,424 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.model.v1.V1Property;
+import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1PropertyController.class)
+@ContextConfiguration(classes = {
+        V1PropertyController.class,
+        V1PropertyAssembler.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1PropertyControllerWIT {
+
+    private static final String PROPERTY_IRI = "http://example.org/EFO_0100";
+    private static final URI PROPERTY_URI = URI.create(
+            "/api/properties/http%253A%252F%252Fexample.org%252FEFO_0100");
+    private static final URI DEFINING_PROPERTY_URI = URI.create(
+            "/api/properties/findByIdAndIsDefiningOntology/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_0100");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private V1PropertyRepository propertyRepository;
+
+    @MockitoBean
+    private EntityLinks entityLinks;
+
+    @BeforeEach
+    void stubPropertyLists() {
+        when(propertyRepository.findAll(anyString(), any())).thenAnswer(invocation ->
+                page(invocation.getArgument(1), property(invocation.getArgument(0))));
+        when(propertyRepository.findAllByIri(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+        when(propertyRepository.findAllByShortForm(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+        when(propertyRepository.findAllByOboId(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+        when(propertyRepository.findAllByIsDefiningOntology(anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(1), property(invocation.getArgument(0))));
+        when(propertyRepository.findAllByIriAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+        when(propertyRepository.findAllByShortFormAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+        when(propertyRepository.findAllByOboIdAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), property(invocation.getArgument(1))));
+    }
+
+    @Test
+    void returnsDefaultPropertyListContract() throws Exception {
+        mockMvc.perform(get("/api/properties"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$._embedded.properties[0].label").value("has specimen"))
+                .andExpect(jsonPath("$._embedded.properties[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.properties[0].short_form").value("EFO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[0].obo_id").value("EFO:0100"))
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("en"))
+                .andExpect(jsonPath("$._embedded.properties[0]._links.self.href")
+                        .value(endsWith("/api/ontologies/efo/properties/"
+                                + "http%253A%252F%252Fexample.org%252FEFO_0100?lang=en")))
+                .andExpect(jsonPath("$.page.size").value(1000))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.totalPages").value(1))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(propertyRepository).findAll("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void bindsLanguagePageSizeAndSort() throws Exception {
+        mockMvc.perform(get("/api/properties")
+                        .param("lang", "fr")
+                        .param("page", "2")
+                        .param("size", "7")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).findAll(
+                "fr", PageRequest.of(2, 7,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "list, -1, 20, 0, 20",
+            "list, 0, 0, 0, 1000",
+            "list, 0, -1, 0, 1000",
+            "list, 0, 1001, 0, 1000",
+            "path, -1, 20, 0, 20",
+            "path, 0, 0, 0, 1000",
+            "path, 0, 1001, 0, 1000",
+            "defining-list, -1, 20, 0, 20",
+            "defining-list, 0, -1, 0, 1000",
+            "defining-list, 0, 1001, 0, 1000",
+            "defining-path, -1, 20, 0, 20",
+            "defining-path, 0, 0, 0, 1000",
+            "defining-path, 0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundaries(
+            String route,
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "list" -> verify(propertyRepository).findAll("en", expected);
+            case "path" -> verify(propertyRepository).findAllByIri(PROPERTY_IRI, "en", expected);
+            case "defining-list" -> verify(propertyRepository)
+                    .findAllByIsDefiningOntology("en", expected);
+            case "defining-path" -> verify(propertyRepository)
+                    .findAllByIriAndIsDefiningOntology(PROPERTY_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void usesDefaultsForMalformedNumericPaginationOnEveryRoute() throws Exception {
+        Pageable defaults = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/properties").param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(PROPERTY_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(DEFINING_PROPERTY_URI)
+                        .param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAll("en", defaults);
+        verify(propertyRepository).findAllByIri(PROPERTY_IRI, "en", defaults);
+        verify(propertyRepository).findAllByIsDefiningOntology("en", defaults);
+        verify(propertyRepository)
+                .findAllByIriAndIsDefiningOntology(PROPERTY_IRI, "en", defaults);
+    }
+
+    @Test
+    void routesIriShortFormAndOboIdParameters() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/properties").param("iri", PROPERTY_IRI))
+                .andExpect(status().isOk());
+        verify(propertyRepository).findAllByIri(PROPERTY_IRI, "en", pageable);
+
+        mockMvc.perform(get("/api/properties").param("short_form", "EFO_0100"))
+                .andExpect(status().isOk());
+        verify(propertyRepository).findAllByShortForm("EFO_0100", "en", pageable);
+
+        mockMvc.perform(get("/api/properties").param("obo_id", "EFO:0100"))
+                .andExpect(status().isOk());
+        verify(propertyRepository).findAllByOboId("EFO:0100", "en", pageable);
+    }
+
+    @Test
+    void appliesIdentifierPrecedence() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/properties")
+                        .param("iri", PROPERTY_IRI)
+                        .param("short_form", "ignored-short-form")
+                        .param("obo_id", "IGNORED:0000"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAllByIri(PROPERTY_IRI, "en", pageable);
+        verify(propertyRepository, never())
+                .findAllByShortForm("ignored-short-form", "en", pageable);
+        verify(propertyRepository, never()).findAllByOboId("IGNORED:0000", "en", pageable);
+    }
+
+    @Test
+    void decodesDoubleEncodedIriPathAndForwardsExplicitOptions() throws Exception {
+        mockMvc.perform(get(PROPERTY_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "shortForm,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+
+        verify(propertyRepository).findAllByIri(
+                PROPERTY_IRI,
+                "fr",
+                PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.ASC, "shortForm"));
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleParametersForCompatibility() throws Exception {
+        mockMvc.perform(get("/api/properties")
+                        .param("search", "specimen")
+                        .param("includeObsoleteEntities", "false")
+                        .param("subset", "core", "slim")
+                        .param("http://example.org/category", "clinical", "policy")
+                        .param("domain", "biology,information"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAll("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void returnsDefaultDefiningOntologyListContract() throws Exception {
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(propertyRepository)
+                .findAllByIsDefiningOntology("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void routesEveryDefiningOntologyIdentifierParameter() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .param("iri", PROPERTY_IRI))
+                .andExpect(status().isOk());
+        verify(propertyRepository)
+                .findAllByIriAndIsDefiningOntology(PROPERTY_IRI, "en", pageable);
+
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .param("short_form", "EFO_0100"))
+                .andExpect(status().isOk());
+        verify(propertyRepository).findAllByShortFormAndIsDefiningOntology(
+                "EFO_0100", "en", pageable);
+
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .param("obo_id", "EFO:0100"))
+                .andExpect(status().isOk());
+        verify(propertyRepository)
+                .findAllByOboIdAndIsDefiningOntology("EFO:0100", "en", pageable);
+    }
+
+    @Test
+    void appliesDefiningOntologyIdentifierPrecedenceAndBindsPagination() throws Exception {
+        Pageable pageable = PageRequest.of(
+                1, 4, org.springframework.data.domain.Sort.Direction.DESC, "shortForm");
+
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .param("iri", PROPERTY_IRI)
+                        .param("short_form", "ignored-short-form")
+                        .param("obo_id", "IGNORED:0000")
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "4")
+                        .param("sort", "shortForm,desc"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository)
+                .findAllByIriAndIsDefiningOntology(PROPERTY_IRI, "fr", pageable);
+        verify(propertyRepository, never()).findAllByShortFormAndIsDefiningOntology(
+                "ignored-short-form", "fr", pageable);
+        verify(propertyRepository, never())
+                .findAllByOboIdAndIsDefiningOntology("IGNORED:0000", "fr", pageable);
+    }
+
+    @Test
+    void definingOntologyPathDecodesIriAndBindsAllOptions() throws Exception {
+        mockMvc.perform(get(DEFINING_PROPERTY_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).findAllByIriAndIsDefiningOntology(
+                PROPERTY_IRI,
+                "fr",
+                PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void supportsLegacyHalMediaTypeOnEveryRoute() throws Exception {
+        mockMvc.perform(get("/api/properties").accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(PROPERTY_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get("/api/properties/findByIdAndIsDefiningOntology")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(DEFINING_PROPERTY_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageCompatibility() throws Exception {
+        mockMvc.perform(get("/api/properties").param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("en_US"));
+
+        verify(propertyRepository).findAll("en_US", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void returnsStableBadRequestFieldsForUnsupportedSort() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(propertyRepository.findAll("en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get("/api/properties").param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
+    void returnsStableLegacyNotFoundStatusAndMessage() throws Exception {
+        when(propertyRepository.findAll("en", PageRequest.of(0, 1000)))
+                .thenThrow(new org.springframework.data.rest.webmvc.ResourceNotFoundException());
+
+        mockMvc.perform(get("/api/properties"))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
+        mockMvc.perform(post("/api/properties"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private static URI route(String route) {
+        return switch (route) {
+            case "list" -> URI.create("/api/properties");
+            case "path" -> PROPERTY_URI;
+            case "defining-list" -> URI.create(
+                    "/api/properties/findByIdAndIsDefiningOntology");
+            case "defining-path" -> DEFINING_PROPERTY_URI;
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        };
+    }
+
+    private static PageImpl<V1Property> page(Pageable pageable, V1Property... properties) {
+        return new PageImpl<>(List.of(properties), pageable, properties.length);
+    }
+
+    private static V1Property property(String lang) {
+        V1Property property = new V1Property();
+        property.iri = PROPERTY_IRI;
+        property.lang = lang;
+        property.label = "has specimen";
+        property.description = new String[]{"Relates a study to its specimen."};
+        property.synonyms = new String[]{"specimen relation"};
+        property.ontologyName = "efo";
+        property.ontologyPrefix = "EFO";
+        property.ontologyIri = "http://www.ebi.ac.uk/efo";
+        property.isObsolete = false;
+        property.isLocal = true;
+        property.hasChildren = false;
+        property.isRoot = true;
+        property.shortForm = "EFO_0100";
+        property.oboId = "EFO:0100";
+        property.annotation = Map.of();
+        return property;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
@@ -1,0 +1,149 @@
+package uk.ac.ebi.spot.ols.repository.v1;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.model.v1.V1Property;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class V1PropertyRepositoryIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1PropertyRepositoryHandle repositoryHandle;
+    private static V1PropertyRepository repository;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializePropertyDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createV1PropertyRepository(POSTGRES);
+        repository = repositoryHandle.repository();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsPropertiesInStableOrder() {
+        Page<V1Property> page = repository.findAll("en", PageRequest.of(0, 20));
+
+        assertThat(page).extracting(property -> property.iri).containsExactly(
+                "http://example.org/DUO_0100",
+                "http://example.org/EFO_0100",
+                "http://example.org/EFO_0101",
+                "http://example.org/EFO_0199");
+        assertThat(page.getTotalElements()).isEqualTo(4);
+        assertThat(page.getContent().get(1).label).isEqualTo("has specimen");
+        assertThat(page.getContent().get(1).isLocal).isTrue();
+        assertThat(page.getContent().get(1).isObsolete).isFalse();
+        assertThat(page.getContent().get(3).isLocal).isFalse();
+        assertThat(page.getContent().get(3).isObsolete).isTrue();
+    }
+
+    @Test
+    void appliesPaginationAndSupportedSorting() {
+        Page<V1Property> secondPage = repository.findAll("en", PageRequest.of(1, 2));
+        Page<V1Property> descending = repository.findAll(
+                "en",
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "iri")));
+
+        assertThat(secondPage).extracting(property -> property.iri).containsExactly(
+                "http://example.org/EFO_0101",
+                "http://example.org/EFO_0199");
+        assertThat(secondPage.getTotalElements()).isEqualTo(4);
+        assertThat(secondPage.getTotalPages()).isEqualTo(2);
+        assertThat(descending).extracting(property -> property.iri).containsExactly(
+                "http://example.org/EFO_0199",
+                "http://example.org/EFO_0101",
+                "http://example.org/EFO_0100",
+                "http://example.org/DUO_0100");
+    }
+
+    @Test
+    void rejectsUnsupportedSortFields() {
+        assertThatThrownBy(() -> repository.findAll(
+                "en", PageRequest.of(0, 20, Sort.by("notARealField"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported sort field");
+    }
+
+    @Test
+    void findsPropertiesByIriShortFormAndOboId() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIri(
+                "http://example.org/EFO_0100", "fr", pageable))
+                .singleElement()
+                .satisfies(property -> {
+                    assertThat(property.label).isEqualTo("has specimen");
+                    assertThat(property.lang).isEqualTo("fr");
+                    assertThat(property.isLocal).isTrue();
+                    assertThat(property.isObsolete).isFalse();
+                    assertThat(property.description)
+                            .containsExactly("Relates a study to its specimen.");
+                });
+        assertThat(repository.findAllByShortForm("EFO_0100", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+        assertThat(repository.findAllByOboId("EFO:0100", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+    }
+
+    @Test
+    void returnsEmptyPagesForUnknownIdentifiers() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIri("http://example.org/missing", "en", pageable))
+                .isEmpty();
+        assertThat(repository.findAllByShortForm("MISSING", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboId("MISSING:0000", "en", pageable)).isEmpty();
+    }
+
+    @Test
+    void restrictsEveryIdentifierRepresentationToDefiningOntologies() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIsDefiningOntology("en", pageable))
+                .allSatisfy(property -> assertThat(property.isLocal).isTrue())
+                .extracting(property -> property.iri)
+                .containsExactly(
+                        "http://example.org/DUO_0100",
+                        "http://example.org/EFO_0100",
+                        "http://example.org/EFO_0101");
+        assertThat(repository.findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_0199", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByShortFormAndIsDefiningOntology(
+                "EFO_0199", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboIdAndIsDefiningOntology(
+                "EFO:0199", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboIdAndIsDefiningOntology(
+                "EFO:0100", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageWithLabelFallback() {
+        Page<V1Property> page = repository.findAll("en_US", PageRequest.of(0, 1));
+
+        assertThat(page).singleElement().satisfies(property -> {
+            assertThat(property.lang).isEqualTo("en_US");
+            assertThat(property.label).isEqualTo("permits sample");
+        });
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -13,6 +13,7 @@ import uk.ac.ebi.spot.ols.repository.PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
 import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
 import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
 import uk.ac.ebi.spot.ols.service.PostgresClient;
 
@@ -120,6 +121,20 @@ public final class PostgresIntegrationTestSupport {
         ReflectionTestUtils.setField(repository, "searchClient", searchClient);
         ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
         return new PropertyRepositoryHandle(repository, postgresClient);
+    }
+
+    public static V1PropertyRepositoryHandle createV1PropertyRepository(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        V1PropertyRepository repository = new V1PropertyRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
+        return new V1PropertyRepositoryHandle(repository, postgresClient);
     }
 
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
@@ -380,6 +395,16 @@ public final class PostgresIntegrationTestSupport {
 
     public record PropertyRepositoryHandle(
             PropertyRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record V1PropertyRepositoryHandle(
+            V1PropertyRepository repository,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/backend/src/test/resources/fixtures/properties/README.md
+++ b/backend/src/test/resources/fixtures/properties/README.md
@@ -8,7 +8,9 @@ ontology scoping, obsolete selection, and hierarchy behavior.
 - `EFO_0101` is an active child of the shared `EFO_0100` property. Its `directParents` and
   `directAncestors` arrays exercise the production PostgreSQL hierarchy columns.
 - `DUO_0100` provides a second ontology and a definition-weighted ranking case.
-- `EFO_0199` is obsolete and is excluded by the controller default.
+- `EFO_0199` is obsolete and non-defining. It is excluded by the V2 controller default while its
+  defining-ontology flag distinguishes the legacy V1 filtered and unfiltered routes without
+  changing active-property search ranking.
 
 The wrapper fields map to production `ols_entities` columns and the nested `json` object is the
 compressed API document returned by the repository. Update both views together, then run the Java

--- a/backend/src/test/resources/fixtures/properties/property-fixture.json
+++ b/backend/src/test/resources/fixtures/properties/property-fixture.json
@@ -85,7 +85,7 @@
       "ontologyId": "efo",
       "iri": "http://example.org/EFO_0199",
       "isObsolete": true,
-      "isDefiningOntology": true,
+      "isDefiningOntology": false,
       "label": ["legacy material relation"],
       "synonym": ["obsolete property"],
       "definition": ["An obsolete property retained for filter tests."],
@@ -111,7 +111,7 @@
         "shortForm": "EFO_0199",
         "curie": "EFO:0199",
         "isObsolete": true,
-        "isDefiningOntology": true,
+        "isDefiningOntology": false,
         "hasDirectParents": false,
         "hasHierarchicalParents": false,
         "linkedEntities": {}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -335,6 +335,28 @@ Verified locally on 2026-08-25 with Java 17 and Rancher Desktop:
   suites, preserving established fixture totals while exercising production `direct_parents` and
   `direct_ancestors` columns. No production defect was exposed.
 
+## Implemented V1 property-controller baseline
+
+Verified locally on 2026-08-25 with Java 17 and Rancher Desktop:
+
+- Surefire runs 298 tests, including 8 direct `V1PropertyControllerTest` cases and 29
+  `V1PropertyControllerWIT` cases. Two runs with a deliberately unavailable Docker socket took
+  approximately 18.1 and 19.3 seconds.
+- Failsafe runs 73 PostgreSQL tests, including 7 `V1PropertyRepositoryIT` cases and 4 thin
+  `V1PropertyControllerIT` cases. Two complete database-gate runs took approximately 43.6 and
+  42.6 seconds.
+- The clean `verify` lifecycle runs all 371 tests in approximately 57.1 seconds.
+- Whole-backend JaCoCo coverage is 28.9% lines and 23.2% branches. The V1 property controller
+  covers all 28 lines and all 12 branches; its repository covers 43 of 89 lines, including every
+  finder used by the controller's four routes. No coverage failure threshold is introduced.
+- V1 compatibility retains its 1000-item default page size, arbitrary language identifiers with
+  value fallback, identifier precedence, double-encoded IRI paths, legacy HAL responses, and
+  servlet-style 404 reason. The property fixture uses its obsolete record as the non-defining case
+  so active V2 property search ranking remains unchanged. The rollout exposed that the V1 mapper
+  omitted the public `is_obsolete` and `is_defining_ontology` flags. The minimal production fix
+  merged in PR #1371, and the repository and thin controller ITs now assert both mapped values
+  through the real PostgreSQL-to-HTTP path.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary
- add direct controller tests for V1-owned routing and identifier decisions
- add a 29-case V1PropertyControllerWIT contract matrix covering all four routes, parameters, pagination, encoded identifiers, HAL fields, and stable errors
- add seven real-PostgreSQL repository tests and four thin controller-to-database integration tests
- rebase onto merged PR #1371 and assert the repaired is_obsolete and is_defining_ontology flags through PostgreSQL and HTTP
- record the measured V1 property-controller baseline

## Selection rationale
V1PropertyController is the next corresponding compatibility surface after V2PropertyController. Its four legacy routes combine identifier precedence, double-encoded IRIs, V1 pagination/language/HAL behavior, defining-ontology filtering, and downstream API compatibility, while the disposable PostgreSQL fixture can exercise the repository behavior directly.

## Verification
- Java 17
- fast suite twice with a deliberately unavailable Docker socket: 298 tests; 18.1s and 19.3s
- PostgreSQL gate twice with Rancher Desktop: 73 tests; 43.6s and 42.6s
- clean full verify: 371 tests; 57.1s
- JaCoCo: 28.9% backend lines, 23.2% branches; V1PropertyController 28/28 lines and 12/12 branches

## Notes
- test_api.sh is unchanged
- no production code is included; the mapper defect was fixed separately in merged PR #1371