### PR TITLE
fix: explain invalid ontology ids

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/Validation.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/Validation.java
@@ -14,7 +14,7 @@ public class Validation {
     public static void validateOntologyId(String ontologyId) {
 
         if (!ontologyId.matches("^[-A-Za-z0-9_.]+$"))
-            throw new IllegalArgumentException();
+            throw new IllegalArgumentException("Invalid ontology ID: " + ontologyId);
 
     }
 

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ValidationTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ValidationTest.java
@@ -1,0 +1,18 @@
+package uk.ac.ebi.spot.ols.repository;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ValidationTest {
+
+    @Test
+    void reportsTheInvalidOntologyId() {
+        IllegalArgumentException exception = assertThrows(
+                IllegalArgumentException.class,
+                () -> Validation.validateOntologyId("efo/unsafe"));
+
+        assertEquals("Invalid ontology ID: efo/unsafe", exception.getMessage());
+    }
+}


### PR DESCRIPTION
## Summary

- include the rejected ontology ID in the IllegalArgumentException raised by Validation.validateOntologyId
- add a focused regression test for the error message

This is intentionally separate from the V1 suggest controller testing PR because it changes shared production validation behavior.