### PR TITLE
test: cover V2 statistics controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerIT.java
@@ -1,0 +1,58 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V2StatisticsControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+
+        V2StatisticsController controller = new V2StatisticsController();
+        controller.searchClient = searchClientHandle.searchClient();
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void returnsStatisticsThroughTheControllerAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/v2/stats"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.lastModified").value("2026-08-25T00:00:00Z"))
+                .andExpect(jsonPath("$.numberOfOntologies").value(4))
+                .andExpect(jsonPath("$.numberOfClasses").value(4))
+                .andExpect(jsonPath("$.numberOfIndividuals").value(0))
+                .andExpect(jsonPath("$.numberOfProperties").value(1));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerTest.java
@@ -1,0 +1,68 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import uk.ac.ebi.spot.ols.model.v2.V2Statistics;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V2StatisticsControllerTest {
+
+    private static final String LAST_MODIFIED = "2026-08-25T00:00:00Z";
+
+    private OlsSearchClient searchClient;
+    private V2StatisticsController controller;
+
+    @BeforeEach
+    void setUp() {
+        searchClient = mock(OlsSearchClient.class);
+        controller = new V2StatisticsController();
+        controller.searchClient = searchClient;
+    }
+
+    @Test
+    void mapsSearchClientCountsIntoTheStatisticsResponse() throws Exception {
+        when(searchClient.getLastModified()).thenReturn(LAST_MODIFIED);
+        when(searchClient.getCountsByField("type")).thenReturn(Map.of(
+                "ontology", 4L,
+                "class", 4L,
+                "individual", 2L,
+                "property", 1L));
+
+        var response = controller.getStatistics();
+        V2Statistics statistics = response.getBody();
+
+        assertNotNull(statistics);
+        assertEquals(HttpStatus.OK,
+                ((org.springframework.http.ResponseEntity<?>) response).getStatusCode());
+        assertEquals(LAST_MODIFIED, statistics.lastModified);
+        assertEquals(4, statistics.numberOfOntologies);
+        assertEquals(4, statistics.numberOfClasses);
+        assertEquals(2, statistics.numberOfIndividuals);
+        assertEquals(1, statistics.numberOfProperties);
+        verify(searchClient).getLastModified();
+        verify(searchClient).getCountsByField("type");
+    }
+
+    @Test
+    void defaultsMissingEntityTypeCountsToZero() throws Exception {
+        when(searchClient.getLastModified()).thenReturn(LAST_MODIFIED);
+        when(searchClient.getCountsByField("type")).thenReturn(Map.of("class", 4L));
+
+        V2Statistics statistics = controller.getStatistics().getBody();
+
+        assertNotNull(statistics);
+        assertEquals(0, statistics.numberOfOntologies);
+        assertEquals(4, statistics.numberOfClasses);
+        assertEquals(0, statistics.numberOfIndividuals);
+        assertEquals(0, statistics.numberOfProperties);
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2StatisticsControllerWIT.java
@@ -1,0 +1,76 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.beans.factory.annotation.Autowired;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V2StatisticsController.class)
+@ContextConfiguration(classes = {
+        V2StatisticsController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V2StatisticsControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OlsSearchClient searchClient;
+
+    @BeforeEach
+    void stubStatistics() {
+        when(searchClient.getLastModified()).thenReturn("2026-08-25T00:00:00Z");
+        when(searchClient.getCountsByField("type")).thenReturn(Map.of(
+                "ontology", 4L,
+                "class", 4L,
+                "individual", 2L,
+                "property", 1L));
+    }
+
+    @Test
+    void returnsTheStatisticsContract() throws Exception {
+        mockMvc.perform(get("/api/v2/stats"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.lastModified").value("2026-08-25T00:00:00Z"))
+                .andExpect(jsonPath("$.numberOfOntologies").value(4))
+                .andExpect(jsonPath("$.numberOfClasses").value(4))
+                .andExpect(jsonPath("$.numberOfIndividuals").value(2))
+                .andExpect(jsonPath("$.numberOfProperties").value(1));
+    }
+
+    @Test
+    void supportsTheDeclaredHalMediaType() throws Exception {
+        mockMvc.perform(get("/api/v2/stats").accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON))
+                .andExpect(jsonPath("$.numberOfOntologies").value(4));
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/v2/stats"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientStatisticsIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientStatisticsIT.java
@@ -1,0 +1,52 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class OlsSearchClientStatisticsIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static OlsSearchClient searchClient;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+        searchClient = searchClientHandle.searchClient();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void countsEntitiesBySearchTypeThroughPostgres() {
+        Map<String, Long> counts = searchClient.getCountsByField("type");
+
+        assertThat(counts)
+                .containsEntry("ontology", 4L)
+                .containsEntry("class", 4L)
+                .containsEntry("property", 1L)
+                .doesNotContainKey("individual");
+    }
+
+    @Test
+    void returnsTheMostRecentOntologyLoadDateFromPostgres() {
+        assertThat(searchClient.getLastModified()).isEqualTo("2026-08-25T00:00:00Z");
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -112,6 +112,11 @@ public final class PostgresIntegrationTestSupport {
         return new V1RepositoryHandle(repository, postgresClient);
     }
 
+    public static SearchClientHandle createSearchClient(PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        return new SearchClientHandle(createSearchClient(postgresClient), postgresClient);
+    }
+
     public static EntityRepositoryHandle createEntityRepository(PostgreSQLContainer<?> container) {
         PostgresClient postgresClient = createPostgresClient(container);
         OlsSearchClient searchClient = createSearchClient(postgresClient);
@@ -266,7 +271,7 @@ public final class PostgresIntegrationTestSupport {
                     id, type, iri, ontology_id, _json, is_obsolete, label, definition,
                     search_type, is_defining_ontology, filter_tags, filter_domain,
                     "filter_http://example.org/category")
-                VALUES (?, 'ontology', ?, ?, ?, ?, ?, ?, 'ontology', TRUE, ?, ?, ?)
+                VALUES (?, 'Ontology', ?, ?, ?, ?, ?, ?, 'ontology', TRUE, ?, ?, ?)
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (JsonElement element : fixture.getAsJsonArray("records")) {
@@ -540,6 +545,16 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1RepositoryHandle(
             V1OntologyRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record SearchClientHandle(
+            OlsSearchClient searchClient,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/backend/src/test/resources/fixtures/ontologies/README.md
+++ b/backend/src/test/resources/fixtures/ontologies/README.md
@@ -9,6 +9,7 @@ production snapshot.
   filters.
 - `duo` provides distinct information-domain and data-use search terms.
 - `legacy-efo` is deliberately obsolete.
+- `efo` has the latest load timestamp so statistics tests cover selecting the most recent load.
 
 The wrapper fields map directly to PostgreSQL search/filter columns. The nested `json` object is
 the compressed API document returned by the repository. It also carries the small stable V1

--- a/backend/src/test/resources/fixtures/ontologies/ontology-fixture.json
+++ b/backend/src/test/resources/fixtures/ontologies/ontology-fixture.json
@@ -18,7 +18,7 @@
         "description": "An ontology for variables in biomedical studies.",
         "preferredPrefix": "EFO",
         "language": ["en"],
-        "loaded": "2026-08-24T00:00:00Z",
+        "loaded": "2026-08-25T00:00:00Z",
         "numberOfClasses": "100",
         "numberOfProperties": "12",
         "numberOfIndividuals": "3",

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -424,6 +424,24 @@ Verified locally on 2026-08-27 with Java 17 and Rancher Desktop:
   regression and the two affected expected API responses; the repository and thin controller ITs
   now assert both values through the real PostgreSQL-to-HTTP path.
 
+## Implemented V2 statistics-controller baseline
+
+Verified locally on 2026-09-01 with Java 17 and Rancher Desktop:
+
+- Surefire runs 584 tests, including 2 direct `V2StatisticsControllerTest` cases and 3
+  `V2StatisticsControllerWIT` cases. Two Docker-free runs took Maven 20.041 and 20.215 seconds
+  (wall-clock 21.09 and 21.03 seconds).
+- Failsafe runs 119 PostgreSQL tests, including 2 `OlsSearchClientStatisticsIT` cases and 1 thin
+  `V2StatisticsControllerIT` case. Two complete database-gate runs took Maven 68 and 71 seconds
+  (wall-clock 69.68 and 72.66 seconds).
+- The clean `verify` lifecycle runs all 703 tests in Maven 82 seconds (wall-clock 83.82 seconds).
+- Whole-backend JaCoCo coverage is 37.0% lines and 27.3% branches. The
+  `V2StatisticsController` covers all 10 of its executable lines. No coverage failure threshold
+  is introduced.
+- The statistics tests use the shared four-record ontology/entity fixture. Its ontology loader
+  stores the production database type literal and includes a later EFO load timestamp so the
+  PostgreSQL search tests exercise type counts and most-recent-load selection deterministically.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary\n\n- add direct, Spring MVC contract, PostgreSQL repository, and thin controller coverage for GET /api/v2/stats\n- exercise JSON and HAL responses plus unsupported-method handling\n- record the measured backend testing baseline\n\n## Verification\n\n- Java 17\n- Surefire: 584 tests, twice Docker-free\n- Failsafe: 119 PostgreSQL tests, twice\n- clean verify: 703 tests\n- JaCoCo: 37.0% lines, 27.3% branches\n\nNo production code or test_api.sh changed.