### PR TITLE
Fix ontology-scoped individual identifier lookup

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualController.java
@@ -88,12 +88,12 @@ public class V1OntologyIndividualController {
                 terms = new PageImpl<V1Individual>(Arrays.asList(term));
             }
         } else if (shortForm != null) {
-            V1Individual term = individualRepository.findByOntologyAndShortForm(ontologyId, shortForm, lang);
+            V1Individual term = individualRepository.findByOntologyAndShortForm(ontologyId, lang, shortForm);
             if (term != null) {
                 terms = new PageImpl<V1Individual>(Arrays.asList(term));
             }
         } else if (oboId != null) {
-            V1Individual term = individualRepository.findByOntologyAndOboId(ontologyId, oboId, lang);
+            V1Individual term = individualRepository.findByOntologyAndOboId(ontologyId, lang, oboId);
             if (term != null) {
                 terms = new PageImpl<V1Individual>(Arrays.asList(term));
             }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerIdentifierTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerIdentifierTest.java
@@ -1,0 +1,52 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1OntologyIndividualControllerIdentifierTest {
+
+    private V1OntologyIndividualController controller;
+    private V1IndividualRepository repository;
+    private PagedResourcesAssembler<V1Individual> assembler;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        repository = mock(V1IndividualRepository.class);
+        assembler = mock(PagedResourcesAssembler.class);
+        controller = new V1OntologyIndividualController();
+        ReflectionTestUtils.setField(controller, "individualRepository", repository);
+        controller.individualAssembler = mock(V1IndividualAssembler.class);
+    }
+
+    @Test
+    void forwardsLanguageBeforeShortForm() {
+        when(repository.findByOntologyAndShortForm("efo", "fr", "EFO_I100"))
+                .thenReturn(new V1Individual());
+
+        controller.getAllIndividualsByOntology(
+                "EFO", null, "EFO_I100", null, "fr", PageRequest.of(0, 20), assembler);
+
+        verify(repository).findByOntologyAndShortForm("efo", "fr", "EFO_I100");
+    }
+
+    @Test
+    void forwardsLanguageBeforeOboId() {
+        when(repository.findByOntologyAndOboId("efo", "fr", "EFO:I100"))
+                .thenReturn(new V1Individual());
+
+        controller.getAllIndividualsByOntology(
+                "EFO", null, null, "EFO:I100", "fr", PageRequest.of(0, 20), assembler);
+
+        verify(repository).findByOntologyAndOboId("efo", "fr", "EFO:I100");
+    }
+}


### PR DESCRIPTION
## Summary
- forward `lang` and `short_form` to `V1IndividualRepository` in its declared order
- forward `lang` and `obo_id` in its declared order
- add focused controller regressions for both identifier forms

## Verification
- Java 17 focused regression: 2 tests passed
- Java 17 Docker-free `mvn -B -ntp -pl backend -am test`: 632 tests passed in Maven 20.208s (20.99s wall)
- `test_api.sh` unchanged and not run locally