### PR TITLE
Restrict V2 class hierarchy results to classes

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
@@ -118,7 +118,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         Page<JsonElement> result = isNullOrEmpty(search) ? this.postgresClient.getDirectChildren(
                 id, nodeProps, pageable) :
@@ -137,7 +137,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getAncestors(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -151,7 +151,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getDescendants(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -164,7 +164,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getHierarchicalDescendants(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -178,7 +178,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getHierarchicalChildren(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -192,7 +192,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getHierarchicalAncestors(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -206,7 +206,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+individual+" + iri;
 
-        Map<String, String> nodeProps = includeObsolete ? Map.of() : Map.of("isObsolete", "false");
+        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
 
         return this.postgresClient.getAncestors(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -225,6 +225,12 @@ public class ClassRepository {
         return this.postgresClient.getSimilar("OntologyClass", iri, pageable, modelName)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
                 ;
+    }
+
+    private static Map<String, String> classNodeProperties(boolean includeObsolete) {
+        return includeObsolete
+                ? Map.of("type", "OntologyClass")
+                : Map.of("type", "OntologyClass", "isObsolete", "false");
     }
 
     public double getSimilarity(String iri, String iri2, String modelName) {

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
@@ -270,8 +270,14 @@ public class OlsPostgresClient {
     private Condition buildNodePropCondition(String qualifier, Map<String, String> nodeProps) {
         Condition condition = DSL.trueCondition();
         for (var entry : nodeProps.entrySet()) {
-            if ("isObsolete".equals(entry.getKey())) {
-                condition = condition.and(field(qualifier, "is_obsolete", Boolean.class).eq("true".equals(entry.getValue())));
+            switch (entry.getKey()) {
+                case "isObsolete" -> condition = condition.and(
+                        field(qualifier, "is_obsolete", Boolean.class)
+                                .eq("true".equals(entry.getValue())));
+                case "type" -> condition = condition.and(
+                        field(qualifier, "type", String.class).eq(entry.getValue()));
+                default -> {
+                }
             }
         }
         return condition;

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeIT.java
@@ -1,0 +1,62 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class ClassRepositoryHierarchyTypeIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.ClassRepositoryHandle repositoryHandle;
+
+    @BeforeAll
+    static void setUpDatabase() throws SQLException {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        try (Connection connection = POSTGRES.createConnection("");
+                Statement statement = connection.createStatement()) {
+            statement.executeUpdate("""
+                    UPDATE ols_entities
+                    SET direct_ancestors = ARRAY['http://example.org/EFO_0001']
+                    WHERE id = 'efo+property+http://example.org/EFO_0100'
+                    """);
+        }
+        repositoryHandle = PostgresIntegrationTestSupport.createClassRepository(POSTGRES);
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void classDescendantsExcludeCrossTypeEntitiesInTheSameHierarchyColumn() {
+        Page<JsonElement> descendants = repositoryHandle.repository().getDescendantsByOntologyId(
+                "efo",
+                PageRequest.of(0, 20),
+                "http://example.org/EFO_0001",
+                false,
+                "en",
+                new JsonTransformOptions());
+
+        assertThat(descendants).isEmpty();
+        assertThat(descendants.getTotalElements()).isZero();
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeTest.java
@@ -1,0 +1,117 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+class ClassRepositoryHierarchyTypeTest {
+
+    @Test
+    void everyHierarchyRouteRestrictsResultsToClassesAndActiveEntities() {
+        RecordingPostgresClient postgresClient = new RecordingPostgresClient();
+        ClassRepository repository = repository(postgresClient);
+
+        invokeEveryHierarchyRoute(repository, false);
+
+        assertThat(postgresClient.nodeProperties).hasSize(7)
+                .allSatisfy(properties -> assertThat(properties).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("type", "OntologyClass", "isObsolete", "false")));
+    }
+
+    @Test
+    void includingObsoleteEntitiesStillRestrictsHierarchyResultsToClasses() {
+        RecordingPostgresClient postgresClient = new RecordingPostgresClient();
+        ClassRepository repository = repository(postgresClient);
+
+        invokeEveryHierarchyRoute(repository, true);
+
+        assertThat(postgresClient.nodeProperties).hasSize(7)
+                .allSatisfy(properties -> assertThat(properties)
+                        .containsExactlyEntriesOf(Map.of("type", "OntologyClass")));
+    }
+
+    private static ClassRepository repository(RecordingPostgresClient postgresClient) {
+        ClassRepository repository = new ClassRepository();
+        setField(repository, "postgresClient", postgresClient);
+        return repository;
+    }
+
+    private static void invokeEveryHierarchyRoute(
+            ClassRepository repository,
+            boolean includeObsolete) {
+        Pageable pageable = PageRequest.of(0, 20);
+        JsonTransformOptions options = new JsonTransformOptions();
+        String iri = "http://example.org/EFO_0001";
+
+        repository.getChildrenByOntologyId(
+                "efo", pageable, iri, includeObsolete, null, "en", options);
+        repository.getAncestorsByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+        repository.getDescendantsByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+        repository.getHierarchicalDescendantsByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+        repository.getHierarchicalChildrenByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+        repository.getHierarchicalAncestorsByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+        repository.getIndividualAncestorsByOntologyId(
+                "efo", pageable, iri, includeObsolete, "en", options);
+    }
+
+    private static class RecordingPostgresClient extends OlsPostgresClient {
+        private final List<Map<String, String>> nodeProperties = new ArrayList<>();
+
+        @Override
+        public Page<JsonElement> getDirectChildren(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getAncestors(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getDescendants(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getHierarchicalDescendants(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getHierarchicalChildren(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getHierarchicalAncestors(
+                String id, Map<String, String> properties, Pageable pageable) {
+            return record(properties, pageable);
+        }
+
+        private Page<JsonElement> record(Map<String, String> properties, Pageable pageable) {
+            nodeProperties.add(properties);
+            return Page.empty(pageable);
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -8,6 +8,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.utility.DockerImageName;
 import uk.ac.ebi.spot.ols.repository.EntityRepository;
+import uk.ac.ebi.spot.ols.repository.ClassRepository;
 import uk.ac.ebi.spot.ols.repository.OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
@@ -135,6 +136,20 @@ public final class PostgresIntegrationTestSupport {
         ReflectionTestUtils.setField(repository, "searchClient", searchClient);
         ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
         return new V1PropertyRepositoryHandle(repository, postgresClient);
+    }
+
+    public static ClassRepositoryHandle createClassRepository(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        ClassRepository repository = new ClassRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
+        return new ClassRepositoryHandle(repository, postgresClient);
     }
 
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
@@ -405,6 +420,16 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1PropertyRepositoryHandle(
             V1PropertyRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record ClassRepositoryHandle(
+            ClassRepository repository,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override


### PR DESCRIPTION
## Summary
- restrict every V2 class hierarchy route to `OntologyClass` targets
- teach the shared PostgreSQL hierarchy query to apply an explicit node `type`
- add unit and disposable-PostgreSQL regressions for cross-type hierarchy leakage

## Defect
A class descendant query could return an individual or property when that row named the class in a hierarchy array, because `ClassRepository` passed only the obsolete filter to the generic PostgreSQL hierarchy lookup.

## Verification
- Java 17 `mvn -B -ntp -pl backend -am test`: 263 tests passed; Docker deliberately unavailable; 19.2s
- Java 17 targeted `ClassRepositoryHierarchyTypeIT`: 1 PostgreSQL test passed using `pgvector/pgvector:0.8.0-pg17`; 13.1s

The broader V2 class controller test rollout remains on a separate branch and will rebase only after this fix merges.