### PR TITLE
test: cover v1 search controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerIT.java
@@ -1,0 +1,67 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1SearchControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+
+        V1SearchController controller = new V1SearchController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClientHandle.searchClient());
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void searchesThroughTheControllerAndRealPostgresClient() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("ontology", "efo")
+                        .param("type", "class")
+                        .param("rows", "1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.responseHeader.status").value(0))
+                .andExpect(jsonPath("$.response.numFound").value(3))
+                .andExpect(jsonPath("$.response.start").value(0))
+                .andExpect(jsonPath("$.response.docs.length()").value(1))
+                .andExpect(jsonPath("$.response.docs[0].iri")
+                        .value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].label").value("Liver disease"))
+                .andExpect(jsonPath("$.facet_counts.facet_fields.ontologyId[0]").value("efo"))
+                .andExpect(jsonPath("$.facet_counts.facet_fields.ontologyId[1]").value("3"));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerTest.java
@@ -1,0 +1,173 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class V1SearchControllerTest {
+
+    private OlsSearchClient searchClient;
+    private V1SearchController controller;
+
+    @BeforeEach
+    void setUp() {
+        searchClient = mock(OlsSearchClient.class);
+        controller = new V1SearchController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(List.of(), 0, Map.of()));
+    }
+
+    @Test
+    void buildsTheLegacySearchQueryOwnedByTheController() throws Exception {
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.search(
+                "LIVER",
+                List.of("EFO"),
+                List.of("class"),
+                List.of("core"),
+                List.of("label"),
+                List.of("description, short_form", "obo_id"),
+                true,
+                "iri",
+                true,
+                true,
+                List.of("http://example.org/PARENT"),
+                List.of("http://example.org/ANCESTOR"),
+                false,
+                true,
+                5,
+                2,
+                "json",
+                "en",
+                response);
+
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(), org.mockito.ArgumentMatchers.eq(2),
+                org.mockito.ArgumentMatchers.eq(5), org.mockito.ArgumentMatchers.eq(true));
+
+        OlsSearchQuery query = captor.getValue();
+        assertThat(query.getSearchText()).isEqualTo("LIVER");
+        assertThat(ReflectionTestUtils.getField(query, "exactMatch")).isEqualTo(true);
+        assertThat((List<String>) field(query, "searchFields"))
+                .isEqualTo(List.of("definition", "shortForm", "oboId"));
+        assertThat(filterValues(query, "ontologyId")).containsExactly(List.of("EFO"));
+        assertThat(filterValues(query, "subset")).containsExactly(List.of("core"));
+        assertThat(filterValues(query, "type")).containsExactly(List.of("class"));
+        assertThat(filterValues(query, "isDefiningOntology")).containsExactly(List.of("true"));
+        assertThat(filterValues(query, "hasChildren")).containsExactly(List.of("false"));
+        assertThat(filterValues(query, "hierarchicalAncestor"))
+                .containsExactly(
+                        List.of("http://example.org/PARENT"),
+                        List.of("http://example.org/ANCESTOR"));
+        assertThat(filterValues(query, "isObsolete")).containsExactly(List.of("true"));
+        assertThat((List<String>) field(query, "facetFields")).isEqualTo(List.of(
+                "ontologyId",
+                "ontologyIri",
+                "ontologyPreferredPrefix",
+                "type",
+                "isDefiningOntology",
+                "isObsolete"));
+    }
+
+    @Test
+    void includesRequestedHierarchyParentsThroughAlternativeFilters() throws Exception {
+        controller.search(
+                "liver", null, null, null, null, null, false, null,
+                false, false,
+                List.of("http://example.org/PARENT"),
+                List.of("http://example.org/ANCESTOR"),
+                true, false, 10, 0, "json", "en",
+                new MockHttpServletResponse());
+
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(), anyInt(), anyInt(), anyBoolean());
+
+        assertThat(anyFilterGroups(captor.getValue())).containsExactly(
+                Map.of(
+                        "iri", List.of("http://example.org/PARENT"),
+                        "hierarchicalAncestor", List.of("http://example.org/PARENT")),
+                Map.of(
+                        "iri", List.of("http://example.org/ANCESTOR"),
+                        "hierarchicalAncestor", List.of("http://example.org/ANCESTOR")));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "NULL, false",
+            "'   ', false",
+            "false, false",
+            "FALSE, false",
+            "true, true",
+            "iri, true"
+    })
+    void preservesLegacyGroupFieldSemantics(String rawGroupField, boolean expectedGrouping)
+            throws Exception {
+        String groupField = "NULL".equals(rawGroupField) ? null : rawGroupField;
+
+        controller.search(
+                "liver", null, null, null, null, null, false, groupField,
+                false, false, null, null, false, false, 10, 0, "json", "en",
+                new MockHttpServletResponse());
+
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(10),
+                org.mockito.ArgumentMatchers.eq(expectedGrouping));
+    }
+
+    @Test
+    void rejectsInvalidOntologyIdsBeforeSearching() {
+        assertThrows(IllegalArgumentException.class, () -> controller.search(
+                "liver", List.of("efo/unsafe"), null, null, null, null, false, null,
+                false, false, null, null, false, false, 10, 0, "json", "en",
+                new MockHttpServletResponse()));
+
+        verifyNoInteractions(searchClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T field(OlsSearchQuery query, String name) {
+        return (T) ReflectionTestUtils.getField(query, name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Collection<String>> filterValues(OlsSearchQuery query, String fieldName) {
+        List<Object> filters = (List<Object>) ReflectionTestUtils.getField(query, "filters");
+        return filters.stream()
+                .filter(filter -> fieldName.equals(ReflectionTestUtils.getField(filter, "field")))
+                .map(filter -> (Collection<String>) ReflectionTestUtils.getField(filter, "values"))
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, List<String>>> anyFilterGroups(OlsSearchQuery query) {
+        List<List<Object>> groups = field(query, "anyFilterGroups");
+        return groups.stream()
+                .map(group -> group.stream().collect(java.util.stream.Collectors.toMap(
+                        filter -> (String) ReflectionTestUtils.getField(filter, "field"),
+                        filter -> List.copyOf((Collection<String>)
+                                ReflectionTestUtils.getField(filter, "values")))))
+                .toList();
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SearchControllerWIT.java
@@ -1,0 +1,385 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
+
+import java.util.Collection;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1SearchController.class)
+@ContextConfiguration(classes = {
+        V1SearchController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1SearchControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OlsSearchClient searchClient;
+
+    @MockitoBean
+    private V1OntologyRepository ontologyRepository;
+
+    @BeforeEach
+    void stubSearch() {
+        Map<String, Map<String, Long>> facets = new LinkedHashMap<>();
+        facets.put("ontologyId", new LinkedHashMap<>(Map.of("efo", 1L)));
+        facets.put("type", new LinkedHashMap<>(Map.of("class", 1L)));
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt(), anyBoolean()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(
+                        List.of(searchDocument()), 1, facets));
+    }
+
+    @Test
+    void returnsTheDefaultLegacySearchContract() throws Exception {
+        mockMvc.perform(get("/api/search").param("q", "liver"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(jsonPath("$.responseHeader.status").value(0))
+                .andExpect(jsonPath("$.responseHeader.QTime").value(0))
+                .andExpect(jsonPath("$.response.numFound").value(1))
+                .andExpect(jsonPath("$.response.start").value(0))
+                .andExpect(jsonPath("$.response.docs[0].id")
+                        .value("efo+class+http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].iri")
+                        .value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].label").value("Liver disease"))
+                .andExpect(jsonPath("$.response.docs[0].description[0]")
+                        .value("A disorder affecting hepatic tissue."))
+                .andExpect(jsonPath("$.response.docs[0].short_form").value("EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].obo_id").value("EFO:0001"))
+                .andExpect(jsonPath("$.response.docs[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$.response.docs[0].ontology_prefix").value("EFO"))
+                .andExpect(jsonPath("$.response.docs[0].type").value("class"))
+                .andExpect(jsonPath("$.response.docs[0].exact_synonyms[0]")
+                        .value("Hepatic disorder"))
+                .andExpect(jsonPath("$.response.docs[0].related_synonyms[0]")
+                        .value("Liver condition"))
+                .andExpect(jsonPath("$.response.docs[0].narrow_synonyms[0]")
+                        .value("Inherited liver disease"))
+                .andExpect(jsonPath("$.response.docs[0].broad_synonyms[0]")
+                        .value("Hepatic disease"))
+                .andExpect(jsonPath("$.facet_counts.facet_fields.ontologyId[0]").value("efo"))
+                .andExpect(jsonPath("$.facet_counts.facet_fields.ontologyId[1]").value("1"));
+
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(10),
+                org.mockito.ArgumentMatchers.eq(false));
+        OlsSearchQuery query = capturedQuery();
+        assertThat(query.getSearchText()).isEqualTo("liver");
+        assertThat(filterValues(query, "isObsolete")).containsExactly("false");
+    }
+
+    @Test
+    void bindsAndTranslatesRepeatedCommaAndSpaceSeparatedQueryFields() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "Liver disease")
+                        .param("queryFields", "description,short_form", "obo_id label")
+                        .param("exact", "true"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat((List<String>) field(query, "searchFields"))
+                .isEqualTo(List.of("definition", "shortForm", "oboId", "label"));
+        assertThat((Boolean) field(query, "exactMatch")).isEqualTo(true);
+    }
+
+    @Test
+    void bindsRepeatedOntologyTypeAndSlimValues() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("ontology", "efo", "duo")
+                        .param("type", "class", "property")
+                        .param("slim", "core", "slim"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "ontologyId")).containsExactly("efo", "duo");
+        assertThat(filterValues(query, "type")).containsExactly("class", "property");
+        assertThat(filterValues(query, "subset")).containsExactly("core", "slim");
+    }
+
+    @Test
+    void bindsCommaSeparatedOntologyTypeAndSlimValues() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("ontology", "efo,duo")
+                        .param("type", "class,property")
+                        .param("slim", "core,slim"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "ontologyId")).containsExactly("efo", "duo");
+        assertThat(filterValues(query, "type")).containsExactly("class", "property");
+        assertThat(filterValues(query, "subset")).containsExactly("core", "slim");
+    }
+
+    @Test
+    void bindsLocalLeafObsoleteAndGroupOptions() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("local", "true")
+                        .param("isLeaf", "true")
+                        .param("obsoletes", "true")
+                        .param("groupField", "iri"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "isDefiningOntology")).containsExactly("true");
+        assertThat(filterValues(query, "hasChildren")).containsExactly("false");
+        assertThat(filterValues(query, "isObsolete")).containsExactly("true");
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(10),
+                org.mockito.ArgumentMatchers.eq(true));
+    }
+
+    @Test
+    void bindsEncodedHierarchyIrisAsInclusiveAlternatives() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("childrenOf", "http://example.org/PARENT")
+                        .param("allChildrenOf", "http://example.org/ANCESTOR")
+                        .param("inclusive", "true"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(anyFilterGroups(query)).containsExactly(
+                Map.of(
+                        "iri", List.of("http://example.org/PARENT"),
+                        "hierarchicalAncestor", List.of("http://example.org/PARENT")),
+                Map.of(
+                        "iri", List.of("http://example.org/ANCESTOR"),
+                        "hierarchicalAncestor", List.of("http://example.org/ANCESTOR")));
+    }
+
+    @Test
+    void bindsEncodedHierarchyIrisAsExclusiveFilters() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("childrenOf", "http://example.org/PARENT")
+                        .param("allChildrenOf", "http://example.org/ANCESTOR")
+                        .param("inclusive", "false"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValuesList(query, "hierarchicalAncestor"))
+                .containsExactly(
+                        List.of("http://example.org/PARENT"),
+                        List.of("http://example.org/ANCESTOR"));
+        assertThat(anyFilterGroups(query)).isEmpty();
+    }
+
+    @Test
+    void projectsRequestedFieldsAnnotationsAndRequestedLanguage() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("fieldList",
+                                "label,synonym,subset,ontology_iri,is_defining_ontology,comment_annotation")
+                        .param("format", "json")
+                        .param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.docs[0].label").value("Maladie du foie"))
+                .andExpect(jsonPath("$.response.docs[0].synonym[0]").value("Trouble hepatique"))
+                .andExpect(jsonPath("$.response.docs[0].subset[0]").value("core"))
+                .andExpect(jsonPath("$.response.docs[0].ontology_iri")
+                        .value("http://www.ebi.ac.uk/efo"))
+                .andExpect(jsonPath("$.response.docs[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$.response.docs[0].comment_annotation[0]")
+                        .value("Commentaire francais"))
+                .andExpect(jsonPath("$.response.docs[0].iri").doesNotExist());
+    }
+
+    @Test
+    void forwardsPaginationBoundaryValuesAndReturnsTheRequestedStart() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("start", "0")
+                        .param("rows", "0"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.start").value(0));
+
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(0),
+                org.mockito.ArgumentMatchers.eq(false));
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleParametersForCompatibility() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("page", "7")
+                        .param("size", "4")
+                        .param("facetFields", "type")
+                        .param("http://example.org/category", "clinical"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.numFound").value(1));
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(field(query, "filters").toString())
+                .doesNotContain("page", "size", "facetFields", "category");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"exact", "obsoletes", "local", "inclusive", "isLeaf"})
+    void rejectsMalformedBooleanValuesWithStableErrorFields(String parameter) throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param(parameter, "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"rows", "start"})
+    void rejectsMalformedPaginationValuesWithStableErrorFields(String parameter) throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param(parameter, "not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void rejectsMalformedOntologyIdsWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/search")
+                        .param("q", "liver")
+                        .param("ontology", "efo/unsafe"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+
+        verifyNoInteractions(searchClient);
+    }
+
+    @Test
+    void rejectsMissingRequiredQueryWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/search"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/search").param("q", "liver"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private OlsSearchQuery capturedQuery() {
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(), anyInt(), anyInt(), anyBoolean());
+        return captor.getValue();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T field(OlsSearchQuery query, String name) {
+        return (T) ReflectionTestUtils.getField(query, name);
+    }
+
+    private static Collection<String> filterValues(OlsSearchQuery query, String fieldName) {
+        return filterValuesList(query, fieldName).get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<String>> filterValuesList(
+            OlsSearchQuery query, String fieldName) {
+        List<Object> filters = (List<Object>) ReflectionTestUtils.getField(query, "filters");
+        return filters.stream()
+                .filter(filter -> fieldName.equals(ReflectionTestUtils.getField(filter, "field")))
+                .map(filter -> (Collection<String>) ReflectionTestUtils.getField(filter, "values"))
+                .map(List::copyOf)
+                .toList();
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Map<String, List<String>>> anyFilterGroups(OlsSearchQuery query) {
+        List<List<Object>> groups = field(query, "anyFilterGroups");
+        return groups.stream()
+                .map(group -> group.stream().collect(java.util.stream.Collectors.toMap(
+                        filter -> (String) ReflectionTestUtils.getField(filter, "field"),
+                        filter -> List.copyOf((Collection<String>)
+                                ReflectionTestUtils.getField(filter, "values")))))
+                .toList();
+    }
+
+    private static String searchDocument() {
+        return """
+                {
+                  "id": "efo+class+http://example.org/EFO_0001",
+                  "type": ["entity", "class"],
+                  "ontologyId": "efo",
+                  "ontologyPreferredPrefix": "EFO",
+                  "ontologyIri": ["http://www.ebi.ac.uk/efo"],
+                  "iri": "http://example.org/EFO_0001",
+                  "label": [
+                    {"type": ["literal"], "lang": "en", "value": "Liver disease"},
+                    {"type": ["literal"], "lang": "fr", "value": "Maladie du foie"}
+                  ],
+                  "definition": ["A disorder affecting hepatic tissue."],
+                  "synonym": [
+                    {"type": ["literal"], "lang": "en", "value": "Hepatic disorder"},
+                    {"type": ["literal"], "lang": "fr", "value": "Trouble hepatique"}
+                  ],
+                  "shortForm": "EFO_0001",
+                  "curie": "EFO:0001",
+                  "isDefiningOntology": "true",
+                  "http://www.geneontology.org/formats/oboInOwl#hasExactSynonym": ["Hepatic disorder"],
+                  "http://www.geneontology.org/formats/oboInOwl#hasRelatedSynonym": ["Liver condition"],
+                  "http://www.geneontology.org/formats/oboInOwl#hasNarrowSynonym": ["Inherited liver disease"],
+                  "http://www.geneontology.org/formats/oboInOwl#hasBroadSynonym": ["Hepatic disease"],
+                  "http://www.geneontology.org/formats/oboInOwl#inSubset": ["core"],
+                  "http://www.w3.org/2000/01/rdf-schema#comment": [
+                    {"type": ["literal"], "lang": "en", "value": "English comment"},
+                    {"type": ["literal"], "lang": "fr", "value": "Commentaire francais"}
+                  ],
+                  "definitionProperty": [],
+                  "synonymProperty": ["http://www.geneontology.org/formats/oboInOwl#hasExactSynonym"],
+                  "hierarchicalProperty": [],
+                  "linkedEntities": {}
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSearchIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSearchIT.java
@@ -1,0 +1,134 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class OlsSearchClientSearchIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static OlsSearchClient searchClient;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+        searchClient = searchClientHandle.searchClient();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void searchesAndPagesRawJsonWithLegacyFacetCounts() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("liver");
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+        query.addFacetField("ontologyId");
+        query.addFacetField("type");
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 0, 1, false);
+
+        assertThat(result.numFound).isEqualTo(4);
+        assertThat(result.jsonStrings).hasSize(1);
+        assertThat(label(result.jsonStrings.get(0))).isEqualTo("Liver disease");
+        assertThat(result.facets.get("ontologyId")).containsEntry("efo", 4L);
+        assertThat(result.facets.get("type"))
+                .containsEntry("class", 3L)
+                .containsEntry("individual", 1L);
+    }
+
+    @Test
+    void appliesExactFieldOntologyTypeSlimAndLocalFilters() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("Liver disease");
+        query.setExactMatch(true);
+        query.setSearchFields(List.of("label"));
+        query.addFilter("ontologyId", List.of("EFO"), SearchType.WHOLE_FIELD);
+        query.addFilter("type", List.of("class"), SearchType.WHOLE_FIELD);
+        query.addFilter("subset", List.of("core"), SearchType.WHOLE_FIELD);
+        query.addFilter("isDefiningOntology", List.of("true"), SearchType.WHOLE_FIELD);
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 0, 10, false);
+
+        assertThat(result.numFound).isEqualTo(1);
+        assertThat(result.jsonStrings).singleElement()
+                .satisfies(json -> assertThat(label(json)).isEqualTo("Liver disease"));
+    }
+
+    @Test
+    void searchesACompleteIriWithoutTokenisingIt() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("HTTP://EXAMPLE.ORG/EFO_0001");
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 0, 10, false);
+
+        assertThat(result.numFound).isEqualTo(1);
+        assertThat(result.jsonStrings).singleElement()
+                .satisfies(json -> assertThat(iri(json)).isEqualTo("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void executesTheGroupedRawSearchPathWithDeterministicPagination() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("liver");
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 1, 1, true);
+
+        assertThat(result.numFound).isEqualTo(4);
+        assertThat(result.jsonStrings).hasSize(1);
+        assertThat(iri(result.jsonStrings.get(0))).isEqualTo("http://example.org/EFO_1001");
+    }
+
+    @Test
+    void includesTheRequestedParentWithItsPostgresBackedDescendants() {
+        String parentIri = "http://example.org/EFO_0001";
+
+        OlsSearchQuery exclusive = new OlsSearchQuery();
+        exclusive.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+        exclusive.addFilter("hierarchicalAncestor", List.of(parentIri), SearchType.WHOLE_FIELD);
+
+        OlsSearchQuery inclusive = new OlsSearchQuery();
+        inclusive.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+        inclusive.addAnyFilter(Map.of(
+                "iri", List.of(parentIri),
+                "hierarchicalAncestor", List.of(parentIri)), SearchType.WHOLE_FIELD);
+
+        assertThat(searchClient.searchRaw(exclusive, 0, 10, false).jsonStrings)
+                .extracting(OlsSearchClientSearchIT::iri)
+                .containsExactly("http://example.org/EFO_1001");
+        assertThat(searchClient.searchRaw(inclusive, 0, 10, false).jsonStrings)
+                .extracting(OlsSearchClientSearchIT::iri)
+                .containsExactly(
+                        "http://example.org/EFO_0001",
+                        "http://example.org/EFO_1001");
+    }
+
+    private static String label(String json) {
+        return JsonParser.parseString(json).getAsJsonObject().get("label").getAsString();
+    }
+
+    private static String iri(String json) {
+        return JsonParser.parseString(json).getAsJsonObject().get("iri").getAsString();
+    }
+}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -466,6 +466,31 @@ Verified locally on 2026-09-01 with Java 17 and Rancher Desktop:
   message. Both fixes were isolated, merged, and covered by focused regressions before this test
   branch was rebased.
 
+## Implemented V1 search-controller baseline
+
+Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
+
+- Surefire runs 629 tests, including 9 direct `V1SearchControllerTest` invocations and 20
+  `V1SearchControllerWIT` invocations. Two Docker-free runs took Maven 18.903 and 18.705 seconds
+  (wall-clock 19.83 and 19.41 seconds) with a deliberately unavailable Docker socket.
+- Failsafe runs 128 PostgreSQL tests, including 5 `OlsSearchClientSearchIT` cases and 1 thin
+  `V1SearchControllerIT` case. Two complete database-gate runs took Maven 1 minute 25 seconds and
+  1 minute 22 seconds (wall-clock 87.36 and 83.37 seconds).
+- The clean `verify` lifecycle runs all 757 tests in Maven 1 minute 39 seconds (wall-clock 101.92
+  seconds).
+- Whole-backend JaCoCo coverage is 44.3% lines (2,119 of 4,787) and 35.3% branches (677 of
+  1,916). The V1 search controller covers 152 of 153 executable lines and 91 of 98 branches. No
+  coverage failure threshold is introduced.
+- The search suites preserve the public V1 response envelope, documented default and requested
+  fields, all typed route parameters, repeated and comma-separated values, encoded hierarchy
+  IRIs, pagination boundaries, grouping, stable error fields, and ignored compatibility
+  parameters. The PostgreSQL cases reuse committed synthetic fixtures and the production schema
+  generator to cover text and exact-field search, facets, filters, full IRIs, ranking, grouping,
+  pagination, and inclusive hierarchy semantics.
+- The rollout exposed that `inclusive=true` excluded the requested parent after the PostgreSQL
+  migration. PR #1384 restored the legacy parent-or-descendant behavior with focused regressions;
+  it was isolated and merged before this test branch was rebased.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary

- add direct controller tests for V1 query construction, hierarchy inclusion, grouping, and ontology validation
- add an exactly named Spring MVC WIT suite covering the single public route, supported parameters, defaults, repeated and comma-separated values, encoded IRIs, response fields, pagination boundaries, compatibility parameters, and stable errors
- add real PostgreSQL search-client coverage plus a thin controller-to-database integration test using committed synthetic fixtures and the production schema generator
- record the measured V1 search-controller baseline in the backend testing strategy

## Compatibility defect isolated first

PR #1384 restored legacy `inclusive=true` behavior so hierarchy search includes the requested parent as well as descendants. It merged into `dev` with all 13 checks green before this branch was rebased. This PR changes no production code.

## Local verification

Java 17:

- focused direct/WIT: 29 tests; Maven 25.770s on the final assertion set
- focused PostgreSQL: 6 tests; Maven 13.758s
- Docker-free Surefire twice: 629 tests; Maven 18.903s and 18.705s, with a deliberately unavailable Docker socket
- complete PostgreSQL gate twice: 128 tests; Maven 1m25s and 1m22s; wall 87.36s and 83.37s
- clean full verify: 757 tests; Maven 1m39s; wall 101.92s

JaCoCo: 44.3% lines (2,119/4,787) and 35.3% branches (677/1,916). `V1SearchController` covers 152/153 executable lines and 91/98 branches.

`test_api.sh` is unchanged and was not run locally; downstream Build & Test API CI remains the external API gate.