### PR TITLE
Fix inclusive V1 hierarchy search

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchController.java
@@ -162,16 +162,22 @@ public class V1SearchController {
 
         if (childrenOf != null) {
             if (inclusive) {
-                // inclusive: also include the parent itself — filter by iri OR hierarchicalAncestor
-                // Handled by adding both iri and ancestor as possible matches
-                searchQuery.addFilter("hierarchicalAncestor", childrenOf, SearchType.WHOLE_FIELD);
+                searchQuery.addAnyFilter(Map.of(
+                        "iri", childrenOf,
+                        "hierarchicalAncestor", childrenOf), SearchType.WHOLE_FIELD);
             } else {
                 searchQuery.addFilter("hierarchicalAncestor", childrenOf, SearchType.WHOLE_FIELD);
             }
         }
 
         if (allChildrenOf != null) {
-            searchQuery.addFilter("hierarchicalAncestor", allChildrenOf, SearchType.WHOLE_FIELD);
+            if (inclusive) {
+                searchQuery.addAnyFilter(Map.of(
+                        "iri", allChildrenOf,
+                        "hierarchicalAncestor", allChildrenOf), SearchType.WHOLE_FIELD);
+            } else {
+                searchQuery.addFilter("hierarchicalAncestor", allChildrenOf, SearchType.WHOLE_FIELD);
+            }
         }
 
         searchQuery.addFilter("isObsolete", List.of(Boolean.toString(queryObsoletes)), SearchType.WHOLE_FIELD);

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQuery.java
@@ -32,6 +32,7 @@ public class OlsSearchQuery {
     String searchText = null;
     boolean exactMatch = false;
     List<SearchFilter> filters = new ArrayList<>();
+    List<List<SearchFilter>> anyFilterGroups = new ArrayList<>();
     List<SearchFilter> excludeFilters = new ArrayList<>();
     List<String> facetFields = new ArrayList<>();
     List<String> searchFields = null;
@@ -89,6 +90,19 @@ public class OlsSearchQuery {
 
     public void addFilter(String propertyName, Collection<String> propertyValues, SearchType searchType) {
         this.filters.add(new SearchFilter(propertyName, propertyValues, false, searchType));
+    }
+
+    /**
+     * Add a group of alternative filters. The group is ANDed with the rest of the query, while
+     * its members are ORed together.
+     */
+    public void addAnyFilter(
+            Map<String, ? extends Collection<String>> alternatives, SearchType searchType) {
+        List<SearchFilter> group = alternatives.entrySet().stream()
+                .map(entry -> new SearchFilter(
+                        entry.getKey(), entry.getValue(), false, searchType))
+                .toList();
+        this.anyFilterGroups.add(group);
     }
 
     public void addExcludeFilter(String propertyName, Collection<String> propertyValues, SearchType searchType) {
@@ -163,6 +177,16 @@ public class OlsSearchQuery {
                 continue;
             }
             condition = condition.and(buildFilterCondition(qualifier, f, false));
+        }
+
+        for (List<SearchFilter> group : anyFilterGroups) {
+            Condition alternatives = DSL.falseCondition();
+            for (SearchFilter f : group) {
+                if (isFilterAvailable(availableFilterColumns, f.field)) {
+                    alternatives = alternatives.or(buildFilterCondition(qualifier, f, false));
+                }
+            }
+            condition = condition.and(alternatives);
         }
 
         for (SearchFilter f : excludeFilters) {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerInclusiveTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerInclusiveTest.java
@@ -1,0 +1,51 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1SearchControllerInclusiveTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    void inclusiveHierarchySearchMatchesTheRequestedParentOrItsDescendants(
+            boolean allChildren) throws Exception {
+        OlsSearchClient searchClient = mock(OlsSearchClient.class);
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(List.of(), 0, Map.of()));
+        V1SearchController controller = new V1SearchController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+
+        controller.search(
+                "", null, null, null, null, null, false, null,
+                false, false,
+                allChildren ? null : List.of("http://example.org/PARENT"),
+                allChildren ? List.of("http://example.org/PARENT") : null,
+                true, false, 10, 0, "json", "en", new MockHttpServletResponse());
+
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(10),
+                org.mockito.ArgumentMatchers.eq(false));
+        OlsSearchQuery query = captor.getValue();
+
+        assertThat(query.buildCondition(Set.of()).toString())
+                .contains("iri", "hierarchical_ancestors", "http://example.org/PARENT", " or ");
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQueryAnyFilterTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchQueryAnyFilterTest.java
@@ -1,0 +1,30 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class OlsSearchQueryAnyFilterTest {
+
+    @Test
+    void combinesAlternativeFieldsWithOrInsideTheSurroundingFilters() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+        query.addAnyFilter(Map.of(
+                "iri", List.of("http://example.org/PARENT"),
+                "hierarchicalAncestor", List.of("http://example.org/PARENT")),
+                SearchType.WHOLE_FIELD);
+
+        String sql = query.buildCondition(Set.of()).toString();
+
+        assertThat(sql)
+                .contains("is_obsolete")
+                .contains("iri")
+                .contains("hierarchical_ancestors")
+                .contains(" or ");
+    }
+}


### PR DESCRIPTION
## Summary
- restore the V1 `inclusive=true` contract for `childrenOf` and `allChildrenOf`
- combine the requested parent IRI and hierarchical-ancestor match as alternatives inside the surrounding search filters
- add focused controller and query-builder regression coverage

## Defect
The PostgreSQL migration added only the `hierarchicalAncestor` filter in both inclusive and non-inclusive branches. As a result, `inclusive=true` omitted the requested parent itself, unlike the prior V1 search behavior.

## Validation
- focused Java 17 regression tests: 3 passed
- Docker-free Java 17 backend suite: 600 passed
- Maven time: 21.967s; wall clock: 23.30s
- Graphify refreshed: 6,195 nodes, 16,857 edges, 285 communities

This production fix is intentionally isolated from the broader V1SearchController layered-testing PR.