### PR TITLE
Fix V1 select pagination offset

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectController.java
@@ -177,7 +177,7 @@ public class V1SelectController {
 
         Map<String, Object> responseBody = new LinkedHashMap<>();
         responseBody.put("numFound", result.numFound);
-        responseBody.put("start", 0);
+        responseBody.put("start", start);
         responseBody.put("docs", docs);
 
         Map<String, Object> responseObj = new LinkedHashMap<>();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerPaginationTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerPaginationTest.java
@@ -1,0 +1,38 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class V1SelectControllerPaginationTest {
+
+    @Test
+    void returnsTheRequestedStartOffsetInTheLegacyResponse() throws Exception {
+        OlsSearchClient searchClient = mock(OlsSearchClient.class);
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(List.of(), 0, Map.of()));
+
+        V1SelectController controller = new V1SelectController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.select(
+                "liver", null, null, null, null, false, false,
+                null, null, 2, 2, "en", response);
+
+        assertEquals(2, JsonParser.parseString(response.getContentAsString())
+                .getAsJsonObject().getAsJsonObject("response").get("start").getAsInt());
+    }
+}


### PR DESCRIPTION
V1 /api/select applies the requested start offset in OlsSearchClient but always serialized response.start as 0. This minimal fix returns the actual start value and adds a focused regression test. Discovered while beginning the layered V1SelectController coverage milestone; no testing-framework or unrelated production changes included.\n\nLocal Java 17 verification:\n- focused regression: 1 test passed\n- full Docker-free backend suite: 630 tests passed (Maven 19.318s, wall 20.09s)