### PR TITLE
Test V1 ontology individual controller across layered suites

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerIT.java
@@ -1,0 +1,156 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.MessageResolver;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.core.AnnotationLinkRelationProvider;
+import org.springframework.hateoas.server.core.DelegatingLinkRelationProvider;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1OntologyIndividualControllerIT {
+
+    private static final URI INDIVIDUAL_URI = URI.create(
+            "/api/ontologies/EFO/individuals/http%253A%252F%252Fexample.org%252FEFO_I100");
+    private static final URI TYPES_URI = URI.create(INDIVIDUAL_URI + "/types");
+    private static final URI ALL_TYPES_URI = URI.create(INDIVIDUAL_URI + "/alltypes");
+    private static final URI JS_TREE_URI = URI.create(INDIVIDUAL_URI + "/jstree");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1OntologyIndividualRepositoryHandle
+            repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
+        repositoryHandle =
+                PostgresIntegrationTestSupport.createV1OntologyIndividualRepositories(POSTGRES);
+
+        V1OntologyIndividualController controller = new V1OntologyIndividualController();
+        ReflectionTestUtils.setField(
+                controller, "individualRepository", repositoryHandle.individualRepository());
+        ReflectionTestUtils.setField(
+                controller, "jsTreeRepository", repositoryHandle.jsTreeRepository());
+        controller.individualAssembler = new V1IndividualAssembler();
+        controller.termAssembler = new V1TermAssembler();
+
+        HateoasPageableHandlerMethodArgumentResolver pageableResolver =
+                new HateoasPageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(1000);
+        PagedResourcesAssemblerArgumentResolver assemblerResolver =
+                new PagedResourcesAssemblerArgumentResolver(pageableResolver);
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(pageableResolver, assemblerResolver)
+                .setMessageConverters(
+                        new StringHttpMessageConverter(StandardCharsets.UTF_8),
+                        halMessageConverter())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsOntologyIndividualsThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri")
+                        .value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$._embedded.individuals[1].is_defining_ontology")
+                        .value(false))
+                .andExpect(jsonPath("$._embedded.individuals[2].is_obsolete").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedOntologyIndividualThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(INDIVIDUAL_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.iri").value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$.label").value("Liver specimen alpha"))
+                .andExpect(jsonPath("$.lang").value("fr"));
+    }
+
+    @Test
+    void getsDirectIndividualTypesThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(TYPES_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$._embedded.terms[0].label").value("Liver disease"));
+    }
+
+    @Test
+    void getsAllIndividualTypesThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(ALL_TYPES_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsIndividualJsTreeThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$[0].text").value("Liver disease"))
+                .andExpect(jsonPath("$[0].parent").value("#"))
+                .andExpect(jsonPath("$[1].iri").value("http://example.org/EFO_I100"))
+                .andExpect(jsonPath("$[1].text").value("Liver specimen alpha"))
+                .andExpect(jsonPath("$[1].state.selected").value(true));
+    }
+
+    private static MappingJackson2HttpMessageConverter halMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jackson2HalModule());
+        objectMapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(
+                new DelegatingLinkRelationProvider(
+                        new AnnotationLinkRelationProvider(),
+                        new EvoInflectorLinkRelationProvider()),
+                CurieProvider.NONE,
+                MessageResolver.DEFAULTS_ONLY));
+
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaTypes.HAL_JSON));
+        return converter;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerTest.java
@@ -1,0 +1,191 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1OntologyIndividualControllerTest {
+
+    private V1OntologyIndividualController controller;
+    private V1IndividualRepository individualRepository;
+    private V1JsTreeRepository jsTreeRepository;
+    private V1IndividualAssembler individualAssembler;
+    private V1TermAssembler termAssembler;
+    private PagedResourcesAssembler<V1Individual> individualResourcesAssembler;
+    private PagedResourcesAssembler<V1Term> termResourcesAssembler;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        individualRepository = mock(V1IndividualRepository.class);
+        jsTreeRepository = mock(V1JsTreeRepository.class);
+        individualAssembler = mock(V1IndividualAssembler.class);
+        termAssembler = mock(V1TermAssembler.class);
+        individualResourcesAssembler = mock(PagedResourcesAssembler.class);
+        termResourcesAssembler = mock(PagedResourcesAssembler.class);
+        pageable = PageRequest.of(1, 7);
+
+        controller = new V1OntologyIndividualController();
+        ReflectionTestUtils.setField(controller, "individualRepository", individualRepository);
+        ReflectionTestUtils.setField(controller, "jsTreeRepository", jsTreeRepository);
+        controller.individualAssembler = individualAssembler;
+        controller.termAssembler = termAssembler;
+    }
+
+    @Test
+    void listsOntologyIndividualsWhenNoIdentifierIsSupplied() {
+        OlsFacetedResultsPage<V1Individual> individuals = new OlsFacetedResultsPage<>(
+                List.of(individual()), Map.of(), pageable, 1);
+        PagedModel<EntityModel<V1Individual>> assembled = PagedModel.empty();
+        when(individualRepository.findAllByOntology("efo", "fr", pageable))
+                .thenReturn(individuals);
+        when(individualResourcesAssembler.toModel(individuals, individualAssembler))
+                .thenReturn(assembled);
+
+        var response = controller.getAllIndividualsByOntology(
+                "EFO", null, null, null, "fr", pageable, individualResourcesAssembler);
+
+        assertSame(assembled, response.getBody());
+        verify(individualRepository).findAllByOntology("efo", "fr", pageable);
+    }
+
+    @Test
+    void selectsIriBeforeShortFormAndOboIdUsingRepositoryArgumentOrder() {
+        when(individualRepository.findByOntologyAndIri("efo", "the-iri", "fr"))
+                .thenReturn(individual());
+
+        controller.getAllIndividualsByOntology(
+                "EFO", "the-iri", "EFO_I100", "EFO:I100", "fr", pageable,
+                individualResourcesAssembler);
+
+        verify(individualRepository).findByOntologyAndIri("efo", "the-iri", "fr");
+        verify(individualRepository, never())
+                .findByOntologyAndShortForm("efo", "fr", "EFO_I100");
+        verify(individualRepository, never())
+                .findByOntologyAndOboId("efo", "fr", "EFO:I100");
+
+        when(individualRepository.findByOntologyAndShortForm("efo", "fr", "EFO_I200"))
+                .thenReturn(individual());
+        controller.getAllIndividualsByOntology(
+                "EFO", null, "EFO_I200", "EFO:I200", "fr", pageable,
+                individualResourcesAssembler);
+        verify(individualRepository).findByOntologyAndShortForm("efo", "fr", "EFO_I200");
+
+        when(individualRepository.findByOntologyAndOboId("efo", "fr", "EFO:I300"))
+                .thenReturn(individual());
+        controller.getAllIndividualsByOntology(
+                "EFO", null, null, "EFO:I300", "fr", pageable,
+                individualResourcesAssembler);
+        verify(individualRepository).findByOntologyAndOboId("efo", "fr", "EFO:I300");
+
+        controller.getAllIndividualsByOntology(
+                "EFO", "missing-iri", null, null, "fr", pageable,
+                individualResourcesAssembler);
+        controller.getAllIndividualsByOntology(
+                "EFO", null, "missing-short-form", null, "fr", pageable,
+                individualResourcesAssembler);
+        controller.getAllIndividualsByOntology(
+                "EFO", null, null, "MISSING:1", "fr", pageable,
+                individualResourcesAssembler);
+        verify(individualResourcesAssembler, times(3)).toModel(null, individualAssembler);
+    }
+
+    @Test
+    void getsDecodedIndividualAndReportsMissingIndividual() {
+        when(individualRepository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_I100", "en"))
+                .thenReturn(individual());
+        EntityModel<V1Individual> assembled = EntityModel.of(individual());
+        when(individualAssembler.toModel(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(assembled);
+
+        var response = controller.getIndividual(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_I100", "en");
+
+        assertSame(assembled, response.getBody());
+        verify(individualRepository).findByOntologyAndIri(
+                "efo", "http://example.org/EFO_I100", "en");
+
+        when(individualRepository.findByOntologyAndIri("efo", "missing", "en"))
+                .thenReturn(null);
+        ResourceNotFoundException error = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getIndividual("EFO", "missing", "en"));
+        assertEquals("No individual with id missing in efo", error.getMessage());
+    }
+
+    @Test
+    void delegatesDecodedDirectAndAllTypes() {
+        PageImpl<V1Term> terms = new PageImpl<>(List.of(term()));
+        when(individualRepository.getDirectTypes(
+                "efo", "http://example.org/EFO_I100", "fr", pageable)).thenReturn(terms);
+        when(individualRepository.getAllTypes(
+                "efo", "http://example.org/EFO_I100", "fr", pageable)).thenReturn(terms);
+
+        controller.getDirectTypes(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_I100", "fr", pageable,
+                termResourcesAssembler);
+        controller.ancestors(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_I100", "fr", pageable,
+                termResourcesAssembler);
+
+        verify(individualRepository).getDirectTypes(
+                "efo", "http://example.org/EFO_I100", "fr", pageable);
+        verify(individualRepository).getAllTypes(
+                "efo", "http://example.org/EFO_I100", "fr", pageable);
+    }
+
+    @Test
+    void serializesTheDecodedIndividualJsTree() {
+        when(jsTreeRepository.getJsTreeForIndividual(
+                "http://example.org/EFO_I100", "efo", "fr"))
+                .thenReturn(List.of(Map.of(
+                        "iri", "http://example.org/EFO_I100",
+                        "text", "Liver specimen alpha")));
+
+        var response = controller.getJsTree(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_I100", "fr");
+
+        verify(jsTreeRepository).getJsTreeForIndividual(
+                "http://example.org/EFO_I100", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_I100", "Liver specimen alpha");
+    }
+
+    private static V1Individual individual() {
+        V1Individual individual = new V1Individual();
+        individual.iri = "http://example.org/EFO_I100";
+        return individual;
+    }
+
+    private static V1Term term() {
+        V1Term term = new V1Term();
+        term.iri = "http://example.org/EFO_0001";
+        return term;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyIndividualControllerWIT.java
@@ -1,0 +1,440 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.model.v1.V1Individual;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+import uk.ac.ebi.spot.ols.service.PostgresClient;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1OntologyIndividualController.class)
+@ContextConfiguration(classes = {
+        V1OntologyIndividualController.class,
+        V1IndividualAssembler.class,
+        V1TermAssembler.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1OntologyIndividualControllerWIT {
+
+    private static final String INDIVIDUAL_IRI = "http://example.org/EFO_I100";
+    private static final String CLASS_IRI = "http://example.org/EFO_0001";
+    private static final URI INDIVIDUAL_URI = URI.create(
+            "/api/ontologies/EFO/individuals/http%253A%252F%252Fexample.org%252FEFO_I100");
+    private static final URI TYPES_URI = URI.create(INDIVIDUAL_URI + "/types");
+    private static final URI ALL_TYPES_URI = URI.create(INDIVIDUAL_URI + "/alltypes");
+    private static final URI JS_TREE_URI = URI.create(INDIVIDUAL_URI + "/jstree");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private V1IndividualRepository individualRepository;
+
+    @MockitoBean
+    private V1JsTreeRepository jsTreeRepository;
+
+    @MockitoBean
+    private PostgresClient postgresClient;
+
+    @MockitoBean
+    private EntityLinks entityLinks;
+
+    @BeforeEach
+    void stubResponses() {
+        when(individualRepository.findAllByOntology(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> individualPage(
+                        invocation.getArgument(2), invocation.getArgument(1)));
+        when(individualRepository.findByOntologyAndIri(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> individual(invocation.getArgument(2)));
+        when(individualRepository.findByOntologyAndShortForm(
+                anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> individual(invocation.getArgument(1)));
+        when(individualRepository.findByOntologyAndOboId(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> individual(invocation.getArgument(1)));
+        when(individualRepository.getDirectTypes(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(individualRepository.getAllTypes(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(jsTreeRepository.getJsTreeForIndividual(anyString(), anyString(), anyString()))
+                .thenReturn(List.of(Map.of(
+                        "id", "individual-node",
+                        "parent", "class-node",
+                        "iri", INDIVIDUAL_IRI,
+                        "text", "Liver specimen alpha",
+                        "state", Map.of("selected", true),
+                        "children", false,
+                        "ontology_name", "efo")));
+    }
+
+    @Test
+    void returnsDefaultOntologyIndividualListContract() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI))
+                .andExpect(jsonPath("$._embedded.individuals[0].label")
+                        .value("Liver specimen alpha"))
+                .andExpect(jsonPath("$._embedded.individuals[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("en"))
+                .andExpect(jsonPath("$._embedded.individuals[0]._links.self.href")
+                        .value(endsWith("/api/ontologies/efo/individuals/"
+                                + "http%253A%252F%252Fexample.org%252FEFO_I100?lang=en")))
+                .andExpect(jsonPath("$.page.size").value(1000))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.totalPages").value(1))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(individualRepository).findAllByOntology(
+                "efo", "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void bindsCollectionLanguagePageSizeAndSort() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("lang", "fr")
+                        .param("page", "2")
+                        .param("size", "7")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("fr"));
+
+        verify(individualRepository).findAllByOntology(
+                "efo", "fr", PageRequest.of(2, 7,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void routesEveryCollectionIdentifierAndAppliesPrecedence() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("iri", INDIVIDUAL_IRI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI));
+        verify(individualRepository).findByOntologyAndIri("efo", INDIVIDUAL_IRI, "fr");
+
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("short_form", "EFO_I100").param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI));
+        verify(individualRepository).findByOntologyAndShortForm("efo", "fr", "EFO_I100");
+
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("obo_id", "EFO:I100").param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].iri").value(INDIVIDUAL_IRI));
+        verify(individualRepository).findByOntologyAndOboId("efo", "fr", "EFO:I100");
+
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("iri", INDIVIDUAL_IRI)
+                        .param("short_form", "ignored")
+                        .param("obo_id", "IGNORED:1"))
+                .andExpect(status().isOk());
+        verify(individualRepository, never())
+                .findByOntologyAndShortForm("efo", "en", "ignored");
+        verify(individualRepository, never())
+                .findByOntologyAndOboId("efo", "en", "IGNORED:1");
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleCollectionParameters() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("search", "specimen")
+                        .param("includeObsoleteEntities", "false")
+                        .param("subset", "core", "slim")
+                        .param("http://example.org/category", "clinical", "policy"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAllByOntology(
+                "efo", "en", PageRequest.of(0, 1000));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "list, -1, 20, 0, 20",
+            "list, 0, 0, 0, 1000",
+            "list, 0, 1001, 0, 1000",
+            "types, -1, 20, 0, 20",
+            "types, 0, -1, 0, 1000",
+            "types, 0, 1001, 0, 1000",
+            "alltypes, -1, 20, 0, 20",
+            "alltypes, 0, 0, 0, 1000",
+            "alltypes, 0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundariesAcrossPagedRoutes(
+            String route,
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "list" -> verify(individualRepository)
+                    .findAllByOntology("efo", "en", expected);
+            case "types" -> verify(individualRepository)
+                    .getDirectTypes("efo", INDIVIDUAL_IRI, "en", expected);
+            case "alltypes" -> verify(individualRepository)
+                    .getAllTypes("efo", INDIVIDUAL_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void usesPaginationDefaultsForMalformedNumericValuesAcrossPagedRoutes() throws Exception {
+        Pageable defaults = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get("/api/ontologies/EFO/individuals")
+                        .param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(TYPES_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(ALL_TYPES_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAllByOntology("efo", "en", defaults);
+        verify(individualRepository).getDirectTypes("efo", INDIVIDUAL_IRI, "en", defaults);
+        verify(individualRepository).getAllTypes("efo", INDIVIDUAL_IRI, "en", defaults);
+    }
+
+    @Test
+    void returnsDoubleEncodedIndividualWithDefaultAndExplicitLanguage() throws Exception {
+        mockMvc.perform(get(INDIVIDUAL_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.iri").value(INDIVIDUAL_IRI))
+                .andExpect(jsonPath("$.label").value("Liver specimen alpha"))
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.lang").value("en"));
+        verify(individualRepository).findByOntologyAndIri("efo", INDIVIDUAL_IRI, "en");
+
+        mockMvc.perform(get(INDIVIDUAL_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lang").value("fr"));
+        verify(individualRepository).findByOntologyAndIri("efo", INDIVIDUAL_IRI, "fr");
+    }
+
+    @Test
+    void returnsDirectTypesWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(TYPES_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(CLASS_IRI))
+                .andExpect(jsonPath("$._embedded.terms[0].label").value("Liver disease"))
+                .andExpect(jsonPath("$.page.size").value(1000));
+
+        mockMvc.perform(get(TYPES_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(individualRepository).getDirectTypes(
+                "efo", INDIVIDUAL_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsAllTypesWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(ALL_TYPES_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(CLASS_IRI))
+                .andExpect(jsonPath("$.page.totalElements").value(1));
+
+        mockMvc.perform(get(ALL_TYPES_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "shortForm,asc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(individualRepository).getAllTypes(
+                "efo", INDIVIDUAL_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.ASC, "shortForm"));
+    }
+
+    @Test
+    void returnsDoubleEncodedIndividualJsTreeWithExplicitLanguage() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value(INDIVIDUAL_IRI))
+                .andExpect(jsonPath("$[0].text").value("Liver specimen alpha"))
+                .andExpect(jsonPath("$[0].state.selected").value(true));
+
+        verify(jsTreeRepository).getJsTreeForIndividual(INDIVIDUAL_IRI, "efo", "fr");
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageCompatibilityAcrossRouteFamilies() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals").param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.individuals[0].lang").value("en_US"));
+        mockMvc.perform(get(TYPES_URI).param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("en_US"));
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "en_US"))
+                .andExpect(status().isOk());
+
+        verify(individualRepository).findAllByOntology(
+                "efo", "en_US", PageRequest.of(0, 1000));
+        verify(individualRepository).getDirectTypes(
+                "efo", INDIVIDUAL_IRI, "en_US", PageRequest.of(0, 1000));
+        verify(jsTreeRepository).getJsTreeForIndividual(INDIVIDUAL_IRI, "efo", "en_US");
+    }
+
+    @Test
+    void supportsLegacyHalMediaTypeOnEveryHalRoute() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/individuals").accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(INDIVIDUAL_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(TYPES_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        mockMvc.perform(get(ALL_TYPES_URI).accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+    }
+
+    @Test
+    void returnsStableLegacyNotFoundStatusAndMessage() throws Exception {
+        when(individualRepository.findByOntologyAndIri("efo", INDIVIDUAL_IRI, "en"))
+                .thenReturn(null);
+
+        mockMvc.perform(get(INDIVIDUAL_URI))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void returnsStableBadRequestFieldsForUnsupportedSort() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(individualRepository.getDirectTypes("efo", INDIVIDUAL_IRI, "en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get(TYPES_URI).param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
+        mockMvc.perform(post("/api/ontologies/EFO/individuals"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private static URI route(String route) {
+        return switch (route) {
+            case "list" -> URI.create("/api/ontologies/EFO/individuals");
+            case "types" -> TYPES_URI;
+            case "alltypes" -> ALL_TYPES_URI;
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        };
+    }
+
+    private static OlsFacetedResultsPage<V1Individual> individualPage(
+            Pageable pageable,
+            String lang) {
+        return new OlsFacetedResultsPage<>(
+                List.of(individual(lang)), Map.of(), pageable, 1);
+    }
+
+    private static PageImpl<V1Term> termPage(Pageable pageable, String lang) {
+        return new PageImpl<>(List.of(term(lang)), pageable, 1);
+    }
+
+    private static V1Individual individual(String lang) {
+        V1Individual individual = new V1Individual();
+        individual.iri = INDIVIDUAL_IRI;
+        individual.lang = lang;
+        individual.label = "Liver specimen alpha";
+        individual.description = new String[]{
+                "An individual example assigned to the liver disease class."};
+        individual.synonyms = new String[]{"Clinical liver sample"};
+        individual.ontologyName = "efo";
+        individual.ontologyPrefix = "EFO";
+        individual.ontologyIri = "http://www.ebi.ac.uk/efo";
+        individual.isObsolete = false;
+        individual.isLocal = true;
+        individual.hasChildren = false;
+        individual.isRoot = true;
+        individual.shortForm = "EFO_I100";
+        individual.oboId = "EFO:I100";
+        individual.inSubsets = List.of("individuals");
+        individual.annotation = Map.of();
+        return individual;
+    }
+
+    private static V1Term term(String lang) {
+        V1Term term = new V1Term();
+        term.iri = CLASS_IRI;
+        term.lang = lang;
+        term.label = "Liver disease";
+        term.description = new String[]{"A disorder affecting hepatic tissue."};
+        term.synonyms = new String[]{"Hepatic disorder"};
+        term.ontologyName = "efo";
+        term.ontologyPrefix = "EFO";
+        term.ontologyIri = "http://www.ebi.ac.uk/efo";
+        term.shortForm = "EFO_0001";
+        term.oboId = "EFO:0001";
+        term.inSubsets = List.of();
+        term.annotation = Map.of();
+        term.oboDefinitionCitations = List.of();
+        term.oboXrefs = List.of();
+        term.oboSynonyms = List.of();
+        term.related = List.of();
+        return term;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1IndividualRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1IndividualRepositoryIT.java
@@ -12,6 +12,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.ac.ebi.spot.ols.model.v1.V1Individual;
 import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,14 +25,17 @@ class V1IndividualRepositoryIT {
     private static final PostgreSQLContainer<?> POSTGRES =
             PostgresIntegrationTestSupport.newContainer();
 
-    private static PostgresIntegrationTestSupport.V1IndividualRepositoryHandle repositoryHandle;
+    private static PostgresIntegrationTestSupport.V1OntologyIndividualRepositoryHandle repositoryHandle;
     private static V1IndividualRepository repository;
+    private static V1JsTreeRepository jsTreeRepository;
 
     @BeforeAll
     static void setUpDatabase() {
         PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
-        repositoryHandle = PostgresIntegrationTestSupport.createV1IndividualRepository(POSTGRES);
-        repository = repositoryHandle.repository();
+        repositoryHandle =
+                PostgresIntegrationTestSupport.createV1OntologyIndividualRepositories(POSTGRES);
+        repository = repositoryHandle.individualRepository();
+        jsTreeRepository = repositoryHandle.jsTreeRepository();
     }
 
     @AfterAll
@@ -145,5 +151,57 @@ class V1IndividualRepositoryIT {
             assertThat(individual.lang).isEqualTo("en_US");
             assertThat(individual.label).isEqualTo("Permission instance");
         });
+    }
+
+    @Test
+    void scopesListsAndEveryIdentifierToOneOntology() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByOntology("efo", "en", pageable))
+                .extracting(individual -> individual.iri)
+                .containsExactly(
+                        "http://example.org/EFO_I100",
+                        "http://example.org/EFO_I200",
+                        "http://example.org/EFO_I999");
+        assertThat(repository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_I100", "fr").lang).isEqualTo("fr");
+        assertThat(repository.findByOntologyAndShortForm("efo", "fr", "EFO_I100").iri)
+                .isEqualTo("http://example.org/EFO_I100");
+        assertThat(repository.findByOntologyAndOboId("efo", "fr", "EFO:I100").iri)
+                .isEqualTo("http://example.org/EFO_I100");
+        assertThat(repository.findByOntologyAndIri(
+                "duo", "http://example.org/EFO_I100", "en")).isNull();
+    }
+
+    @Test
+    void returnsDirectAndAllTypesFromProductionHierarchyColumns() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.getDirectTypes(
+                "efo", "http://example.org/EFO_I100", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getAllTypes(
+                "efo", "http://example.org/EFO_I100", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+    }
+
+    @Test
+    void buildsTheIndividualJsTreeFromRealPostgresAncestors() {
+        List<Map<String, Object>> tree = jsTreeRepository.getJsTreeForIndividual(
+                "http://example.org/EFO_I100", "efo", "en");
+
+        assertThat(tree).hasSize(2);
+        assertThat(tree.get(0))
+                .containsEntry("iri", "http://example.org/EFO_0001")
+                .containsEntry("text", "Liver disease")
+                .containsEntry("parent", "#");
+        assertThat(tree.get(1))
+                .containsEntry("iri", "http://example.org/EFO_I100")
+                .containsEntry("text", "Liver specimen alpha")
+                .containsEntry("children", false);
+        assertThat(((Map<?, ?>) tree.get(1).get("state")).get("selected"))
+                .isEqualTo(true);
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -15,6 +15,7 @@ import uk.ac.ebi.spot.ols.repository.PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
 import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
 import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
@@ -200,9 +201,32 @@ public final class PostgresIntegrationTestSupport {
         PostgresClient postgresClient = createPostgresClient(container);
         OlsSearchClient searchClient = createSearchClient(postgresClient);
 
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
         V1IndividualRepository repository = new V1IndividualRepository();
         ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
         return new V1IndividualRepositoryHandle(repository, postgresClient);
+    }
+
+    public static V1OntologyIndividualRepositoryHandle createV1OntologyIndividualRepositories(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        V1IndividualRepository individualRepository = new V1IndividualRepository();
+        ReflectionTestUtils.setField(individualRepository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(individualRepository, "postgresClient", olsPostgresClient);
+
+        V1JsTreeRepository jsTreeRepository = new V1JsTreeRepository();
+        ReflectionTestUtils.setField(jsTreeRepository, "postgresClient", olsPostgresClient);
+
+        return new V1OntologyIndividualRepositoryHandle(
+                individualRepository, jsTreeRepository, postgresClient);
     }
 
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
@@ -524,10 +548,11 @@ public final class PostgresIntegrationTestSupport {
                 INSERT INTO ols_entities (
                     id, type, iri, ontology_id, _json, is_obsolete, label, search_type,
                     short_form, curie, obo_id, synonym, definition, is_defining_ontology,
-                    subset, related_to, label_for_suggest, filter_tags, filter_domain,
+                    subset, related_to, direct_parents, direct_ancestors,
+                    label_for_suggest, filter_tags, filter_domain,
                     "filter_http://example.org/category",
                     "filter_http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (JsonElement element : fixture.getAsJsonArray("records")) {
@@ -548,13 +573,15 @@ public final class PostgresIntegrationTestSupport {
                 statement.setBoolean(14, record.get("isDefiningOntology").getAsBoolean());
                 statement.setArray(15, textArray(connection, record.getAsJsonArray("subset")));
                 statement.setArray(16, textArray(connection, record.getAsJsonArray("relatedTo")));
-                statement.setString(17, record.getAsJsonArray("label").get(0).getAsString());
-                statement.setArray(18, textArray(connection, record.getAsJsonArray("tags")));
-                statement.setArray(19, textArray(connection, record.getAsJsonArray("domain")));
-                statement.setArray(20, textArray(
+                statement.setArray(17, textArray(connection, record.getAsJsonArray("directParents")));
+                statement.setArray(18, textArray(connection, record.getAsJsonArray("directAncestors")));
+                statement.setString(19, record.getAsJsonArray("label").get(0).getAsString());
+                statement.setArray(20, textArray(connection, record.getAsJsonArray("tags")));
+                statement.setArray(21, textArray(connection, record.getAsJsonArray("domain")));
+                statement.setArray(22, textArray(
                         connection,
                         record.getAsJsonArray("http://example.org/category")));
-                statement.setArray(21, textArray(
+                statement.setArray(23, textArray(
                         connection,
                         record.getAsJsonArray("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")));
                 statement.addBatch();
@@ -674,6 +701,17 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1IndividualRepositoryHandle(
             V1IndividualRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record V1OntologyIndividualRepositoryHandle(
+            V1IndividualRepository individualRepository,
+            V1JsTreeRepository jsTreeRepository,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/backend/src/test/resources/fixtures/individuals/README.md
+++ b/backend/src/test/resources/fixtures/individuals/README.md
@@ -3,6 +3,8 @@
 This four-record synthetic supplement is loaded only by the V1 and V2 individual suites. It keeps
 the shared entity fixture totals unchanged while covering global and ontology-scoped individual
 search, obsolete filtering, pagination, dynamic properties, lookup by IRI, and class membership.
+The same records carry direct-parent and ancestor columns plus nested `directParent` values for
+the V1 ontology-scoped `types`, `alltypes`, and JS-tree routes.
 
 - Two active EFO individuals distinguish defining status, search fields, ranking, filters, and
   membership in different EFO classes.

--- a/backend/src/test/resources/fixtures/individuals/individual-fixture.json
+++ b/backend/src/test/resources/fixtures/individuals/individual-fixture.json
@@ -15,6 +15,12 @@
       "curie": "EFO:I100",
       "subset": ["individuals"],
       "relatedTo": [],
+      "directParents": [
+        "http://example.org/EFO_0001"
+      ],
+      "directAncestors": [
+        "http://example.org/EFO_0001"
+      ],
       "tags": ["clinical"],
       "domain": ["biology"],
       "http://example.org/category": ["clinical"],
@@ -33,7 +39,10 @@
         "curie": "EFO:I100",
         "isObsolete": false,
         "isDefiningOntology": true,
-        "hasDirectParents": false,
+        "directParent": [
+          "http://example.org/EFO_0001"
+        ],
+        "hasDirectParents": true,
         "hasHierarchicalParents": false,
         "linkedEntities": {}
       }
@@ -53,6 +62,13 @@
       "curie": "EFO:I200",
       "subset": ["individuals"],
       "relatedTo": [],
+      "directParents": [
+        "http://example.org/EFO_0002"
+      ],
+      "directAncestors": [
+        "http://example.org/EFO_0001",
+        "http://example.org/EFO_0002"
+      ],
       "tags": ["experimental"],
       "domain": ["biology"],
       "http://example.org/category": ["research"],
@@ -71,7 +87,10 @@
         "curie": "EFO:I200",
         "isObsolete": false,
         "isDefiningOntology": false,
-        "hasDirectParents": false,
+        "directParent": [
+          "http://example.org/EFO_0002"
+        ],
+        "hasDirectParents": true,
         "hasHierarchicalParents": false,
         "linkedEntities": {}
       }
@@ -91,6 +110,12 @@
       "curie": "DUO:I100",
       "subset": ["individuals"],
       "relatedTo": [],
+      "directParents": [
+        "http://example.org/DUO_0001"
+      ],
+      "directAncestors": [
+        "http://example.org/DUO_0001"
+      ],
       "tags": ["policy"],
       "domain": ["information"],
       "http://example.org/category": ["policy"],
@@ -109,7 +134,10 @@
         "curie": "DUO:I100",
         "isObsolete": false,
         "isDefiningOntology": true,
-        "hasDirectParents": false,
+        "directParent": [
+          "http://example.org/DUO_0001"
+        ],
+        "hasDirectParents": true,
         "hasHierarchicalParents": false,
         "linkedEntities": {}
       }
@@ -129,6 +157,12 @@
       "curie": "EFO:I999",
       "subset": ["legacy"],
       "relatedTo": [],
+      "directParents": [
+        "http://example.org/EFO_0001"
+      ],
+      "directAncestors": [
+        "http://example.org/EFO_0001"
+      ],
       "tags": ["archived"],
       "domain": ["biology"],
       "http://example.org/category": ["archived"],
@@ -147,7 +181,10 @@
         "curie": "EFO:I999",
         "isObsolete": true,
         "isDefiningOntology": true,
-        "hasDirectParents": false,
+        "directParent": [
+          "http://example.org/EFO_0001"
+        ],
+        "hasDirectParents": true,
         "hasHierarchicalParents": false,
         "linkedEntities": {}
       }

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -491,6 +491,31 @@ Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
   migration. PR #1384 restored the legacy parent-or-descendant behavior with focused regressions;
   it was isolated and merged before this test branch was rebased.
 
+## Implemented V1 ontology-individual-controller baseline
+
+Verified locally on 2026-09-03 with Java 17 and Rancher Desktop:
+
+- Surefire runs 660 tests, including 5 direct `V1OntologyIndividualControllerTest` cases and 23
+  `V1OntologyIndividualControllerWIT` invocations. Two runs with a deliberately unavailable
+  Docker socket took Maven 19.620 and 19.634 seconds (wall-clock 20.54 and 20.53 seconds).
+- Failsafe runs 136 PostgreSQL tests, including 10 `V1IndividualRepositoryIT` cases and 5 thin
+  `V1OntologyIndividualControllerIT` cases. Two complete database-gate runs took Maven 1 minute 25
+  seconds each (wall-clock 86.92 and 86.81 seconds).
+- The clean `verify` lifecycle runs all 796 tests in Maven 1 minute 36 seconds (wall-clock 97.79
+  seconds).
+- Whole-backend JaCoCo coverage is 48.9% lines (2,338 of 4,785) and 38.5% branches (738 of
+  1,916). The V1 ontology-individual controller covers 37 of 40 executable lines and all 14
+  branches; only its JSON-serialization failure path remains uncovered. Its individual repository
+  covers 74 of 76 lines. No coverage failure threshold is introduced.
+- The suites preserve all five ontology-scoped individual routes, legacy HAL fields, ontology and
+  language handling, identifier precedence, double-encoded IRI paths, pagination normalization,
+  direct and transitive types, JS-tree output, and stable error fields. The existing four-record
+  individual fixture now carries synthetic direct-parent and ancestor data without changing its
+  record count.
+- The rollout exposed that collection lookup by `short_form` or `obo_id` passed the identifier and
+  language to the repository in the wrong order. PR #1388 corrected both calls with focused
+  regressions and was isolated and merged before this test branch was rebased.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary
- add direct controller tests for route selection, decoding, type delegation, and JS-tree serialization
- add an exactly named Spring MVC WIT suite for all five routes and supported parameters, pagination compatibility, HAL fields, and stable errors
- extend the committed individual fixture for real PostgreSQL type and JS-tree coverage, with three repository cases and five thin controller-to-database cases
- record the measured Java 17 baseline in the backend testing strategy

## Defect isolated first
- #1388 fixes the short-form and OBO-ID repository argument order and is merged into dev

## Local verification
- focused unit/WIT: 28 tests, Maven 18.240s after final assertion update
- Docker-free Surefire twice: 660 tests, Maven 19.620s and 19.634s; wall 20.54s and 20.53s
- focused PostgreSQL: 15 tests, Maven 15.443s; wall 16.24s
- PostgreSQL gate twice: 136 tests, Maven 1m25s each; wall 86.92s and 86.81s
- clean verify: 796 tests, Maven 1m36s; wall 97.79s
- JaCoCo: 48.9% lines and 38.5% branches; controller 37/40 lines and 14/14 branches

No production code or API golden fixtures are changed. test_api.sh is unchanged and was not run locally.