### PR TITLE
Test V1 select controller across layered backend suites

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerIT.java
@@ -1,0 +1,67 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1SelectControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+
+        V1SelectController controller = new V1SelectController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClientHandle.searchClient());
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void selectsThroughTheControllerAndRealPostgresClient() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("ontology", "efo")
+                        .param("type", "class")
+                        .param("start", "1")
+                        .param("rows", "1"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.responseHeader.status").value(0))
+                .andExpect(jsonPath("$.response.numFound").value(3))
+                .andExpect(jsonPath("$.response.start").value(1))
+                .andExpect(jsonPath("$.response.docs.length()").value(1))
+                .andExpect(jsonPath("$.response.docs[0].iri")
+                        .value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$.response.docs[0].label")
+                        .value("Clinical liver child"));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerTest.java
@@ -1,0 +1,172 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class V1SelectControllerTest {
+
+    private OlsSearchClient searchClient;
+    private V1SelectController controller;
+
+    @BeforeEach
+    void setUp() {
+        searchClient = mock(OlsSearchClient.class);
+        controller = new V1SelectController();
+        ReflectionTestUtils.setField(controller, "searchClient", searchClient);
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(List.of(), 0, Map.of()));
+    }
+
+    @Test
+    void buildsTheLegacySelectQueryOwnedByTheController() throws Exception {
+        controller.select(
+                "LIVER",
+                List.of("EFO"),
+                List.of("class", "property"),
+                List.of("core"),
+                List.of("label"),
+                true,
+                true,
+                List.of("http://example.org/PARENT"),
+                List.of("http://example.org/ANCESTOR"),
+                5,
+                2,
+                "en",
+                new MockHttpServletResponse());
+
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(),
+                org.mockito.ArgumentMatchers.eq(2), org.mockito.ArgumentMatchers.eq(5));
+
+        OlsSearchQuery query = captor.getValue();
+        assertThat(query.getSearchText()).isEqualTo("LIVER");
+        assertThat(filterValues(query, "ontologyId")).containsExactly(List.of("EFO"));
+        assertThat(filterValues(query, "type"))
+                .containsExactly(List.of("class", "property"));
+        assertThat(filterValues(query, "subset")).containsExactly(List.of("core"));
+        assertThat(filterValues(query, "isDefiningOntology"))
+                .containsExactly(List.of("true"));
+        assertThat(filterValues(query, "directAncestor"))
+                .containsExactly(List.of("http://example.org/PARENT"));
+        assertThat(filterValues(query, "hierarchicalAncestor"))
+                .containsExactly(List.of("http://example.org/ANCESTOR"));
+        assertThat(filterValues(query, "isObsolete")).containsExactly(List.of("true"));
+    }
+
+    @Test
+    void rendersTheDefaultLocalizedLegacyProjection() throws Exception {
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(
+                        List.of(selectDocument()), 1, Map.of()));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.select(
+                "liver", null, null, null, null, false, false,
+                null, null, 10, 0, "fr", response);
+
+        JsonObject body = JsonParser.parseString(response.getContentAsString()).getAsJsonObject();
+        JsonObject header = body.getAsJsonObject("responseHeader");
+        JsonObject result = body.getAsJsonObject("response");
+        JsonObject document = result.getAsJsonArray("docs").get(0).getAsJsonObject();
+
+        assertThat(header.get("status").getAsInt()).isZero();
+        assertThat(header.get("QTime").getAsInt()).isZero();
+        assertThat(header.getAsJsonObject("params").get("q").getAsString()).isEqualTo("liver");
+        assertThat(result.get("numFound").getAsLong()).isEqualTo(1);
+        assertThat(result.get("start").getAsInt()).isZero();
+        assertThat(document.keySet()).containsExactlyInAnyOrder(
+                "id", "iri", "short_form", "obo_id", "label", "ontology_name",
+                "ontology_prefix", "description", "type");
+        assertThat(document.get("label").getAsString()).isEqualTo("Maladie du foie");
+        assertThat(document.getAsJsonArray("description").get(0).getAsString())
+                .isEqualTo("A disorder affecting hepatic tissue.");
+        assertThat(document.get("type").getAsString()).isEqualTo("class");
+        assertThat(body.getAsJsonObject("highlighting").keySet()).isEmpty();
+    }
+
+    @Test
+    void projectsOnlyTheExplicitlyRequestedOptionalFields() throws Exception {
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(
+                        List.of(selectDocument()), 1, Map.of()));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        controller.select(
+                "liver", null, null, null,
+                List.of("label", "synonym", "is_defining_ontology"),
+                false, false, null, null, 10, 0, "en", response);
+
+        JsonObject document = JsonParser.parseString(response.getContentAsString())
+                .getAsJsonObject().getAsJsonObject("response")
+                .getAsJsonArray("docs").get(0).getAsJsonObject();
+        assertThat(document.keySet())
+                .containsExactlyInAnyOrder("label", "synonym", "is_defining_ontology");
+        assertThat(document.get("label").getAsString()).isEqualTo("Liver disease");
+        assertThat(document.getAsJsonArray("synonym").get(0).getAsString())
+                .isEqualTo("Hepatic disorder");
+        assertThat(document.get("is_defining_ontology").getAsBoolean()).isTrue();
+    }
+
+    @Test
+    void rejectsInvalidOntologyIdsBeforeSearching() {
+        assertThrows(IllegalArgumentException.class, () -> controller.select(
+                "liver", List.of("efo/unsafe"), null, null, null, false, false,
+                null, null, 10, 0, "en", new MockHttpServletResponse()));
+
+        verifyNoInteractions(searchClient);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<Collection<String>> filterValues(
+            OlsSearchQuery query, String fieldName) {
+        List<Object> filters = (List<Object>) ReflectionTestUtils.getField(query, "filters");
+        return filters.stream()
+                .filter(filter -> fieldName.equals(ReflectionTestUtils.getField(filter, "field")))
+                .map(filter -> (Collection<String>) ReflectionTestUtils.getField(filter, "values"))
+                .toList();
+    }
+
+    static String selectDocument() {
+        return """
+                {
+                  "id": "efo+class+http://example.org/EFO_0001",
+                  "type": ["entity", "class"],
+                  "ontologyId": "efo",
+                  "ontologyPreferredPrefix": "EFO",
+                  "iri": "http://example.org/EFO_0001",
+                  "label": [
+                    {"type": ["literal"], "lang": "en", "value": "Liver disease"},
+                    {"type": ["literal"], "lang": "fr", "value": "Maladie du foie"}
+                  ],
+                  "definition": ["A disorder affecting hepatic tissue."],
+                  "synonym": [
+                    {"type": ["literal"], "lang": "en", "value": "Hepatic disorder"},
+                    {"type": ["literal"], "lang": "fr", "value": "Trouble hepatique"}
+                  ],
+                  "shortForm": "EFO_0001",
+                  "curie": "EFO:0001",
+                  "isDefiningOntology": "true"
+                }
+                """;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1SelectControllerWIT.java
@@ -1,0 +1,318 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchQuery;
+import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1SelectController.class)
+@ContextConfiguration(classes = {
+        V1SelectController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1SelectControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OlsSearchClient searchClient;
+
+    @MockitoBean
+    private V1OntologyRepository ontologyRepository;
+
+    @BeforeEach
+    void stubSearch() {
+        when(searchClient.searchRaw(any(OlsSearchQuery.class), anyInt(), anyInt()))
+                .thenReturn(new OlsSearchClient.RawSearchResult(
+                        List.of(V1SelectControllerTest.selectDocument()), 1, Map.of()));
+    }
+
+    @Test
+    void returnsTheDefaultLegacySelectContract() throws Exception {
+        mockMvc.perform(get("/api/select").param("q", "liver"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(content().encoding("UTF-8"))
+                .andExpect(jsonPath("$.responseHeader.params.q").value("liver"))
+                .andExpect(jsonPath("$.responseHeader.status").value(0))
+                .andExpect(jsonPath("$.responseHeader.QTime").value(0))
+                .andExpect(jsonPath("$.response.numFound").value(1))
+                .andExpect(jsonPath("$.response.start").value(0))
+                .andExpect(jsonPath("$.response.docs[0].id")
+                        .value("efo+class+http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].iri")
+                        .value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].label").value("Liver disease"))
+                .andExpect(jsonPath("$.response.docs[0].description[0]")
+                        .value("A disorder affecting hepatic tissue."))
+                .andExpect(jsonPath("$.response.docs[0].short_form").value("EFO_0001"))
+                .andExpect(jsonPath("$.response.docs[0].obo_id").value("EFO:0001"))
+                .andExpect(jsonPath("$.response.docs[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$.response.docs[0].ontology_prefix").value("EFO"))
+                .andExpect(jsonPath("$.response.docs[0].type").value("class"))
+                .andExpect(jsonPath("$.highlighting").isEmpty());
+
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(0), org.mockito.ArgumentMatchers.eq(10));
+        OlsSearchQuery query = capturedQuery();
+        assertThat(query.getSearchText()).isEqualTo("liver");
+        assertThat(filterValues(query, "isObsolete")).containsExactly("false");
+        assertThat(filterValuesList(query, "isDefiningOntology")).isEmpty();
+    }
+
+    @Test
+    void bindsRepeatedOntologyTypeAndSlimValues() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("ontology", "efo", "duo")
+                        .param("type", "class", "property")
+                        .param("slim", "core", "slim"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "ontologyId")).containsExactly("efo", "duo");
+        assertThat(filterValues(query, "type")).containsExactly("class", "property");
+        assertThat(filterValues(query, "subset")).containsExactly("core", "slim");
+    }
+
+    @Test
+    void bindsCommaSeparatedOntologyTypeAndSlimValues() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("ontology", "efo,duo")
+                        .param("type", "class,property")
+                        .param("slim", "core,slim"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "ontologyId")).containsExactly("efo", "duo");
+        assertThat(filterValues(query, "type")).containsExactly("class", "property");
+        assertThat(filterValues(query, "subset")).containsExactly("core", "slim");
+    }
+
+    @Test
+    void bindsTrueLocalAndObsoleteOptions() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("local", "true")
+                        .param("obsoletes", "true"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "isDefiningOntology")).containsExactly("true");
+        assertThat(filterValues(query, "isObsolete")).containsExactly("true");
+    }
+
+    @Test
+    void bindsExplicitFalseLocalAndObsoleteOptions() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("local", "false")
+                        .param("obsoletes", "false"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValuesList(query, "isDefiningOntology")).isEmpty();
+        assertThat(filterValues(query, "isObsolete")).containsExactly("false");
+    }
+
+    @Test
+    void bindsRepeatedEncodedHierarchyIris() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("childrenOf", "http://example.org/PARENT", "urn:test:parent")
+                        .param("allChildrenOf", "http://example.org/ANCESTOR", "urn:test:ancestor"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "directAncestor"))
+                .containsExactly("http://example.org/PARENT", "urn:test:parent");
+        assertThat(filterValues(query, "hierarchicalAncestor"))
+                .containsExactly("http://example.org/ANCESTOR", "urn:test:ancestor");
+    }
+
+    @Test
+    void bindsCommaSeparatedHierarchyIris() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("childrenOf", "http://example.org/PARENT,urn:test:parent")
+                        .param("allChildrenOf", "http://example.org/ANCESTOR,urn:test:ancestor"))
+                .andExpect(status().isOk());
+
+        OlsSearchQuery query = capturedQuery();
+        assertThat(filterValues(query, "directAncestor"))
+                .containsExactly("http://example.org/PARENT", "urn:test:parent");
+        assertThat(filterValues(query, "hierarchicalAncestor"))
+                .containsExactly("http://example.org/ANCESTOR", "urn:test:ancestor");
+    }
+
+    @Test
+    void projectsCommaSeparatedFieldsInTheRequestedLanguage() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("fieldList", "label,synonym,is_defining_ontology")
+                        .param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.docs[0].label").value("Maladie du foie"))
+                .andExpect(jsonPath("$.response.docs[0].synonym[0]")
+                        .value("Trouble hepatique"))
+                .andExpect(jsonPath("$.response.docs[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$.response.docs[0].iri").doesNotExist());
+    }
+
+    @Test
+    void projectsRepeatedFieldListValues() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("fieldList", "label", "synonym", "is_defining_ontology"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.docs[0].label").value("Liver disease"))
+                .andExpect(jsonPath("$.response.docs[0].synonym[0]")
+                        .value("Hepatic disorder"))
+                .andExpect(jsonPath("$.response.docs[0].is_defining_ontology").value(true))
+                .andExpect(jsonPath("$.response.docs[0].iri").doesNotExist());
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "0, 0",
+            "-1, 1",
+            "1, -1"
+    })
+    void forwardsPaginationBoundaryValuesAndReturnsTheRequestedStart(int start, int rows)
+            throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("start", Integer.toString(start))
+                        .param("rows", Integer.toString(rows)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.start").value(start));
+
+        verify(searchClient).searchRaw(any(OlsSearchQuery.class),
+                org.mockito.ArgumentMatchers.eq(start), org.mockito.ArgumentMatchers.eq(rows));
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleParametersForCompatibility() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("page", "7")
+                        .param("size", "4")
+                        .param("sort", "label,asc")
+                        .param("facetFields", "type")
+                        .param("http://example.org/category", "clinical"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.response.numFound").value(1));
+
+        assertThat(ReflectionTestUtils.getField(capturedQuery(), "filters").toString())
+                .doesNotContain("page", "size", "sort", "facetFields", "category");
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"obsoletes", "local"})
+    void rejectsMalformedBooleanValuesWithStableErrorFields(String parameter) throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param(parameter, "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {"rows", "start"})
+    void rejectsMalformedPaginationValuesWithStableErrorFields(String parameter) throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param(parameter, "not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void rejectsMalformedOntologyIdsWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/select")
+                        .param("q", "liver")
+                        .param("ontology", "efo/unsafe"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+
+        verifyNoInteractions(searchClient);
+    }
+
+    @Test
+    void rejectsMissingRequiredQueryWithStableErrorFields() throws Exception {
+        mockMvc.perform(get("/api/select"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/select").param("q", "liver"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private OlsSearchQuery capturedQuery() {
+        ArgumentCaptor<OlsSearchQuery> captor = ArgumentCaptor.forClass(OlsSearchQuery.class);
+        verify(searchClient).searchRaw(captor.capture(), anyInt(), anyInt());
+        return captor.getValue();
+    }
+
+    private static Collection<String> filterValues(OlsSearchQuery query, String fieldName) {
+        return filterValuesList(query, fieldName).get(0);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static List<List<String>> filterValuesList(
+            OlsSearchQuery query, String fieldName) {
+        List<Object> filters = (List<Object>) ReflectionTestUtils.getField(query, "filters");
+        return filters.stream()
+                .filter(filter -> fieldName.equals(ReflectionTestUtils.getField(filter, "field")))
+                .map(filter -> (Collection<String>) ReflectionTestUtils.getField(filter, "values"))
+                .map(List::copyOf)
+                .toList();
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSelectIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/search/OlsSearchClientSelectIT.java
@@ -1,0 +1,98 @@
+package uk.ac.ebi.spot.ols.repository.search;
+
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+class OlsSearchClientSelectIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.SearchClientHandle searchClientHandle;
+    private static OlsSearchClient searchClient;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        searchClientHandle = PostgresIntegrationTestSupport.createSearchClient(POSTGRES);
+        searchClient = searchClientHandle.searchClient();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        searchClientHandle.close();
+    }
+
+    @Test
+    void searchesAndPagesTheRawDocumentsUsedBySelect() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("liver");
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 1, 1);
+
+        assertThat(result.numFound).isEqualTo(4);
+        assertThat(result.jsonStrings).singleElement()
+                .satisfies(json -> assertThat(iri(json))
+                        .isEqualTo("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void appliesOntologyTypeSlimAndLocalSelectFilters() {
+        OlsSearchQuery query = new OlsSearchQuery();
+        query.setSearchText("liver");
+        query.addFilter("ontologyId", List.of("EFO"), SearchType.WHOLE_FIELD);
+        query.addFilter("type", List.of("class"), SearchType.WHOLE_FIELD);
+        query.addFilter("subset", List.of("core"), SearchType.WHOLE_FIELD);
+        query.addFilter("isDefiningOntology", List.of("true"), SearchType.WHOLE_FIELD);
+        query.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchClient.RawSearchResult result = searchClient.searchRaw(query, 0, 10);
+
+        assertThat(result.numFound).isEqualTo(1);
+        assertThat(result.jsonStrings).singleElement()
+                .satisfies(json -> assertThat(iri(json))
+                        .isEqualTo("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void appliesDirectAndHierarchicalAncestorSelectFilters() {
+        String parentIri = "http://example.org/EFO_0001";
+
+        OlsSearchQuery direct = new OlsSearchQuery();
+        direct.setSearchText("liver");
+        direct.addFilter("directAncestor", List.of(parentIri), SearchType.WHOLE_FIELD);
+        direct.addFilter("isObsolete", List.of("false"), SearchType.WHOLE_FIELD);
+
+        OlsSearchQuery hierarchical = new OlsSearchQuery();
+        hierarchical.setSearchText("liver");
+        hierarchical.addFilter(
+                "hierarchicalAncestor", List.of(parentIri), SearchType.WHOLE_FIELD);
+        hierarchical.addFilter("isObsolete", List.of("true"), SearchType.WHOLE_FIELD);
+
+        assertThat(searchClient.searchRaw(direct, 0, 10).jsonStrings)
+                .extracting(OlsSearchClientSelectIT::iri)
+                .containsExactly(
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_I100");
+        assertThat(searchClient.searchRaw(hierarchical, 0, 10).jsonStrings)
+                .extracting(OlsSearchClientSelectIT::iri)
+                .containsExactly("http://example.org/EFO_1999");
+    }
+
+    private static String iri(String json) {
+        return JsonParser.parseString(json).getAsJsonObject().get("iri").getAsString();
+    }
+}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -491,6 +491,31 @@ Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
   migration. PR #1384 restored the legacy parent-or-descendant behavior with focused regressions;
   it was isolated and merged before this test branch was rebased.
 
+## Implemented V1 select-controller baseline
+
+Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
+
+- Surefire runs 654 tests, including 4 new direct `V1SelectControllerTest` cases, 20
+  `V1SelectControllerWIT` invocations, and the focused pagination regression merged with PR
+  #1386. Two Docker-free runs took Maven 19.167 and 19.035 seconds (wall-clock 20.35 and 19.88
+  seconds) with a deliberately unavailable Docker socket.
+- Failsafe runs 132 PostgreSQL tests, including 3 `OlsSearchClientSelectIT` cases and 1 thin
+  `V1SelectControllerIT` case. Two complete database-gate runs took Maven 1 minute 27 seconds and
+  1 minute 26 seconds (wall-clock 88.17 and 87.10 seconds).
+- The clean `verify` lifecycle runs all 786 tests in Maven 1 minute 38 seconds (wall-clock 99.12
+  seconds).
+- Whole-backend JaCoCo coverage is 45.9% lines (2,196 of 4,785) and 37.6% branches (721 of
+  1,916). The V1 select controller covers all 76 executable lines and 44 of 48 branches. No
+  coverage failure threshold is introduced.
+- The select suites preserve the public V1 autocomplete envelope and legacy field projection;
+  exercise defaults, all typed route parameters, repeated and comma-separated filters, encoded
+  hierarchy IRIs, field lists, pagination boundaries, stable error fields, and ignored
+  compatibility parameters; and use the committed synthetic fixture with the production schema
+  generator for text search, filtering, hierarchy, obsolete terms, and real pagination.
+- The rollout exposed that non-zero `start` values were passed to PostgreSQL but serialized as
+  zero in the legacy response. PR #1386 preserves the requested offset with a focused regression;
+  it was isolated and merged before this test branch was rebased.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary
- add direct controller tests for V1 select query construction and legacy projection decisions
- add an exactly named 20-invocation Spring MVC WIT suite for the public `/api/select` contract
- add real PostgreSQL select/search coverage plus one thin controller-to-database integration test
- record the measured Java 17 verification and JaCoCo baseline

## Selection
`V1SelectController` is the next focused target because `/api/select` is a public autocomplete route with eleven bound parameters, legacy response projection, frontend/downstream consumers, and direct PostgreSQL search behavior. Remaining ontology-scoped controllers are more hierarchy-heavy; V2 defined-fields is static and lower risk; text-tagger/LLM routes require external-service seams.

## Defect isolated first
PR #1386 fixed the genuine pagination compatibility defect found test-first: the requested `start` reached PostgreSQL but the legacy response always serialized zero. That PR merged before this branch was rebased. This PR changes no production code.

## Verification
Java 17 with Rancher Desktop:
- focused unit/WIT: 25 tests, Maven 20.476s, wall 21.48s
- focused PostgreSQL: 4 tests, Maven 14.684s, wall 16.05s
- Docker-free Surefire twice: 654 tests; Maven 19.167s / 19.035s; wall 20.35s / 19.88s
- PostgreSQL gate twice: 132 tests; Maven 1m27s / 1m26s; wall 88.17s / 87.10s
- clean verify: 786 tests; Maven 1m38s; wall 99.12s
- JaCoCo: 45.9% lines (2,196/4,785), 37.6% branches (721/1,916); V1SelectController 76/76 lines and 44/48 branches

`test_api.sh` is unchanged and was not run locally; downstream Build & Test API remains the CI evidence for that path.