### PR TITLE
Filter obsolete class individuals

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualController.java
@@ -170,6 +170,9 @@ public class V2IndividualController {
             @PathVariable("class")
             @Parameter(name = "class",
                     description = "The IRI of the class, this value must be double URL encoded") String classIri,
+            @RequestParam(value = "includeObsoleteEntities", required = false, defaultValue = "false")
+            @Parameter(name = "includeObsoleteEntities",
+                    description = "A boolean parameter to specify if obsolete entities should be included or not. Default value is false.") boolean includeObsoleteEntities,
             @RequestParam(value = "lang", required = false, defaultValue = "en") String lang,
             @ParameterObject JsonTransformOptions outputOpts
     ) throws ResourceNotFoundException, IOException {
@@ -178,7 +181,9 @@ public class V2IndividualController {
 
         return new ResponseEntity<>(
                 new V2PagedResponse<V2Entity>(
-                        individualRepository.getIndividualsOfClass(ontologyId, classIri, pageable, lang, outputOpts).map(V2Entity::new)
+                        individualRepository.getIndividualsOfClass(
+                                ontologyId, classIri, pageable, includeObsoleteEntities, lang, outputOpts)
+                                .map(V2Entity::new)
                 ),
                 HttpStatus.OK);
 
@@ -186,6 +191,5 @@ public class V2IndividualController {
 
 
 }
-
 
 

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/IndividualRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/IndividualRepository.java
@@ -105,7 +105,8 @@ public class IndividualRepository {
     }
 
     public OlsFacetedResultsPage<JsonElement> getIndividualsOfClass(
-            String ontologyId, String classIri, Pageable pageable, String lang, JsonTransformOptions outputOpts) throws IOException {
+            String ontologyId, String classIri, Pageable pageable, boolean includeObsoleteEntities,
+            String lang, JsonTransformOptions outputOpts) throws IOException {
 
         Validation.validateOntologyId(ontologyId);
         Validation.validateLang(lang);
@@ -114,6 +115,9 @@ public class IndividualRepository {
         query.addFilter("type", List.of("individual"), SearchType.WHOLE_FIELD);
         query.addFilter("ontologyId", List.of(ontologyId), SearchType.CASE_INSENSITIVE_TOKENS);
         query.addFilter("http__//www.w3.org/1999/02/22-rdf-syntax-ns#type", List.of(classIri), SearchType.WHOLE_FIELD);
+        if (!includeObsoleteEntities) {
+            query.addFilter(IS_OBSOLETE.getText(), List.of("false"), SearchType.WHOLE_FIELD);
+        }
 
         return searchClient.searchPaginated(query, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -124,4 +128,3 @@ public class IndividualRepository {
 
 
 }
-

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualClassObsoleteFilterWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualClassObsoleteFilterWIT.java
@@ -1,0 +1,64 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.IndividualRepository;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V2IndividualController.class)
+@ContextConfiguration(classes = {
+        V2IndividualController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V2IndividualClassObsoleteFilterWIT {
+
+    private static final URI ROUTE = URI.create(
+            "/api/v2/ontologies/efo/classes/http%253A%252F%252Fexample.org%252FEFO_0001/individuals");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private IndividualRepository individualRepository;
+
+    @Test
+    void excludesObsoleteIndividualsByDefaultAndAllowsExplicitOptIn() throws Exception {
+        when(individualRepository.getIndividualsOfClass(any(), any(), any(), any(Boolean.class), any(), any()))
+                .thenAnswer(invocation -> new OlsFacetedResultsPage<JsonElement>(
+                        List.of(), Map.of(), invocation.getArgument(2), 0));
+
+        mockMvc.perform(get(ROUTE)).andExpect(status().isOk());
+        ArgumentCaptor<Boolean> defaultValue = ArgumentCaptor.forClass(Boolean.class);
+        verify(individualRepository).getIndividualsOfClass(
+                any(), any(), any(), defaultValue.capture(), any(), any());
+        assertFalse(defaultValue.getValue());
+
+        mockMvc.perform(get(ROUTE).param("includeObsoleteEntities", "true"))
+                .andExpect(status().isOk());
+        ArgumentCaptor<Boolean> values = ArgumentCaptor.forClass(Boolean.class);
+        verify(individualRepository, org.mockito.Mockito.times(2)).getIndividualsOfClass(
+                any(), any(), any(), values.capture(), any(), any());
+        assertTrue(values.getAllValues().get(1));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/IndividualRepositoryObsoleteFilterTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/IndividualRepositoryObsoleteFilterTest.java
@@ -1,0 +1,55 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class IndividualRepositoryObsoleteFilterTest {
+
+    @Test
+    void classMembershipExcludesObsoleteIndividualsUnlessExplicitlyIncluded() throws Exception {
+        RecordingSearchClient searchClient = new RecordingSearchClient();
+        IndividualRepository repository = new IndividualRepository();
+        repository.searchClient = searchClient;
+
+        repository.getIndividualsOfClass(
+                "efo", "http://example.org/EFO_0001", PageRequest.of(0, 20), false, "en",
+                new JsonTransformOptions());
+        assertThat(searchClient.condition())
+                .contains("is_obsolete")
+                .contains("false");
+
+        repository.getIndividualsOfClass(
+                "efo", "http://example.org/EFO_0001", PageRequest.of(0, 20), true, "en",
+                new JsonTransformOptions());
+        assertThat(searchClient.condition()).doesNotContain("is_obsolete");
+    }
+
+    private static class RecordingSearchClient extends OlsSearchClient {
+        private OlsSearchQuery query;
+
+        @Override
+        public OlsFacetedResultsPage<JsonElement> searchPaginated(
+                OlsSearchQuery query, Pageable pageable) {
+            this.query = query;
+            return new OlsFacetedResultsPage<>(List.of(), Map.of(), pageable, 0);
+        }
+
+        private String condition() {
+            return query.buildCondition(Set.of(
+                    "filter_http://www.w3.org/1999/02/22-rdf-syntax-ns#type"))
+                    .toString();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- bind the existing frontend `includeObsoleteEntities` query parameter on the V2 class-to-individual route
- exclude obsolete individuals by default in the repository query
- preserve explicit opt-in behavior

## Defect

The frontend already sends `includeObsoleteEntities` for `GET /api/v2/ontologies/{onto}/classes/{class}/individuals`, but the controller ignored it and the repository returned obsolete individual rows unconditionally.

## Tests

- focused Spring MVC binding regression: default false and explicit true
- focused repository query regression: active-only default and opt-in inclusion
- Java 17 full Docker-free backend suite: 468 tests passed in 19.093s

Graphify was refreshed after the code change. `test_api.sh` was not run locally; downstream API CI remains the system-regression gate.
