### PR TITLE
fix: preserve V1 suggest start offset

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestController.java
@@ -57,7 +57,7 @@ public class V1SuggestController {
 
         Map<String, Object> responseBody = new HashMap<>();
         responseBody.put("numFound", labels.size());
-        responseBody.put("start", 0);
+        responseBody.put("start", start);
         responseBody.put("docs", docs);
 
         Map<String, Object> responseObj = new HashMap<>();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerPaginationTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerPaginationTest.java
@@ -1,0 +1,31 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class V1SuggestControllerPaginationTest {
+
+    @Test
+    void returnsTheRequestedStartOffsetInTheLegacyResponse() throws Exception {
+        OlsSearchClient searchClient = mock(OlsSearchClient.class);
+        when(searchClient.suggestLabels("liv", null, 2, 2)).thenReturn(List.of());
+
+        V1SuggestController controller = new V1SuggestController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.suggest("LIV", null, 2, 2, response);
+
+        assertEquals(2, JsonParser.parseString(response.getContentAsString())
+                .getAsJsonObject().getAsJsonObject("response").get("start").getAsInt());
+    }
+}


### PR DESCRIPTION
V1 /api/suggest applies the requested start offset in OlsSearchClient but always serialized response.start as 0. This minimal fix returns the actual start value and adds a focused regression test. Discovered while beginning the layered V1SuggestController coverage milestone; no testing-framework or unrelated production changes included.