### PR TITLE
Map V1 individual status flags

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/mappers/V1IndividualMapper.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/mappers/V1IndividualMapper.java
@@ -37,6 +37,9 @@ public class V1IndividualMapper {
         individual.shortForm = JsonHelper.getString(localizedJson, "shortForm");
         individual.oboId = individual.shortForm.replace("_", ":");
 
+        individual.isLocal = JsonHelper.getBoolean(localizedJson, IS_DEFINING_ONTOLOGY.getText());
+        individual.isObsolete = JsonHelper.getBoolean(localizedJson, IS_OBSOLETE.getText());
+
         return individual;
     }
 

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/mappers/V1IndividualMapperTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/mappers/V1IndividualMapperTest.java
@@ -1,0 +1,32 @@
+package uk.ac.ebi.spot.ols.repository.v1.mappers;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class V1IndividualMapperTest {
+
+    @Test
+    void mapsObsoleteAndDefiningOntologyFlags() {
+        JsonObject json = new JsonObject();
+        json.addProperty("iri", "http://example.org/EFO_I999");
+        json.addProperty("ontologyId", "efo");
+        json.addProperty("ontologyPreferredPrefix", "EFO");
+        json.addProperty("ontologyIri", "http://www.ebi.ac.uk/efo");
+        json.addProperty("label", "legacy individual");
+        json.add("definition", new JsonArray());
+        json.add("synonym", new JsonArray());
+        json.add("subset", new JsonArray());
+        json.addProperty("shortForm", "EFO_I999");
+        json.addProperty("isObsolete", true);
+        json.addProperty("isDefiningOntology", true);
+        json.add("linkedEntities", new JsonObject());
+
+        var individual = V1IndividualMapper.mapIndividual(json, "en");
+
+        assertThat(individual.isObsolete).isTrue();
+        assertThat(individual.isLocal).isTrue();
+    }
+}

--- a/testcases_expected_output_api/ontologies/isobsolete/individuals.json
+++ b/testcases_expected_output_api/ontologies/isobsolete/individuals.json
@@ -19,7 +19,7 @@
     "has_children": false,
     "iri": "http://www.ebi.ac.uk/testcases/defined-fields/isObsolete.rdf#DeprecatedIndividual",
     "is_defining_ontology": false,
-    "is_obsolete": false,
+    "is_obsolete": true,
     "is_root": false,
     "label": "DeprecatedIndividual",
     "lang": "en",

--- a/testcases_expected_output_api/ontologies/isobsolete/individuals/http%253A%252F%252Fwww.ebi.ac.uk%252Ftestcases%252Fdefined-fields%252FisObsolete.rdf%2523DeprecatedIndividual.json
+++ b/testcases_expected_output_api/ontologies/isobsolete/individuals/http%253A%252F%252Fwww.ebi.ac.uk%252Ftestcases%252Fdefined-fields%252FisObsolete.rdf%2523DeprecatedIndividual.json
@@ -18,7 +18,7 @@
   "has_children": false,
   "iri": "http://www.ebi.ac.uk/testcases/defined-fields/isObsolete.rdf#DeprecatedIndividual",
   "is_defining_ontology": false,
-  "is_obsolete": false,
+  "is_obsolete": true,
   "is_root": false,
   "label": "DeprecatedIndividual",
   "lang": "en",


### PR DESCRIPTION
## Summary
- map is_obsolete and is_defining_ontology in V1IndividualMapper
- add a focused mapper regression test
- update the two affected V1 API golden responses for DeprecatedIndividual

## Verification
- Java 17 targeted mapper test
- Java 17 full backend mvn test: 539 tests
- CI-confirmed API diff is limited to DeprecatedIndividual.is_obsolete changing from false to true in the collection and detail responses

Discovered while adding layered V1IndividualController coverage. The broader controller tests remain on a separate branch.