### PR TITLE
test: cover v1 suggest controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerIT.java
@@ -1,0 +1,60 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1SuggestControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+
+        V1SuggestController controller = new V1SuggestController();
+        org.springframework.test.util.ReflectionTestUtils.setField(
+                controller, "searchClient", searchClientHandle.searchClient());
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void returnsSuggestionsThroughTheControllerAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/suggest")
+                        .param("q", "LIVER")
+                        .param("start", "1")
+                        .param("rows", "1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.response.numFound").value(1))
+                .andExpect(jsonPath("$.response.start").value(1))
+                .andExpect(jsonPath("$.response.docs[0].autosuggest").value("Liver disease"));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerTest.java
@@ -1,0 +1,63 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class V1SuggestControllerTest {
+
+    private OlsSearchClient searchClient;
+    private V1SuggestController controller;
+
+    @BeforeEach
+    void setUp() {
+        searchClient = mock(OlsSearchClient.class);
+        controller = new V1SuggestController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+    }
+
+    @Test
+    void lowercasesAndForwardsSuggestionArgumentsAndRendersTheLegacyEnvelope() throws Exception {
+        List<String> labels = List.of("Liver disease", "Liver ailment");
+        when(searchClient.suggestLabels("liv", List.of("efo", "duo"), 2, 2))
+                .thenReturn(labels);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.suggest("LIV", List.of("efo", "duo"), 2, 2, response);
+
+        verify(searchClient).suggestLabels("liv", List.of("efo", "duo"), 2, 2);
+        JsonObject body = JsonParser.parseString(response.getContentAsString()).getAsJsonObject();
+        assertEquals(0, body.getAsJsonObject("responseHeader").get("status").getAsInt());
+        assertEquals(2, body.getAsJsonObject("response").get("numFound").getAsInt());
+        assertEquals(2, body.getAsJsonObject("response").get("start").getAsInt());
+        assertEquals("Liver disease",
+                body.getAsJsonObject("response").getAsJsonArray("docs")
+                        .get(0).getAsJsonObject().get("autosuggest").getAsString());
+        assertEquals("Liver ailment",
+                body.getAsJsonObject("response").getAsJsonArray("docs")
+                        .get(1).getAsJsonObject().get("autosuggest").getAsString());
+    }
+
+    @Test
+    void rejectsInvalidOntologyIdsBeforeCallingTheSearchClient() {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        assertThrows(IllegalArgumentException.class,
+                () -> controller.suggest("liv", List.of("efo/unsafe"), 0, 10, response));
+
+        verifyNoInteractions(searchClient);
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SuggestControllerWIT.java
@@ -1,0 +1,152 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1SuggestController.class)
+@ContextConfiguration(classes = {
+        V1SuggestController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1SuggestControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OlsSearchClient searchClient;
+
+    @BeforeEach
+    void stubSuggestions() {
+        when(searchClient.suggestLabels("liver", null, 0, 10))
+                .thenReturn(List.of("Liver disease", "Liver ailment"));
+        when(searchClient.suggestLabels("liv", List.of("efo", "duo"), 0, 10))
+                .thenReturn(List.of("Liver disease"));
+        when(searchClient.suggestLabels("liv", List.of("efo", "duo"), 2, 1))
+                .thenReturn(List.of("Liver disease"));
+    }
+
+    @Test
+    void returnsTheDefaultLegacySuggestionContract() throws Exception {
+        mockMvc.perform(get("/api/suggest").param("q", "LIVER"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.responseHeader.status").value(0))
+                .andExpect(jsonPath("$.responseHeader.QTime").value(0))
+                .andExpect(jsonPath("$.response.numFound").value(2))
+                .andExpect(jsonPath("$.response.start").value(0))
+                .andExpect(jsonPath("$.response.docs[0].autosuggest").value("Liver disease"))
+                .andExpect(jsonPath("$.response.docs[1].autosuggest").value("Liver ailment"));
+
+        verify(searchClient).suggestLabels("liver", null, 0, 10);
+    }
+
+    @Test
+    void bindsRepeatedOntologyValuesAndPaginationAndReturnsTheRequestedStart() throws Exception {
+        mockMvc.perform(get("/api/suggest")
+                        .param("q", "LIV")
+                        .param("ontology", "efo", "duo")
+                        .param("start", "2")
+                        .param("rows", "1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.response.numFound").value(1))
+                .andExpect(jsonPath("$.response.start").value(2))
+                .andExpect(jsonPath("$.response.docs[0].autosuggest").value("Liver disease"));
+
+        verify(searchClient).suggestLabels("liv", List.of("efo", "duo"), 2, 1);
+    }
+
+    @Test
+    void bindsCommaSeparatedOntologyValues() throws Exception {
+        mockMvc.perform(get("/api/suggest")
+                        .param("q", "LIV")
+                        .param("ontology", "efo,duo"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.docs[0].autosuggest").value("Liver disease"));
+
+        verify(searchClient).suggestLabels("liv", List.of("efo", "duo"), 0, 10);
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleParametersForCompatibility() throws Exception {
+        mockMvc.perform(get("/api/suggest")
+                        .param("q", "LIVER")
+                        .param("exactMatch", "false")
+                        .param("includeObsoleteEntities", "false"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.response.numFound").value(2))
+                .andExpect(jsonPath("$.response.docs[0].autosuggest").value("Liver disease"));
+
+        verify(searchClient).suggestLabels("liver", null, 0, 10);
+    }
+
+    @Test
+    void rejectsMalformedOntologyIdsWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/suggest")
+                        .param("q", "liv")
+                        .param("ontology", "efo/unsafe"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+
+        verifyNoInteractions(searchClient);
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "rows, not-a-number",
+            "start, not-a-number"
+    })
+    void rejectsMalformedPaginationValuesWithStableErrorFields(String parameter, String value)
+            throws Exception {
+        mockMvc.perform(get("/api/suggest").param("q", "liv").param(parameter, value))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void rejectsMissingRequiredQueryWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/suggest"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/suggest"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSuggestIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSuggestIT.java
@@ -1,0 +1,52 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class OlsSearchClientSuggestIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static OlsSearchClient searchClient;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+        searchClient = searchClientHandle.searchClient();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void searchesLabelsAndAppliesTheRequestedPageWindow() {
+        assertThat(searchClient.suggestLabels("liver", null, 0, 10))
+                .containsExactly("Liver ailment", "Liver disease");
+        assertThat(searchClient.suggestLabels("liver", null, 1, 1))
+                .containsExactly("Liver disease");
+    }
+
+    @Test
+    void searchesSynonymsAndRestrictsResultsToTheRequestedOntology() {
+        assertThat(searchClient.suggestLabels("hepatic disorder", List.of("efo"), 0, 10))
+                .containsExactly("Hepatic disorder");
+        assertThat(searchClient.suggestLabels("legacy liver concept", List.of("efo"), 0, 10))
+                .containsExactly("Legacy liver concept");
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -30,7 +30,9 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.zip.GZIPOutputStream;
 
 public final class PostgresIntegrationTestSupport {
@@ -58,6 +60,7 @@ public final class PostgresIntegrationTestSupport {
             executeProductionSchema(connection);
             loadOntologyFixture(connection);
             loadEntityFixture(connection);
+            loadAutosuggestFixture(connection);
         } catch (IOException | InterruptedException | SQLException e) {
             throw new IllegalStateException("Failed to initialize the disposable OLS PostgreSQL database", e);
         }
@@ -344,6 +347,52 @@ public final class PostgresIntegrationTestSupport {
         }
         try (Statement statement = connection.createStatement()) {
             statement.execute("ANALYZE ols_entities");
+        }
+    }
+
+    private static void loadAutosuggestFixture(Connection connection) throws IOException, SQLException {
+        String sql = "INSERT INTO ols_autosuggest (ontology_id, string) VALUES (?, ?)";
+        try (PreparedStatement statement = connection.prepareStatement(sql)) {
+            addAutosuggestRecords(statement, "/fixtures/ontologies/ontology-fixture.json");
+            addAutosuggestRecords(statement, "/fixtures/entities/entity-fixture.json");
+            statement.executeBatch();
+        }
+        try (Statement statement = connection.createStatement()) {
+            statement.execute("ANALYZE ols_autosuggest");
+        }
+    }
+
+    private static void addAutosuggestRecords(PreparedStatement statement, String resource)
+            throws IOException, SQLException {
+        JsonObject fixture;
+        try (InputStream stream = PostgresIntegrationTestSupport.class.getResourceAsStream(resource)) {
+            if (stream == null) {
+                throw new IllegalStateException("Autosuggest integration fixture is missing: " + resource);
+            }
+            fixture = JsonParser.parseReader(
+                    new java.io.InputStreamReader(stream, StandardCharsets.UTF_8)).getAsJsonObject();
+        }
+
+        for (JsonElement element : fixture.getAsJsonArray("records")) {
+            JsonObject record = element.getAsJsonObject();
+            Set<String> values = new HashSet<>();
+            addAutosuggestValues(record.getAsJsonArray("label"), values);
+            if (record.has("synonym")) {
+                addAutosuggestValues(record.getAsJsonArray("synonym"), values);
+            }
+            for (String value : values) {
+                if (!value.isEmpty()) {
+                    statement.setString(1, record.get("ontologyId").getAsString());
+                    statement.setString(2, value);
+                    statement.addBatch();
+                }
+            }
+        }
+    }
+
+    private static void addAutosuggestValues(JsonArray values, Set<String> destination) {
+        for (JsonElement value : values) {
+            destination.add(value.getAsString());
         }
     }
 

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -442,6 +442,30 @@ Verified locally on 2026-09-01 with Java 17 and Rancher Desktop:
   stores the production database type literal and includes a later EFO load timestamp so the
   PostgreSQL search tests exercise type counts and most-recent-load selection deterministically.
 
+## Implemented V1 suggest-controller baseline
+
+Verified locally on 2026-09-01 with Java 17 and Rancher Desktop:
+
+- Surefire runs 597 tests, including 2 direct `V1SuggestControllerTest` cases, 9
+  `V1SuggestControllerWIT` invocations, and the two focused regression tests merged with PRs
+  #1381 and #1382. Two Docker-free runs took Maven 19.153 and 18.993 seconds.
+- Failsafe runs 122 PostgreSQL tests, including 2 `OlsSearchClientSuggestIT` cases and 1 thin
+  `V1SuggestControllerIT` case. Two complete database-gate runs took 75.74 and 76.75 seconds
+  wall-clock.
+- The clean `verify` lifecycle runs all 719 tests in 87.28 seconds wall-clock.
+- Whole-backend JaCoCo coverage is 38.5% lines (1,837 of 4,768) and 28.2% branches (539 of
+  1,908). The V1 suggest controller covers all 2 executable lines and 8 branches. No coverage
+  failure threshold is introduced.
+- The suggest tests add production-shaped autosuggest rows to the shared synthetic fixture,
+  covering labels, synonyms, ontology restriction, deterministic ranking, and pagination through
+  the real PostgreSQL search client. The WIT suite preserves the legacy JSON envelope and
+  exercises defaults, typed failures, repeated and comma-separated ontology values, and frontend
+  compatibility parameters.
+- The rollout exposed two defects in the legacy suggest route. PR #1381 preserves the requested
+  `start` offset in the response, and PR #1382 gives malformed ontology IDs a stable error
+  message. Both fixes were isolated, merged, and covered by focused regressions before this test
+  branch was rebased.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary
- add layered coverage for the public V1 `/api/suggest` route
- exercise real PostgreSQL autosuggest labels, synonyms, ontology restriction, ranking, and pagination
- preserve the legacy response envelope and document the measured baseline

## Coverage
- 2 direct controller unit tests
- 9 `V1SuggestControllerWIT` contract invocations
- 2 `OlsSearchClientSuggestIT` PostgreSQL cases
- 1 thin `V1SuggestControllerIT` PostgreSQL-backed route case

## Related defects
- PR #1381 fixes the requested pagination offset in the response
- PR #1382 gives malformed ontology IDs a stable validation message

Both defects were isolated, merged into `dev`, and covered by focused regressions before this branch was rebased. No production code is changed in this PR. `test_api.sh` is unchanged and was not run locally.