### PR TITLE
Test V1 individual controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerIT.java
@@ -1,0 +1,154 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.MessageResolver;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.core.AnnotationLinkRelationProvider;
+import org.springframework.hateoas.server.core.DelegatingLinkRelationProvider;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.net.URI;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1IndividualControllerIT {
+
+    private static final URI INDIVIDUAL_URI = URI.create(
+            "/api/individuals/http%253A%252F%252Fexample.org%252FEFO_I100");
+    private static final URI DEFINING_INDIVIDUAL_URI = URI.create(
+            "/api/individuals/findByIdAndIsDefiningOntology/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_I100");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1IndividualRepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createV1IndividualRepository(POSTGRES);
+
+        V1IndividualController controller = new V1IndividualController();
+        ReflectionTestUtils.setField(
+                controller, "individualRepository", repositoryHandle.repository());
+        controller.individualAssembler = new V1IndividualAssembler();
+
+        HateoasPageableHandlerMethodArgumentResolver pageableResolver =
+                new HateoasPageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(1000);
+        PagedResourcesAssemblerArgumentResolver assemblerResolver =
+                new PagedResourcesAssemblerArgumentResolver(pageableResolver);
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(pageableResolver, assemblerResolver)
+                .setMessageConverters(halMessageConverter())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsIndividualsThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/individuals"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(4))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri")
+                        .value("http://example.org/DUO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[1].label")
+                        .value("Liver specimen alpha"))
+                .andExpect(jsonPath("$._embedded.individuals[1].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$._embedded.individuals[1].is_obsolete").value(false))
+                .andExpect(jsonPath("$._embedded.individuals[2].is_defining_ontology")
+                        .value(false))
+                .andExpect(jsonPath("$._embedded.individuals[3].is_obsolete").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedIndividualThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(INDIVIDUAL_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.individuals[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri")
+                        .value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[0].label")
+                        .value("Liver specimen alpha"))
+                .andExpect(jsonPath("$._embedded.individuals[0].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$._embedded.individuals[0].is_obsolete").value(false));
+    }
+
+    @Test
+    void listsOnlyDefiningOntologyIndividualsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri")
+                        .value("http://example.org/DUO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[0].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$._embedded.individuals[1].iri")
+                        .value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[2].iri")
+                        .value("http://example.org/EFO_I999"))
+                .andExpect(jsonPath("$._embedded.individuals[2].is_obsolete").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedDefiningOntologyIndividualThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(DEFINING_INDIVIDUAL_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri")
+                        .value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[0].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$._embedded.individuals[0].is_obsolete").value(false))
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("fr"));
+    }
+
+    private static MappingJackson2HttpMessageConverter halMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jackson2HalModule());
+        objectMapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(
+                new DelegatingLinkRelationProvider(
+                        new AnnotationLinkRelationProvider(),
+                        new EvoInflectorLinkRelationProvider()),
+                CurieProvider.NONE,
+                MessageResolver.DEFAULTS_ONLY));
+
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaTypes.HAL_JSON));
+        return converter;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerTest.java
@@ -1,0 +1,175 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.RepositoryLinksResource;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1IndividualControllerTest {
+
+    private V1IndividualController controller;
+    private V1IndividualRepository repository;
+    private V1IndividualAssembler individualAssembler;
+    private PagedResourcesAssembler<V1Individual> resourcesAssembler;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        repository = mock(V1IndividualRepository.class);
+        individualAssembler = mock(V1IndividualAssembler.class);
+        resourcesAssembler = mock(PagedResourcesAssembler.class);
+        pageable = PageRequest.of(1, 7);
+        controller = new V1IndividualController();
+        ReflectionTestUtils.setField(controller, "individualRepository", repository);
+        controller.individualAssembler = individualAssembler;
+    }
+
+    @Test
+    void listsAllIndividualsWhenNoIdentifierIsSupplied() {
+        OlsFacetedResultsPage<V1Individual> individuals =
+                page(individual("http://example.org/EFO_I100"));
+        PagedModel<EntityModel<V1Individual>> assembled = PagedModel.empty();
+        when(repository.findAll("fr", pageable)).thenReturn(individuals);
+        when(resourcesAssembler.toModel(individuals, individualAssembler)).thenReturn(assembled);
+
+        var response = controller.getAllIndividuals(
+                null, null, null, "fr", pageable, resourcesAssembler);
+
+        assertEquals(HttpStatus.OK, ((ResponseEntity<?>) response).getStatusCode());
+        assertSame(assembled, response.getBody());
+        verify(repository).findAll("fr", pageable);
+        verify(resourcesAssembler).toModel(individuals, individualAssembler);
+    }
+
+    @Test
+    void selectsIriBeforeShortFormAndOboId() {
+        when(repository.findAllByIri("the-iri", "en", pageable))
+                .thenReturn(page(individual("the-iri")));
+
+        controller.getAllIndividuals(
+                "the-iri", "EFO_I100", "EFO:I100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIri("the-iri", "en", pageable);
+        verify(repository, never()).findAllByShortForm("EFO_I100", "en", pageable);
+        verify(repository, never()).findAllByOboId("EFO:I100", "en", pageable);
+    }
+
+    @Test
+    void selectsShortFormThenOboIdWhenHigherPriorityIdentifiersAreAbsent() {
+        when(repository.findAllByShortForm("EFO_I100", "en", pageable))
+                .thenReturn(page(individual("http://example.org/EFO_I100")));
+
+        controller.getAllIndividuals(
+                null, "EFO_I100", "EFO:I100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByShortForm("EFO_I100", "en", pageable);
+        verify(repository, never()).findAllByOboId("EFO:I100", "en", pageable);
+
+        when(repository.findAllByOboId("EFO:I200", "en", pageable))
+                .thenReturn(page(individual("http://example.org/EFO_I200")));
+        controller.getAllIndividuals(
+                null, null, "EFO:I200",
+                "en", pageable, resourcesAssembler);
+        verify(repository).findAllByOboId("EFO:I200", "en", pageable);
+    }
+
+    @Test
+    void pathRouteDecodesTheIriBeforeUsingTheListDecision() {
+        when(repository.findAllByIri("http://example.org/EFO_I100", "en", pageable))
+                .thenReturn(page(individual("http://example.org/EFO_I100")));
+
+        controller.getAllIndividuals(
+                "http%3A%2F%2Fexample.org%2FEFO_I100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIri(
+                "http://example.org/EFO_I100", "en", pageable);
+    }
+
+    @Test
+    void definingOntologyListUsesTheDefiningRepositoryVariants() {
+        when(repository.findAllByIriAndIsDefiningOntology("the-iri", "en", pageable))
+                .thenReturn(page(individual("the-iri")));
+
+        controller.getAllIndividualsByIdAndIsDefiningOntology(
+                "the-iri", "EFO_I100", "EFO:I100",
+                "en", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIriAndIsDefiningOntology("the-iri", "en", pageable);
+        verify(repository, never()).findAllByShortFormAndIsDefiningOntology(
+                "EFO_I100", "en", pageable);
+        verify(repository, never()).findAllByOboIdAndIsDefiningOntology(
+                "EFO:I100", "en", pageable);
+    }
+
+    @Test
+    void listsAllDefiningOntologyIndividualsWhenNoIdentifierIsSupplied() {
+        when(repository.findAllByIsDefiningOntology("fr", pageable))
+                .thenReturn(page(individual("http://example.org/EFO_I100")));
+
+        controller.getAllIndividualsByIdAndIsDefiningOntology(
+                null, null, null, "fr", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIsDefiningOntology("fr", pageable);
+    }
+
+    @Test
+    void definingOntologyPathDecodesTheIri() {
+        when(repository.findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_I100", "fr", pageable))
+                .thenReturn(page(individual("http://example.org/EFO_I100")));
+
+        controller.getAllIndividualsByIdAndIsDefiningOntology(
+                "http%3A%2F%2Fexample.org%2FEFO_I100",
+                "fr", pageable, resourcesAssembler);
+
+        verify(repository).findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_I100", "fr", pageable);
+    }
+
+    @Test
+    void advertisesTheV1IndividualsCollectionFromTheApiRoot() {
+        RepositoryLinksResource resource = new RepositoryLinksResource();
+
+        RepositoryLinksResource processed = controller.process(resource);
+
+        assertSame(resource, processed);
+        assertTrue(processed.hasLink("individuals"));
+        assertEquals("/api/individuals", processed.getRequiredLink("individuals").getHref());
+    }
+
+    private OlsFacetedResultsPage<V1Individual> page(V1Individual... individuals) {
+        return new OlsFacetedResultsPage<>(
+                List.of(individuals), Map.of(), pageable, individuals.length);
+    }
+
+    private static V1Individual individual(String iri) {
+        V1Individual individual = new V1Individual();
+        individual.iri = iri;
+        return individual;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1IndividualControllerWIT.java
@@ -1,0 +1,432 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1IndividualController.class)
+@ContextConfiguration(classes = {
+        V1IndividualController.class,
+        V1IndividualAssembler.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1IndividualControllerWIT {
+
+    private static final String INDIVIDUAL_IRI = "http://example.org/EFO_I100";
+    private static final URI INDIVIDUAL_URI = URI.create(
+            "/api/individuals/http%253A%252F%252Fexample.org%252FEFO_I100");
+    private static final URI DEFINING_INDIVIDUAL_URI = URI.create(
+            "/api/individuals/findByIdAndIsDefiningOntology/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_I100");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private V1IndividualRepository individualRepository;
+
+    @MockitoBean
+    private EntityLinks entityLinks;
+
+    @BeforeEach
+    void stubIndividualLists() {
+        when(individualRepository.findAll(anyString(), any())).thenAnswer(invocation ->
+                page(invocation.getArgument(1), individual(invocation.getArgument(0))));
+        when(individualRepository.findAllByIri(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+        when(individualRepository.findAllByShortForm(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+        when(individualRepository.findAllByOboId(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+        when(individualRepository.findAllByIsDefiningOntology(anyString(), any()))
+                .thenAnswer(invocation -> page(
+                        invocation.getArgument(1), individual(invocation.getArgument(0))));
+        when(individualRepository.findAllByIriAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+        when(individualRepository.findAllByShortFormAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+        when(individualRepository.findAllByOboIdAndIsDefiningOntology(
+                anyString(), anyString(), any())).thenAnswer(invocation -> page(
+                        invocation.getArgument(2), individual(invocation.getArgument(1))));
+    }
+
+    @Test
+    void returnsDefaultIndividualListContract() throws Exception {
+        mockMvc.perform(get("/api/individuals"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI))
+                .andExpect(jsonPath("$._embedded.individuals[0].label")
+                        .value("Liver specimen alpha"))
+                .andExpect(jsonPath("$._embedded.individuals[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.individuals[0].short_form").value("EFO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[0].obo_id").value("EFO:I100"))
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("en"))
+                .andExpect(jsonPath("$._embedded.individuals[0]._links.self.href")
+                        .value(endsWith("/api/ontologies/efo/individuals/"
+                                + "http%253A%252F%252Fexample.org%252FEFO_I100?lang=en")))
+                .andExpect(jsonPath("$.page.size").value(1000))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.totalPages").value(1))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(individualRepository).findAll("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void bindsLanguagePageSizeAndSort() throws Exception {
+        mockMvc.perform(get("/api/individuals")
+                        .param("lang", "fr")
+                        .param("page", "2")
+                        .param("size", "7")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("fr"));
+
+        verify(individualRepository).findAll(
+                "fr", PageRequest.of(2, 7,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "list, -1, 20, 0, 20",
+            "list, 0, 0, 0, 1000",
+            "list, 0, -1, 0, 1000",
+            "list, 0, 1001, 0, 1000",
+            "path, -1, 20, 0, 20",
+            "path, 0, 0, 0, 1000",
+            "path, 0, 1001, 0, 1000",
+            "defining-list, -1, 20, 0, 20",
+            "defining-list, 0, -1, 0, 1000",
+            "defining-list, 0, 1001, 0, 1000",
+            "defining-path, -1, 20, 0, 20",
+            "defining-path, 0, 0, 0, 1000",
+            "defining-path, 0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundaries(
+            String route,
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "list" -> verify(individualRepository).findAll("en", expected);
+            case "path" -> verify(individualRepository)
+                    .findAllByIri(INDIVIDUAL_IRI, "en", expected);
+            case "defining-list" -> verify(individualRepository)
+                    .findAllByIsDefiningOntology("en", expected);
+            case "defining-path" -> verify(individualRepository)
+                    .findAllByIriAndIsDefiningOntology(INDIVIDUAL_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void usesDefaultsForMalformedNumericPaginationOnEveryRoute() throws Exception {
+        Pageable defaults = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/individuals").param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(INDIVIDUAL_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(DEFINING_INDIVIDUAL_URI)
+                        .param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAll("en", defaults);
+        verify(individualRepository).findAllByIri(INDIVIDUAL_IRI, "en", defaults);
+        verify(individualRepository).findAllByIsDefiningOntology("en", defaults);
+        verify(individualRepository)
+                .findAllByIriAndIsDefiningOntology(INDIVIDUAL_IRI, "en", defaults);
+    }
+
+    @Test
+    void routesIriShortFormAndOboIdParameters() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/individuals").param("iri", INDIVIDUAL_IRI))
+                .andExpect(status().isOk());
+        verify(individualRepository).findAllByIri(INDIVIDUAL_IRI, "en", pageable);
+
+        mockMvc.perform(get("/api/individuals").param("short_form", "EFO_I100"))
+                .andExpect(status().isOk());
+        verify(individualRepository).findAllByShortForm("EFO_I100", "en", pageable);
+
+        mockMvc.perform(get("/api/individuals").param("obo_id", "EFO:I100"))
+                .andExpect(status().isOk());
+        verify(individualRepository).findAllByOboId("EFO:I100", "en", pageable);
+    }
+
+    @Test
+    void appliesIdentifierPrecedence() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/individuals")
+                        .param("iri", INDIVIDUAL_IRI)
+                        .param("short_form", "ignored-short-form")
+                        .param("obo_id", "IGNORED:0000"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAllByIri(INDIVIDUAL_IRI, "en", pageable);
+        verify(individualRepository, never())
+                .findAllByShortForm("ignored-short-form", "en", pageable);
+        verify(individualRepository, never())
+                .findAllByOboId("IGNORED:0000", "en", pageable);
+    }
+
+    @Test
+    void decodesDoubleEncodedIriPathAndForwardsExplicitOptions() throws Exception {
+        mockMvc.perform(get(INDIVIDUAL_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "shortForm,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI));
+
+        verify(individualRepository).findAllByIri(
+                INDIVIDUAL_IRI,
+                "fr",
+                PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.ASC, "shortForm"));
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleParametersForCompatibility() throws Exception {
+        mockMvc.perform(get("/api/individuals")
+                        .param("search", "specimen")
+                        .param("includeObsoleteEntities", "false")
+                        .param("subset", "core", "slim")
+                        .param("http://example.org/category", "clinical", "policy")
+                        .param("domain", "biology,information"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAll("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void returnsDefaultDefiningOntologyListContract() throws Exception {
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].is_defining_ontology")
+                        .value(true))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(individualRepository)
+                .findAllByIsDefiningOntology("en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void routesEveryDefiningOntologyIdentifierParameter() throws Exception {
+        Pageable pageable = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .param("iri", INDIVIDUAL_IRI))
+                .andExpect(status().isOk());
+        verify(individualRepository)
+                .findAllByIriAndIsDefiningOntology(INDIVIDUAL_IRI, "en", pageable);
+
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .param("short_form", "EFO_I100"))
+                .andExpect(status().isOk());
+        verify(individualRepository).findAllByShortFormAndIsDefiningOntology(
+                "EFO_I100", "en", pageable);
+
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .param("obo_id", "EFO:I100"))
+                .andExpect(status().isOk());
+        verify(individualRepository)
+                .findAllByOboIdAndIsDefiningOntology("EFO:I100", "en", pageable);
+    }
+
+    @Test
+    void appliesDefiningOntologyIdentifierPrecedenceAndBindsPagination() throws Exception {
+        Pageable pageable = PageRequest.of(
+                1, 4, org.springframework.data.domain.Sort.Direction.DESC, "shortForm");
+
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .param("iri", INDIVIDUAL_IRI)
+                        .param("short_form", "ignored-short-form")
+                        .param("obo_id", "IGNORED:0000")
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "4")
+                        .param("sort", "shortForm,desc"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository)
+                .findAllByIriAndIsDefiningOntology(INDIVIDUAL_IRI, "fr", pageable);
+        verify(individualRepository, never()).findAllByShortFormAndIsDefiningOntology(
+                "ignored-short-form", "fr", pageable);
+        verify(individualRepository, never())
+                .findAllByOboIdAndIsDefiningOntology("IGNORED:0000", "fr", pageable);
+    }
+
+    @Test
+    void definingOntologyPathDecodesIriAndBindsAllOptions() throws Exception {
+        mockMvc.perform(get(DEFINING_INDIVIDUAL_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("fr"));
+
+        verify(individualRepository).findAllByIriAndIsDefiningOntology(
+                INDIVIDUAL_IRI,
+                "fr",
+                PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void supportsLegacyHalMediaTypeOnEveryRoute() throws Exception {
+        mockMvc.perform(get("/api/individuals").accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(INDIVIDUAL_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get("/api/individuals/findByIdAndIsDefiningOntology")
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(DEFINING_INDIVIDUAL_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageCompatibility() throws Exception {
+        mockMvc.perform(get("/api/individuals").param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("en_US"));
+
+        verify(individualRepository).findAll("en_US", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void returnsStableBadRequestFieldsForUnsupportedSort() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(individualRepository.findAll("en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get("/api/individuals").param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
+    void returnsStableLegacyNotFoundStatusAndMessage() throws Exception {
+        when(individualRepository.findAll("en", PageRequest.of(0, 1000)))
+                .thenThrow(new org.springframework.data.rest.webmvc.ResourceNotFoundException());
+
+        mockMvc.perform(get("/api/individuals"))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
+        mockMvc.perform(post("/api/individuals"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private static URI route(String route) {
+        return switch (route) {
+            case "list" -> URI.create("/api/individuals");
+            case "path" -> INDIVIDUAL_URI;
+            case "defining-list" -> URI.create(
+                    "/api/individuals/findByIdAndIsDefiningOntology");
+            case "defining-path" -> DEFINING_INDIVIDUAL_URI;
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        };
+    }
+
+    private static OlsFacetedResultsPage<V1Individual> page(
+            Pageable pageable,
+            V1Individual... individuals) {
+        return new OlsFacetedResultsPage<>(
+                List.of(individuals), Map.of(), pageable, individuals.length);
+    }
+
+    private static V1Individual individual(String lang) {
+        V1Individual individual = new V1Individual();
+        individual.iri = INDIVIDUAL_IRI;
+        individual.lang = lang;
+        individual.label = "Liver specimen alpha";
+        individual.description = new String[]{
+                "An individual example assigned to the liver disease class."};
+        individual.synonyms = new String[]{"Clinical liver sample"};
+        individual.ontologyName = "efo";
+        individual.ontologyPrefix = "EFO";
+        individual.ontologyIri = "http://www.ebi.ac.uk/efo";
+        individual.isObsolete = false;
+        individual.isLocal = true;
+        individual.hasChildren = false;
+        individual.isRoot = true;
+        individual.shortForm = "EFO_I100";
+        individual.oboId = "EFO:I100";
+        individual.inSubsets = List.of("individuals");
+        individual.annotation = Map.of();
+        return individual;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1IndividualRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1IndividualRepositoryIT.java
@@ -1,0 +1,149 @@
+package uk.ac.ebi.spot.ols.repository.v1;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Testcontainers
+class V1IndividualRepositoryIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1IndividualRepositoryHandle repositoryHandle;
+    private static V1IndividualRepository repository;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createV1IndividualRepository(POSTGRES);
+        repository = repositoryHandle.repository();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsIndividualsInStableOrderAndMapsPublicFlags() {
+        Page<V1Individual> page = repository.findAll("en", PageRequest.of(0, 20));
+
+        assertThat(page).extracting(individual -> individual.iri).containsExactly(
+                "http://example.org/DUO_I100",
+                "http://example.org/EFO_I100",
+                "http://example.org/EFO_I200",
+                "http://example.org/EFO_I999");
+        assertThat(page.getTotalElements()).isEqualTo(4);
+        assertThat(page.getContent().get(1).label).isEqualTo("Liver specimen alpha");
+        assertThat(page.getContent().get(1).isLocal).isTrue();
+        assertThat(page.getContent().get(1).isObsolete).isFalse();
+        assertThat(page.getContent().get(2).isLocal).isFalse();
+        assertThat(page.getContent().get(3).isObsolete).isTrue();
+    }
+
+    @Test
+    void appliesPaginationAndSupportedSorting() {
+        Page<V1Individual> secondPage = repository.findAll("en", PageRequest.of(1, 2));
+        Page<V1Individual> descending = repository.findAll(
+                "en",
+                PageRequest.of(0, 20, Sort.by(Sort.Direction.DESC, "iri")));
+
+        assertThat(secondPage).extracting(individual -> individual.iri).containsExactly(
+                "http://example.org/EFO_I200",
+                "http://example.org/EFO_I999");
+        assertThat(secondPage.getTotalElements()).isEqualTo(4);
+        assertThat(secondPage.getTotalPages()).isEqualTo(2);
+        assertThat(descending).extracting(individual -> individual.iri).containsExactly(
+                "http://example.org/EFO_I999",
+                "http://example.org/EFO_I200",
+                "http://example.org/EFO_I100",
+                "http://example.org/DUO_I100");
+    }
+
+    @Test
+    void rejectsUnsupportedSortFields() {
+        assertThatThrownBy(() -> repository.findAll(
+                "en", PageRequest.of(0, 20, Sort.by("notARealField"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Unsupported sort field");
+    }
+
+    @Test
+    void findsIndividualsByIriShortFormAndOboId() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIri(
+                "http://example.org/EFO_I100", "fr", pageable))
+                .singleElement()
+                .satisfies(individual -> {
+                    assertThat(individual.label).isEqualTo("Liver specimen alpha");
+                    assertThat(individual.lang).isEqualTo("fr");
+                    assertThat(individual.isLocal).isTrue();
+                    assertThat(individual.isObsolete).isFalse();
+                    assertThat(individual.description).containsExactly(
+                            "An individual example assigned to the liver disease class.");
+                });
+        assertThat(repository.findAllByShortForm("EFO_I100", "en", pageable))
+                .extracting(individual -> individual.iri)
+                .containsExactly("http://example.org/EFO_I100");
+        assertThat(repository.findAllByOboId("EFO:I100", "en", pageable))
+                .extracting(individual -> individual.iri)
+                .containsExactly("http://example.org/EFO_I100");
+    }
+
+    @Test
+    void returnsEmptyPagesForUnknownIdentifiers() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIri("http://example.org/missing", "en", pageable))
+                .isEmpty();
+        assertThat(repository.findAllByShortForm("MISSING", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboId("MISSING:0000", "en", pageable)).isEmpty();
+    }
+
+    @Test
+    void restrictsEveryIdentifierRepresentationToDefiningOntologies() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByIsDefiningOntology("en", pageable))
+                .allSatisfy(individual -> assertThat(individual.isLocal).isTrue())
+                .extracting(individual -> individual.iri)
+                .containsExactly(
+                        "http://example.org/DUO_I100",
+                        "http://example.org/EFO_I100",
+                        "http://example.org/EFO_I999");
+        assertThat(repository.findAllByIriAndIsDefiningOntology(
+                "http://example.org/EFO_I200", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByShortFormAndIsDefiningOntology(
+                "EFO_I200", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboIdAndIsDefiningOntology(
+                "EFO:I200", "en", pageable)).isEmpty();
+        assertThat(repository.findAllByOboIdAndIsDefiningOntology(
+                "EFO:I100", "en", pageable))
+                .extracting(individual -> individual.iri)
+                .containsExactly("http://example.org/EFO_I100");
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageWithLabelFallback() {
+        Page<V1Individual> page = repository.findAll("en_US", PageRequest.of(0, 1));
+
+        assertThat(page).singleElement().satisfies(individual -> {
+            assertThat(individual.lang).isEqualTo("en_US");
+            assertThat(individual.label).isEqualTo("Permission instance");
+        });
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.spot.ols.repository.OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
 import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
@@ -184,6 +185,16 @@ public final class PostgresIntegrationTestSupport {
         ReflectionTestUtils.setField(repository, "searchClient", searchClient);
         ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
         return new IndividualRepositoryHandle(repository, postgresClient);
+    }
+
+    public static V1IndividualRepositoryHandle createV1IndividualRepository(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        V1IndividualRepository repository = new V1IndividualRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        return new V1IndividualRepositoryHandle(repository, postgresClient);
     }
 
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
@@ -589,6 +600,16 @@ public final class PostgresIntegrationTestSupport {
 
     public record IndividualRepositoryHandle(
             IndividualRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record V1IndividualRepositoryHandle(
+            V1IndividualRepository repository,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/backend/src/test/resources/fixtures/individuals/README.md
+++ b/backend/src/test/resources/fixtures/individuals/README.md
@@ -1,7 +1,7 @@
 # Individual integration fixture
 
-This four-record synthetic supplement is loaded only by the V2 individual suites. It keeps the
-shared entity fixture totals unchanged while covering global and ontology-scoped individual
+This four-record synthetic supplement is loaded only by the V1 and V2 individual suites. It keeps
+the shared entity fixture totals unchanged while covering global and ontology-scoped individual
 search, obsolete filtering, pagination, dynamic properties, lookup by IRI, and class membership.
 
 - Two active EFO individuals distinguish defining status, search fields, ranking, filters, and

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -400,6 +400,30 @@ Verified locally on 2026-08-27 with Java 17 and Rancher Desktop:
   fix merged in PR #1375; its focused regressions and the broader repository/controller suites now
   preserve default exclusion and explicit opt-in.
 
+## Implemented V1 individual-controller baseline
+
+Verified locally on 2026-08-27 with Java 17 and Rancher Desktop:
+
+- Surefire runs 576 tests, including 8 direct `V1IndividualControllerTest` cases and 29
+  `V1IndividualControllerWIT` invocations. Two runs with a deliberately unavailable Docker socket
+  took approximately 19.1 and 18.7 seconds.
+- Failsafe runs 116 PostgreSQL tests, including 7 `V1IndividualRepositoryIT` cases and 4 thin
+  `V1IndividualControllerIT` cases. Two complete database-gate runs took approximately 1 minute 4
+  seconds and 1 minute 2 seconds.
+- The clean `verify` lifecycle runs all 692 tests in approximately 1 minute 12 seconds.
+- Whole-backend JaCoCo coverage is 35.8% lines and 25.9% branches, up from the measured merged
+  prerequisite baseline of 34.1% lines and 25.3% branches. The V1 individual controller covers all
+  28 lines and all 12 branches; its repository covers 43 of 76 lines, including every finder used
+  by the controller's four routes. No coverage failure threshold is introduced.
+- V1 compatibility retains its 1000-item default page size, arbitrary language identifiers with
+  value fallback, identifier precedence, double-encoded IRI paths, legacy HAL responses, and
+  servlet-style 404 reason. The suites reuse the four-record individual fixture without changing
+  shared fixture totals.
+- The rollout exposed that `V1IndividualMapper` omitted the public `is_obsolete` and
+  `is_defining_ontology` flags. The minimal production fix merged in PR #1377 with a focused mapper
+  regression and the two affected expected API responses; the repository and thin controller ITs
+  now assert both values through the real PostgreSQL-to-HTTP path.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Why this controller

V1IndividualController is the legacy counterpart to the newly covered V2 individual API. Its four routes combine identifier precedence, double-encoded IRI paths, defining-ontology filtering, HAL pagination, arbitrary language compatibility, and servlet-style errors. The existing four-record individual fixture makes those contracts independently testable through disposable PostgreSQL without stacking on open work.

## What this adds

- 8 direct controller tests for controller-owned routing and link decisions
- 29 exactly named V1IndividualControllerWIT invocations covering all four routes, supported identifiers and options, defaults, malformed and boundary pagination, reserved/dynamic-style parameters, HAL, encoded IRIs, and stable errors
- 7 V1IndividualRepositoryIT tests against the production schema and synthetic individual fixture
- 4 thin V1IndividualControllerIT tests through the real PostgreSQL-to-HTTP path
- measured testing-strategy baseline and reusable V1 repository test support

The rollout exposed missing public status flags in V1IndividualMapper. That production defect was fixed separately and merged in #1377 before this branch was rebased onto dev.

## Verification

Java 17 with Rancher Desktop:

- Docker unavailable: 576 fast tests twice; Maven 19.149s and 18.659s
- PostgreSQL gate: 116 tests twice; Maven 1m04s and 1m02s
- clean verify: 692 tests; Maven 1m12s
- JaCoCo: 35.8% lines / 25.9% branches, from a measured 34.1% / 25.3% prerequisite baseline
- V1IndividualController: 28/28 lines, 12/12 branches
- V1IndividualRepository: 43/76 lines

`test_api.sh` is unchanged.