### PR TITLE
test: cover v1 ontology property controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerIT.java
@@ -1,0 +1,163 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.MessageResolver;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.core.AnnotationLinkRelationProvider;
+import org.springframework.hateoas.server.core.DelegatingLinkRelationProvider;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1OntologyPropertyControllerIT {
+
+    private static final URI PROPERTY_URI = URI.create(
+            "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0101");
+    private static final URI ROOTS_URI = URI.create("/api/ontologies/EFO/properties/roots");
+    private static final URI PARENTS_URI = URI.create(PROPERTY_URI + "/parents");
+    private static final URI CHILDREN_URI = URI.create(
+            "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0100/children");
+    private static final URI JS_TREE_URI = URI.create(PROPERTY_URI + "/jstree");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1OntologyPropertyRepositoryHandle
+            repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializePropertyDatabase(POSTGRES);
+        repositoryHandle =
+                PostgresIntegrationTestSupport.createV1OntologyPropertyRepositories(POSTGRES);
+
+        V1OntologyPropertyController controller = new V1OntologyPropertyController();
+        ReflectionTestUtils.setField(
+                controller, "propertyRepository", repositoryHandle.propertyRepository());
+        ReflectionTestUtils.setField(
+                controller, "jsTreeRepository", repositoryHandle.jsTreeRepository());
+        controller.termAssembler = new V1PropertyAssembler();
+
+        HateoasPageableHandlerMethodArgumentResolver pageableResolver =
+                new HateoasPageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(1000);
+        PagedResourcesAssemblerArgumentResolver assemblerResolver =
+                new PagedResourcesAssemblerArgumentResolver(pageableResolver);
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(pageableResolver, assemblerResolver)
+                .setMessageConverters(
+                        new StringHttpMessageConverter(StandardCharsets.UTF_8),
+                        halMessageConverter())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsOntologyPropertiesThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/ontologies/EFO/properties"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"))
+                .andExpect(jsonPath("$._embedded.properties[2].is_obsolete").value(true));
+    }
+
+    @Test
+    void getsDoubleEncodedOntologyPropertyThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(PROPERTY_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.iri").value("http://example.org/EFO_0101"))
+                .andExpect(jsonPath("$.label").value("has material"))
+                .andExpect(jsonPath("$.lang").value("fr"));
+    }
+
+    @Test
+    void getsRootsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"));
+    }
+
+    @Test
+    void getsDirectPropertyParentsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"));
+    }
+
+    @Test
+    void getsDirectPropertyChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0101"));
+    }
+
+    @Test
+    void getsPropertyJsTreeThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_0100"))
+                .andExpect(jsonPath("$[0].text").value("has specimen"))
+                .andExpect(jsonPath("$[0].parent").value("#"))
+                .andExpect(jsonPath("$[1].iri").value("http://example.org/EFO_0101"))
+                .andExpect(jsonPath("$[1].text").value("has material"))
+                .andExpect(jsonPath("$[1].state.selected").value(true));
+    }
+
+    private static MappingJackson2HttpMessageConverter halMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jackson2HalModule());
+        objectMapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(
+                new DelegatingLinkRelationProvider(
+                        new AnnotationLinkRelationProvider(),
+                        new EvoInflectorLinkRelationProvider()),
+                CurieProvider.NONE,
+                MessageResolver.DEFAULTS_ONLY));
+
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaTypes.HAL_JSON));
+        return converter;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerIT.java
@@ -38,10 +38,17 @@ class V1OntologyPropertyControllerIT {
     private static final URI PROPERTY_URI = URI.create(
             "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0101");
     private static final URI ROOTS_URI = URI.create("/api/ontologies/EFO/properties/roots");
+    private static final URI PARENT_URI = URI.create(
+            "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0100");
     private static final URI PARENTS_URI = URI.create(PROPERTY_URI + "/parents");
-    private static final URI CHILDREN_URI = URI.create(
-            "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0100/children");
+    private static final URI CHILDREN_URI = URI.create(PARENT_URI + "/children");
+    private static final URI DESCENDANTS_URI = URI.create(PARENT_URI + "/descendants");
+    private static final URI ANCESTORS_URI = URI.create(PROPERTY_URI + "/ancestors");
     private static final URI JS_TREE_URI = URI.create(PROPERTY_URI + "/jstree");
+    // Base64 encoding of "http://example.org/EFO_0100" — the opaque node id a client obtains
+    // from a prior /jstree response and echoes back to expand that node's children.
+    private static final URI JS_TREE_CHILDREN_URI = URI.create(
+            PARENT_URI + "/jstree/children/aHR0cDovL2V4YW1wbGUub3JnL0VGT18wMTAw");
 
     @Container
     private static final PostgreSQLContainer<?> POSTGRES =
@@ -130,6 +137,33 @@ class V1OntologyPropertyControllerIT {
                 .andExpect(jsonPath("$.page.totalElements").value(1))
                 .andExpect(jsonPath("$._embedded.properties[0].iri")
                         .value("http://example.org/EFO_0101"));
+    }
+
+    @Test
+    void getsPropertyDescendantsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0101"));
+    }
+
+    @Test
+    void getsPropertyAncestorsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.properties[0].iri")
+                        .value("http://example.org/EFO_0100"));
+    }
+
+    @Test
+    void getsPropertyJsTreeChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(JS_TREE_CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_0101"))
+                .andExpect(jsonPath("$[0].text").value("has material"));
     }
 
     @Test

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerTest.java
@@ -1,0 +1,225 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Property;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1OntologyPropertyControllerTest {
+
+    private V1OntologyPropertyController controller;
+    private V1PropertyRepository propertyRepository;
+    private V1JsTreeRepository jsTreeRepository;
+    private V1PropertyAssembler termAssembler;
+    private PagedResourcesAssembler<V1Property> propertyResourcesAssembler;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        propertyRepository = mock(V1PropertyRepository.class);
+        jsTreeRepository = mock(V1JsTreeRepository.class);
+        termAssembler = mock(V1PropertyAssembler.class);
+        propertyResourcesAssembler = mock(PagedResourcesAssembler.class);
+        pageable = PageRequest.of(1, 7);
+
+        controller = new V1OntologyPropertyController();
+        ReflectionTestUtils.setField(controller, "propertyRepository", propertyRepository);
+        ReflectionTestUtils.setField(controller, "jsTreeRepository", jsTreeRepository);
+        controller.termAssembler = termAssembler;
+    }
+
+    @Test
+    void listsOntologyPropertiesWhenNoIdentifierIsSupplied() {
+        OlsFacetedResultsPage<V1Property> properties = new OlsFacetedResultsPage<>(
+                List.of(property()), Map.of(), pageable, 1);
+        PagedModel<EntityModel<V1Property>> assembled = PagedModel.empty();
+        when(propertyRepository.findAllByOntology("efo", "fr", pageable))
+                .thenReturn(properties);
+        when(propertyResourcesAssembler.toModel(properties, termAssembler))
+                .thenReturn(assembled);
+
+        var response = controller.getAllPropertiesByOntology(
+                "EFO", null, null, null, "fr", pageable, propertyResourcesAssembler);
+
+        assertSame(assembled, response.getBody());
+        verify(propertyRepository).findAllByOntology("efo", "fr", pageable);
+    }
+
+    @Test
+    void selectsIriBeforeShortFormAndOboIdUsingRepositoryArgumentOrder() {
+        when(propertyRepository.findByOntologyAndIri("efo", "the-iri", "fr"))
+                .thenReturn(property());
+
+        controller.getAllPropertiesByOntology(
+                "EFO", "the-iri", "EFO_0100", "EFO:0100", "fr", pageable,
+                propertyResourcesAssembler);
+
+        verify(propertyRepository).findByOntologyAndIri("efo", "the-iri", "fr");
+        verify(propertyRepository, never())
+                .findByOntologyAndShortForm("efo", "EFO_0100", "fr");
+        verify(propertyRepository, never())
+                .findByOntologyAndOboId("efo", "EFO:0100", "fr");
+
+        when(propertyRepository.findByOntologyAndShortForm("efo", "EFO_0101", "fr"))
+                .thenReturn(property());
+        controller.getAllPropertiesByOntology(
+                "EFO", null, "EFO_0101", "EFO:0101", "fr", pageable,
+                propertyResourcesAssembler);
+        verify(propertyRepository).findByOntologyAndShortForm("efo", "EFO_0101", "fr");
+
+        when(propertyRepository.findByOntologyAndOboId("efo", "EFO:0199", "fr"))
+                .thenReturn(property());
+        controller.getAllPropertiesByOntology(
+                "EFO", null, null, "EFO:0199", "fr", pageable,
+                propertyResourcesAssembler);
+        verify(propertyRepository).findByOntologyAndOboId("efo", "EFO:0199", "fr");
+
+        controller.getAllPropertiesByOntology(
+                "EFO", "missing-iri", null, null, "fr", pageable,
+                propertyResourcesAssembler);
+        controller.getAllPropertiesByOntology(
+                "EFO", null, "missing-short-form", null, "fr", pageable,
+                propertyResourcesAssembler);
+        controller.getAllPropertiesByOntology(
+                "EFO", null, null, "MISSING:1", "fr", pageable,
+                propertyResourcesAssembler);
+        verify(propertyResourcesAssembler, times(3)).toModel(null, termAssembler);
+    }
+
+    @Test
+    void getsRootsAndReportsMissingResource() throws Exception {
+        PageImpl<V1Property> roots = new PageImpl<>(List.of(property()));
+        when(propertyRepository.getRoots("efo", false, "fr", pageable)).thenReturn(roots);
+
+        controller.getRoots("EFO", false, "fr", pageable, propertyResourcesAssembler);
+
+        verify(propertyRepository).getRoots("efo", false, "fr", pageable);
+
+        when(propertyRepository.getRoots("efo", true, "en", pageable)).thenReturn(null);
+        assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getRoots("EFO", true, "en", pageable, propertyResourcesAssembler));
+    }
+
+    @Test
+    void getsDecodedPropertyAndReportsMissingProperty() {
+        when(propertyRepository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_0100", "en"))
+                .thenReturn(property());
+        EntityModel<V1Property> assembled = EntityModel.of(property());
+        when(termAssembler.toModel(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(assembled);
+
+        var response = controller.getProperty(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0100", "en");
+
+        assertSame(assembled, response.getBody());
+        verify(propertyRepository).findByOntologyAndIri(
+                "efo", "http://example.org/EFO_0100", "en");
+
+        when(propertyRepository.findByOntologyAndIri("efo", "missing", "en"))
+                .thenReturn(null);
+        ResourceNotFoundException error = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getProperty("EFO", "missing", "en"));
+        assertEquals("No property with id missing in efo", error.getMessage());
+    }
+
+    @Test
+    void delegatesDecodedParentsChildrenDescendantsAndAncestors() {
+        PageImpl<V1Property> page = new PageImpl<>(List.of(property()));
+        when(propertyRepository.getParents(
+                "efo", "http://example.org/EFO_0101", "fr", pageable)).thenReturn(page);
+        when(propertyRepository.getChildren(
+                "efo", "http://example.org/EFO_0100", "fr", pageable)).thenReturn(page);
+        when(propertyRepository.getDescendants(
+                "efo", "http://example.org/EFO_0100", "fr", pageable)).thenReturn(page);
+        when(propertyRepository.getAncestors(
+                "efo", "http://example.org/EFO_0101", "fr", pageable)).thenReturn(page);
+
+        controller.getParents(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0101", "fr", pageable,
+                propertyResourcesAssembler);
+        controller.children(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0100", "fr", pageable,
+                propertyResourcesAssembler);
+        controller.descendants(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0100", "fr", pageable,
+                propertyResourcesAssembler);
+        controller.ancestors(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0101", "fr", pageable,
+                propertyResourcesAssembler);
+
+        verify(propertyRepository).getParents(
+                "efo", "http://example.org/EFO_0101", "fr", pageable);
+        verify(propertyRepository).getChildren(
+                "efo", "http://example.org/EFO_0100", "fr", pageable);
+        verify(propertyRepository).getDescendants(
+                "efo", "http://example.org/EFO_0100", "fr", pageable);
+        verify(propertyRepository).getAncestors(
+                "efo", "http://example.org/EFO_0101", "fr", pageable);
+    }
+
+    @Test
+    void serializesTheDecodedPropertyJsTree() {
+        when(jsTreeRepository.getJsTreeForProperty(
+                "http://example.org/EFO_0101", "efo", "fr"))
+                .thenReturn(List.of(Map.of(
+                        "iri", "http://example.org/EFO_0101",
+                        "text", "has material")));
+
+        var response = controller.getJsTree(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0101", false, "PreferredRoots", "fr");
+
+        verify(jsTreeRepository).getJsTreeForProperty(
+                "http://example.org/EFO_0101", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_0101", "has material");
+    }
+
+    @Test
+    void serializesTheDecodedPropertyJsTreeChildren() {
+        when(jsTreeRepository.getJsTreeChildrenForProperty(
+                "http://example.org/EFO_0100", "node-1", "efo", "fr"))
+                .thenReturn(List.of(Map.of(
+                        "iri", "http://example.org/EFO_0101",
+                        "text", "has material")));
+
+        var response = controller.graphJsTreeChildren(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0100", "node-1", "fr");
+
+        verify(jsTreeRepository).getJsTreeChildrenForProperty(
+                "http://example.org/EFO_0100", "node-1", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_0101", "has material");
+    }
+
+    private static V1Property property() {
+        V1Property property = new V1Property();
+        property.iri = "http://example.org/EFO_0100";
+        return property;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerWIT.java
@@ -1,0 +1,508 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.model.v1.V1Property;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
+import uk.ac.ebi.spot.ols.service.PostgresClient;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1OntologyPropertyController.class)
+@ContextConfiguration(classes = {
+        V1OntologyPropertyController.class,
+        V1PropertyAssembler.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1OntologyPropertyControllerWIT {
+
+    private static final String PROPERTY_IRI = "http://example.org/EFO_0101";
+    private static final URI LIST_URI = URI.create("/api/ontologies/EFO/properties");
+    private static final URI ROOTS_URI = URI.create("/api/ontologies/EFO/properties/roots");
+    private static final URI PROPERTY_URI = URI.create(
+            "/api/ontologies/EFO/properties/http%253A%252F%252Fexample.org%252FEFO_0101");
+    private static final URI PARENTS_URI = URI.create(PROPERTY_URI + "/parents");
+    private static final URI CHILDREN_URI = URI.create(PROPERTY_URI + "/children");
+    private static final URI DESCENDANTS_URI = URI.create(PROPERTY_URI + "/descendants");
+    private static final URI ANCESTORS_URI = URI.create(PROPERTY_URI + "/ancestors");
+    private static final URI JS_TREE_URI = URI.create(PROPERTY_URI + "/jstree");
+    private static final URI JS_TREE_CHILDREN_URI = URI.create(
+            PROPERTY_URI + "/jstree/children/node-1");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private V1PropertyRepository propertyRepository;
+
+    @MockitoBean
+    private V1JsTreeRepository jsTreeRepository;
+
+    @MockitoBean
+    private PostgresClient postgresClient;
+
+    @MockitoBean
+    private EntityLinks entityLinks;
+
+    @BeforeEach
+    void stubResponses() {
+        when(propertyRepository.findAllByOntology(anyString(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(2), invocation.getArgument(1)));
+        when(propertyRepository.findByOntologyAndIri(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> property(invocation.getArgument(2)));
+        when(propertyRepository.findByOntologyAndShortForm(
+                anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> property(invocation.getArgument(2)));
+        when(propertyRepository.findByOntologyAndOboId(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> property(invocation.getArgument(2)));
+        when(propertyRepository.getRoots(anyString(), anyBoolean(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(propertyRepository.getParents(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(propertyRepository.getChildren(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(propertyRepository.getDescendants(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(propertyRepository.getAncestors(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> propertyPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(jsTreeRepository.getJsTreeForProperty(anyString(), anyString(), anyString()))
+                .thenReturn(List.of(Map.of(
+                        "id", "property-node",
+                        "parent", "#",
+                        "iri", PROPERTY_IRI,
+                        "text", "has material",
+                        "state", Map.of("selected", true),
+                        "children", false,
+                        "ontology_name", "efo")));
+        when(jsTreeRepository.getJsTreeChildrenForProperty(
+                anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(List.of(Map.of(
+                        "id", "child-node",
+                        "parent", "property-node",
+                        "iri", PROPERTY_IRI,
+                        "text", "has material")));
+    }
+
+    @Test
+    void returnsDefaultOntologyPropertyListContract() throws Exception {
+        mockMvc.perform(get(LIST_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$._embedded.properties[0].label").value("has material"))
+                .andExpect(jsonPath("$._embedded.properties[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("en"))
+                .andExpect(jsonPath("$._embedded.properties[0]._links.self.href")
+                        .value(endsWith("/api/ontologies/efo/properties/"
+                                + "http%253A%252F%252Fexample.org%252FEFO_0101?lang=en")))
+                .andExpect(jsonPath("$.page.size").value(1000))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.totalPages").value(1))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(propertyRepository).findAllByOntology("efo", "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void bindsCollectionLanguagePageSizeAndSort() throws Exception {
+        mockMvc.perform(get(LIST_URI)
+                        .param("lang", "fr")
+                        .param("page", "2")
+                        .param("size", "7")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).findAllByOntology(
+                "efo", "fr", PageRequest.of(2, 7,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void routesEveryCollectionIdentifierAndAppliesPrecedence() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("iri", PROPERTY_IRI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+        verify(propertyRepository).findByOntologyAndIri("efo", PROPERTY_IRI, "fr");
+
+        mockMvc.perform(get(LIST_URI).param("short_form", "EFO_0101").param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+        verify(propertyRepository).findByOntologyAndShortForm("efo", "EFO_0101", "fr");
+
+        mockMvc.perform(get(LIST_URI).param("obo_id", "EFO:0101").param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+        verify(propertyRepository).findByOntologyAndOboId("efo", "EFO:0101", "fr");
+
+        mockMvc.perform(get(LIST_URI)
+                        .param("iri", PROPERTY_IRI)
+                        .param("short_form", "ignored")
+                        .param("obo_id", "IGNORED:1"))
+                .andExpect(status().isOk());
+        verify(propertyRepository, never())
+                .findByOntologyAndShortForm("efo", "ignored", "en");
+        verify(propertyRepository, never())
+                .findByOntologyAndOboId("efo", "IGNORED:1", "en");
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleCollectionParameters() throws Exception {
+        mockMvc.perform(get(LIST_URI)
+                        .param("search", "material")
+                        .param("includeObsoleteEntities", "false")
+                        .param("subset", "core", "slim")
+                        .param("http://example.org/category", "clinical", "policy"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAllByOntology("efo", "en", PageRequest.of(0, 1000));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "list, -1, 20, 0, 20",
+            "list, 0, 0, 0, 1000",
+            "list, 0, 1001, 0, 1000",
+            "roots, -1, 20, 0, 20",
+            "roots, 0, 0, 0, 1000",
+            "roots, 0, 1001, 0, 1000",
+            "parents, -1, 20, 0, 20",
+            "parents, 0, 0, 0, 1000",
+            "parents, 0, 1001, 0, 1000",
+            "children, -1, 20, 0, 20",
+            "children, 0, 0, 0, 1000",
+            "children, 0, 1001, 0, 1000",
+            "descendants, -1, 20, 0, 20",
+            "descendants, 0, 0, 0, 1000",
+            "descendants, 0, 1001, 0, 1000",
+            "ancestors, -1, 20, 0, 20",
+            "ancestors, 0, 0, 0, 1000",
+            "ancestors, 0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundariesAcrossPagedRoutes(
+            String route,
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "list" -> verify(propertyRepository).findAllByOntology("efo", "en", expected);
+            case "roots" -> verify(propertyRepository)
+                    .getRoots("efo", false, "en", expected);
+            case "parents" -> verify(propertyRepository)
+                    .getParents("efo", PROPERTY_IRI, "en", expected);
+            case "children" -> verify(propertyRepository)
+                    .getChildren("efo", PROPERTY_IRI, "en", expected);
+            case "descendants" -> verify(propertyRepository)
+                    .getDescendants("efo", PROPERTY_IRI, "en", expected);
+            case "ancestors" -> verify(propertyRepository)
+                    .getAncestors("efo", PROPERTY_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void usesPaginationDefaultsForMalformedNumericValuesAcrossPagedRoutes() throws Exception {
+        Pageable defaults = PageRequest.of(0, 1000);
+
+        mockMvc.perform(get(LIST_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(ROOTS_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(PARENTS_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAllByOntology("efo", "en", defaults);
+        verify(propertyRepository).getRoots("efo", false, "en", defaults);
+        verify(propertyRepository).getParents("efo", PROPERTY_IRI, "en", defaults);
+    }
+
+    @Test
+    void returnsDoubleEncodedPropertyWithDefaultAndExplicitLanguage() throws Exception {
+        mockMvc.perform(get(PROPERTY_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$.label").value("has material"))
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.lang").value("en"));
+        verify(propertyRepository).findByOntologyAndIri("efo", PROPERTY_IRI, "en");
+
+        mockMvc.perform(get(PROPERTY_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lang").value("fr"));
+        verify(propertyRepository).findByOntologyAndIri("efo", PROPERTY_IRI, "fr");
+    }
+
+    @Test
+    void returnsRootsWithDefaultAndExplicitIncludeObsoletes() throws Exception {
+        mockMvc.perform(get(ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+        verify(propertyRepository).getRoots("efo", false, "en", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "true"))
+                .andExpect(status().isOk());
+        verify(propertyRepository).getRoots("efo", true, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void rejectsMalformedIncludeObsoletesWithStableErrorFields() throws Exception {
+        mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400));
+    }
+
+    @Test
+    void returnsParentsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$.page.size").value(1000));
+
+        mockMvc.perform(get(PARENTS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).getParents(
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsChildrenWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+
+        mockMvc.perform(get(CHILDREN_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).getChildren("efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+    }
+
+    @Test
+    void returnsDescendantsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+
+        mockMvc.perform(get(DESCENDANTS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).getDescendants(
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+    }
+
+    @Test
+    void returnsAncestorsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].iri").value(PROPERTY_IRI));
+
+        mockMvc.perform(get(ANCESTORS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+
+        verify(propertyRepository).getAncestors(
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+    }
+
+    @Test
+    void returnsDoubleEncodedPropertyJsTreeWithExplicitLanguage() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$[0].text").value("has material"))
+                .andExpect(jsonPath("$[0].state.selected").value(true));
+
+        verify(jsTreeRepository).getJsTreeForProperty(PROPERTY_IRI, "efo", "fr");
+    }
+
+    @Test
+    void acceptsIgnoredSiblingsAndViewModeParametersOnJsTree() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI)
+                        .param("siblings", "true")
+                        .param("viewMode", "All"))
+                .andExpect(status().isOk());
+
+        verify(jsTreeRepository).getJsTreeForProperty(PROPERTY_IRI, "efo", "en");
+    }
+
+    @Test
+    void returnsPropertyJsTreeChildrenForADecodedNode() throws Exception {
+        mockMvc.perform(get(JS_TREE_CHILDREN_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value(PROPERTY_IRI))
+                .andExpect(jsonPath("$[0].text").value("has material"));
+
+        verify(jsTreeRepository).getJsTreeChildrenForProperty(
+                PROPERTY_IRI, "node-1", "efo", "fr");
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageCompatibilityAcrossRouteFamilies() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("en_US"));
+        mockMvc.perform(get(PARENTS_URI).param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("en_US"));
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "en_US"))
+                .andExpect(status().isOk());
+
+        verify(propertyRepository).findAllByOntology("efo", "en_US", PageRequest.of(0, 1000));
+        verify(propertyRepository).getParents(
+                "efo", PROPERTY_IRI, "en_US", PageRequest.of(0, 1000));
+        verify(jsTreeRepository).getJsTreeForProperty(PROPERTY_IRI, "efo", "en_US");
+    }
+
+    @Test
+    void supportsLegacyHalMediaTypeOnEveryHalRoute() throws Exception {
+        for (URI uri : List.of(
+                LIST_URI, ROOTS_URI, PROPERTY_URI, PARENTS_URI,
+                CHILDREN_URI, DESCENDANTS_URI, ANCESTORS_URI, JS_TREE_URI)) {
+            mockMvc.perform(get(uri).accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        }
+    }
+
+    @Test
+    void returnsStableLegacyNotFoundStatusAndMessage() throws Exception {
+        when(propertyRepository.findByOntologyAndIri("efo", PROPERTY_IRI, "en"))
+                .thenReturn(null);
+
+        mockMvc.perform(get(PROPERTY_URI))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void returnsStableBadRequestFieldsForUnsupportedSort() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(propertyRepository.getParents("efo", PROPERTY_IRI, "en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get(PARENTS_URI).param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
+        mockMvc.perform(post(LIST_URI))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private static URI route(String route) {
+        return switch (route) {
+            case "list" -> LIST_URI;
+            case "roots" -> ROOTS_URI;
+            case "parents" -> PARENTS_URI;
+            case "children" -> CHILDREN_URI;
+            case "descendants" -> DESCENDANTS_URI;
+            case "ancestors" -> ANCESTORS_URI;
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        };
+    }
+
+    private static OlsFacetedResultsPage<V1Property> propertyPage(
+            Pageable pageable,
+            String lang) {
+        return new OlsFacetedResultsPage<>(
+                List.of(property(lang)), Map.of(), pageable, 1);
+    }
+
+    private static V1Property property(String lang) {
+        V1Property property = new V1Property();
+        property.iri = PROPERTY_IRI;
+        property.lang = lang;
+        property.label = "has material";
+        property.description = new String[]{"A specimen relation used in hierarchy tests."};
+        property.synonyms = new String[]{"material relation"};
+        property.ontologyName = "efo";
+        property.ontologyPrefix = "EFO";
+        property.ontologyIri = "http://www.ebi.ac.uk/efo";
+        property.isObsolete = false;
+        property.isLocal = true;
+        property.hasChildren = false;
+        property.isRoot = false;
+        property.shortForm = "EFO_0101";
+        property.oboId = "EFO:0101";
+        property.annotation = Map.of();
+        return property;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyPropertyControllerWIT.java
@@ -257,10 +257,19 @@ class V1OntologyPropertyControllerWIT {
                 .andExpect(status().isOk());
         mockMvc.perform(get(PARENTS_URI).param("page", "bad").param("size", "bad"))
                 .andExpect(status().isOk());
+        mockMvc.perform(get(CHILDREN_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(DESCENDANTS_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
+        mockMvc.perform(get(ANCESTORS_URI).param("page", "bad").param("size", "bad"))
+                .andExpect(status().isOk());
 
         verify(propertyRepository).findAllByOntology("efo", "en", defaults);
         verify(propertyRepository).getRoots("efo", false, "en", defaults);
         verify(propertyRepository).getParents("efo", PROPERTY_IRI, "en", defaults);
+        verify(propertyRepository).getChildren("efo", PROPERTY_IRI, "en", defaults);
+        verify(propertyRepository).getDescendants("efo", PROPERTY_IRI, "en", defaults);
+        verify(propertyRepository).getAncestors("efo", PROPERTY_IRI, "en", defaults);
     }
 
     @Test
@@ -290,6 +299,17 @@ class V1OntologyPropertyControllerWIT {
         mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "true"))
                 .andExpect(status().isOk());
         verify(propertyRepository).getRoots("efo", true, "en", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(ROOTS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
+        verify(propertyRepository).getRoots(
+                "efo", false, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
     }
 
     @Test
@@ -297,7 +317,23 @@ class V1OntologyPropertyControllerWIT {
         mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "not-a-boolean"))
                 .andExpect(status().isBadRequest())
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
-                .andExpect(jsonPath("$.status").value(400));
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'includeObsoletes': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+    }
+
+    @Test
+    void rejectsMalformedSiblingsWithStableErrorFields() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI).param("siblings", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'siblings': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
     }
 
     @Test
@@ -329,11 +365,14 @@ class V1OntologyPropertyControllerWIT {
         mockMvc.perform(get(CHILDREN_URI)
                         .param("lang", "fr")
                         .param("page", "1")
-                        .param("size", "3"))
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
 
-        verify(propertyRepository).getChildren("efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+        verify(propertyRepository).getChildren(
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
     }
 
     @Test
@@ -345,12 +384,14 @@ class V1OntologyPropertyControllerWIT {
         mockMvc.perform(get(DESCENDANTS_URI)
                         .param("lang", "fr")
                         .param("page", "1")
-                        .param("size", "3"))
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
 
         verify(propertyRepository).getDescendants(
-                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
     }
 
     @Test
@@ -362,12 +403,14 @@ class V1OntologyPropertyControllerWIT {
         mockMvc.perform(get(ANCESTORS_URI)
                         .param("lang", "fr")
                         .param("page", "1")
-                        .param("size", "3"))
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$._embedded.properties[0].lang").value("fr"));
 
         verify(propertyRepository).getAncestors(
-                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3));
+                "efo", PROPERTY_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
     }
 
     @Test

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
@@ -225,4 +225,19 @@ class V1PropertyRepositoryIT {
         assertThat(((Map<?, ?>) tree.get(1).get("state")).get("selected"))
                 .isEqualTo(true);
     }
+
+    @Test
+    void buildsThePropertyJsTreeChildrenFromRealPostgresDirectChildren() {
+        String parentNodeId = java.util.Base64.getEncoder().encodeToString(
+                "http://example.org/EFO_0100".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        List<Map<String, Object>> children = jsTreeRepository.getJsTreeChildrenForProperty(
+                "http://example.org/EFO_0100", parentNodeId, "efo", "en");
+
+        assertThat(children).hasSize(1);
+        assertThat(children.get(0))
+                .containsEntry("iri", "http://example.org/EFO_0101")
+                .containsEntry("text", "has material")
+                .containsEntry("parent", parentNodeId);
+    }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1PropertyRepositoryIT.java
@@ -12,6 +12,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.ac.ebi.spot.ols.model.v1.V1Property;
 import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,14 +25,18 @@ class V1PropertyRepositoryIT {
     private static final PostgreSQLContainer<?> POSTGRES =
             PostgresIntegrationTestSupport.newContainer();
 
-    private static PostgresIntegrationTestSupport.V1PropertyRepositoryHandle repositoryHandle;
+    private static PostgresIntegrationTestSupport.V1OntologyPropertyRepositoryHandle
+            repositoryHandle;
     private static V1PropertyRepository repository;
+    private static V1JsTreeRepository jsTreeRepository;
 
     @BeforeAll
     static void setUpDatabase() {
         PostgresIntegrationTestSupport.initializePropertyDatabase(POSTGRES);
-        repositoryHandle = PostgresIntegrationTestSupport.createV1PropertyRepository(POSTGRES);
-        repository = repositoryHandle.repository();
+        repositoryHandle =
+                PostgresIntegrationTestSupport.createV1OntologyPropertyRepositories(POSTGRES);
+        repository = repositoryHandle.propertyRepository();
+        jsTreeRepository = repositoryHandle.jsTreeRepository();
     }
 
     @AfterAll
@@ -145,5 +152,77 @@ class V1PropertyRepositoryIT {
             assertThat(property.lang).isEqualTo("en_US");
             assertThat(property.label).isEqualTo("permits sample");
         });
+    }
+
+    @Test
+    void scopesListsAndEveryIdentifierToOneOntology() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByOntology("efo", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0100",
+                        "http://example.org/EFO_0101",
+                        "http://example.org/EFO_0199");
+        assertThat(repository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_0100", "fr").lang).isEqualTo("fr");
+        assertThat(repository.findByOntologyAndShortForm("efo", "EFO_0100", "fr").iri)
+                .isEqualTo("http://example.org/EFO_0100");
+        assertThat(repository.findByOntologyAndOboId("efo", "EFO:0100", "fr").iri)
+                .isEqualTo("http://example.org/EFO_0100");
+        assertThat(repository.findByOntologyAndIri(
+                "duo", "http://example.org/EFO_0100", "en")).isNull();
+    }
+
+    @Test
+    void returnsRootsAndHierarchyFromProductionColumns() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.getRoots("efo", false, "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+        assertThat(repository.getRoots("efo", true, "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0100",
+                        "http://example.org/EFO_0199");
+        assertThat(repository.getRoots("duo", false, "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/DUO_0100");
+
+        assertThat(repository.getParents(
+                "efo", "http://example.org/EFO_0101", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+        assertThat(repository.getAncestors(
+                "efo", "http://example.org/EFO_0101", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0100");
+        assertThat(repository.getChildren(
+                "efo", "http://example.org/EFO_0100", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0101");
+        assertThat(repository.getDescendants(
+                "efo", "http://example.org/EFO_0100", "en", pageable))
+                .extracting(property -> property.iri)
+                .containsExactly("http://example.org/EFO_0101");
+    }
+
+    @Test
+    void buildsThePropertyJsTreeFromRealPostgresAncestors() {
+        List<Map<String, Object>> tree = jsTreeRepository.getJsTreeForProperty(
+                "http://example.org/EFO_0101", "efo", "en");
+
+        assertThat(tree).hasSize(2);
+        assertThat(tree.get(0))
+                .containsEntry("iri", "http://example.org/EFO_0100")
+                .containsEntry("text", "has specimen")
+                .containsEntry("parent", "#");
+        assertThat(tree.get(1))
+                .containsEntry("iri", "http://example.org/EFO_0101")
+                .containsEntry("text", "has material")
+                .containsEntry("children", false);
+        assertThat(((Map<?, ?>) tree.get(1).get("state")).get("selected"))
+                .isEqualTo(true);
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -229,6 +229,25 @@ public final class PostgresIntegrationTestSupport {
                 individualRepository, jsTreeRepository, postgresClient);
     }
 
+    public static V1OntologyPropertyRepositoryHandle createV1OntologyPropertyRepositories(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        V1PropertyRepository propertyRepository = new V1PropertyRepository();
+        ReflectionTestUtils.setField(propertyRepository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(propertyRepository, "postgresClient", olsPostgresClient);
+
+        V1JsTreeRepository jsTreeRepository = new V1JsTreeRepository();
+        ReflectionTestUtils.setField(jsTreeRepository, "postgresClient", olsPostgresClient);
+
+        return new V1OntologyPropertyRepositoryHandle(
+                propertyRepository, jsTreeRepository, postgresClient);
+    }
+
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
         PostgresClient postgresClient = new PostgresClient();
         ReflectionTestUtils.setField(postgresClient, "host", container.getHost());
@@ -435,9 +454,10 @@ public final class PostgresIntegrationTestSupport {
                 INSERT INTO ols_entities (
                     id, type, iri, ontology_id, _json, is_obsolete, label, search_type,
                     short_form, curie, obo_id, synonym, definition, is_defining_ontology,
-                    subset, related_to, direct_parents, direct_ancestors, label_for_suggest,
+                    subset, related_to, direct_parents, direct_ancestors,
+                    has_direct_parents, has_hierarchical_parents, label_for_suggest,
                     filter_tags, filter_domain, "filter_http://example.org/category")
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (JsonElement element : fixture.getAsJsonArray("records")) {
@@ -460,10 +480,12 @@ public final class PostgresIntegrationTestSupport {
                 statement.setArray(16, textArray(connection, record.getAsJsonArray("relatedTo")));
                 statement.setArray(17, textArray(connection, record.getAsJsonArray("directParents")));
                 statement.setArray(18, textArray(connection, record.getAsJsonArray("directAncestors")));
-                statement.setString(19, record.getAsJsonArray("label").get(0).getAsString());
-                statement.setArray(20, textArray(connection, record.getAsJsonArray("tags")));
-                statement.setArray(21, textArray(connection, record.getAsJsonArray("domain")));
-                statement.setArray(22, textArray(
+                statement.setBoolean(19, !record.getAsJsonArray("directParents").isEmpty());
+                statement.setBoolean(20, false);
+                statement.setString(21, record.getAsJsonArray("label").get(0).getAsString());
+                statement.setArray(22, textArray(connection, record.getAsJsonArray("tags")));
+                statement.setArray(23, textArray(connection, record.getAsJsonArray("domain")));
+                statement.setArray(24, textArray(
                         connection,
                         record.getAsJsonArray("http://example.org/category")));
                 statement.addBatch();
@@ -711,6 +733,17 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1OntologyIndividualRepositoryHandle(
             V1IndividualRepository individualRepository,
+            V1JsTreeRepository jsTreeRepository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record V1OntologyPropertyRepositoryHandle(
+            V1PropertyRepository propertyRepository,
             V1JsTreeRepository jsTreeRepository,
             PostgresClient postgresClient) implements AutoCloseable {
 

--- a/backend/src/test/resources/fixtures/properties/README.md
+++ b/backend/src/test/resources/fixtures/properties/README.md
@@ -1,12 +1,18 @@
 # Property integration fixture
 
-This three-record synthetic supplement is loaded only by the `PropertyRepository` and
-`V2PropertyController` PostgreSQL suites. It leaves the shared entity fixture unchanged while
-adding the smallest data set needed to cover property-specific pagination, ranking, filtering,
-ontology scoping, obsolete selection, and hierarchy behavior.
+This three-record synthetic supplement is loaded by the `PropertyRepository`, `V1PropertyRepository`
+(non-scoped and ontology-scoped), `V2PropertyController`, and `V1OntologyPropertyController`
+PostgreSQL suites. It leaves the shared entity fixture unchanged while adding the smallest data set
+needed to cover property-specific pagination, ranking, filtering, ontology scoping, obsolete
+selection, and hierarchy behavior.
 
 - `EFO_0101` is an active child of the shared `EFO_0100` property. Its `directParents` and
-  `directAncestors` arrays exercise the production PostgreSQL hierarchy columns.
+  `directAncestors` wrapper arrays populate the production `direct_parents`/`direct_ancestors`
+  PostgreSQL columns used by `getParents`/`getChildren`/`getDescendants`/`getAncestors`. Its nested
+  `json.directParent` array and `has_direct_parents`/`has_hierarchical_parents` columns (derived
+  from `directParents` at load time) are the separate signals `getRoots` and the property js-tree
+  builder read — the js-tree builder walks the stored JSON's `directParent` key, not the
+  `direct_parents` column, so both must stay populated together for a non-root record.
 - `DUO_0100` provides a second ontology and a definition-weighted ranking case.
 - `EFO_0199` is obsolete and non-defining. It is excluded by the V2 controller default while its
   defining-ontology flag distinguishes the legacy V1 filtered and unfiltered routes without

--- a/backend/src/test/resources/fixtures/properties/property-fixture.json
+++ b/backend/src/test/resources/fixtures/properties/property-fixture.json
@@ -34,6 +34,7 @@
         "curie": "EFO:0101",
         "isObsolete": false,
         "isDefiningOntology": true,
+        "directParent": ["http://example.org/EFO_0100"],
         "hasDirectParents": true,
         "hasHierarchicalParents": false,
         "linkedEntities": {}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -545,33 +545,42 @@ Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
 
 ## Implemented V1 ontology-property-controller baseline
 
-Verified locally on 2026-09-03 with Java 17 and Rancher Desktop:
+Verified locally on 2026-09-03 with Java 17 and Rancher Desktop, after rebasing onto the merged
+`V1ChildrenJsTreeBuilder` null-safety fix (PR #1391) that this rollout's own route-completeness
+review exposed:
 
-- Surefire runs 729 tests, including 7 direct `V1OntologyPropertyControllerTest` cases and 38
+- Surefire runs 732 tests, including 7 direct `V1OntologyPropertyControllerTest` cases and 39
   `V1OntologyPropertyControllerWIT` invocations. Two runs with a deliberately unavailable Docker
-  socket took Maven 22.888 and 11.392 seconds (wall-clock 24.86 and 12.26 seconds).
-- Failsafe runs 149 PostgreSQL tests, including 3 new ontology-scoped `V1PropertyRepositoryIT`
-  cases (bringing that suite to 10) and 6 thin `V1OntologyPropertyControllerIT` cases. Two
-  complete database-gate runs took Maven 1 minute 34 seconds each (wall-clock 96.17 and 95.47
+  socket ran clean.
+- Failsafe runs 153 PostgreSQL tests, including 4 new ontology-scoped `V1PropertyRepositoryIT`
+  cases (bringing that suite to 11) and 9 thin `V1OntologyPropertyControllerIT` cases — one per
+  route, covering all nine. Two complete database-gate runs ran clean.
+- The clean `verify` lifecycle runs all 885 tests in Maven 1 minute 45 seconds (wall-clock 105.87
   seconds).
-- The clean `verify` lifecycle runs all 878 tests in Maven 1 minute 47 seconds (wall-clock 108.15
-  seconds).
-- Whole-backend JaCoCo coverage is 51.9% lines (2,481 of 4,785) and 41.6% branches (797 of 1,916).
+- Whole-backend JaCoCo coverage is 52.7% lines (2,520 of 4,785) and 41.9% branches (802 of 1,916).
   The V1 ontology-property controller covers 56 of 62 executable lines and all 16 branches; its
   repository covers 87 of 89 lines and 6 of 8 branches. No coverage failure threshold is
   introduced.
 - The suites preserve all nine ontology-scoped property routes (list, roots, single, parents,
-  children, descendants, ancestors, jstree, and jstree children), legacy HAL fields, ontology and
-  language handling, identifier precedence, double-encoded IRI paths, pagination normalization,
-  and stable error fields. The existing three-record property fixture now carries a `directParent`
-  reference and populated `has_direct_parents`/`has_hierarchical_parents` columns for `EFO_0101`
-  without changing its record count, matching production behavior for both the js-tree ancestor
-  builder (which reads `directParent` from the entity's stored JSON) and the roots query (which
-  reads the real `has_direct_parents`/`has_hierarchical_parents` columns rather than the JSON
-  document).
-- This rollout is a test-only fixture extension, not a production defect fix: the fixture
-  previously never exercised `getRoots` or the property js-tree, so the gap was invisible until
-  these new tests required it. No production code changed.
+  children, descendants, ancestors, jstree, and jstree children) with one thin controller-IT case
+  per route, legacy HAL fields, ontology and language handling, identifier precedence,
+  double-encoded IRI paths, pagination normalization, explicit sort binding, and stable
+  success/error contract fields including the exact message for malformed typed parameters
+  (`includeObsoletes`, `siblings`). The existing three-record property fixture now carries a
+  `directParent` reference and populated `has_direct_parents`/`has_hierarchical_parents` columns
+  for `EFO_0101` without changing its record count, matching production behavior for both the
+  js-tree ancestor builder (which reads `directParent` from the entity's stored JSON) and the
+  roots query (which reads the real `has_direct_parents`/`has_hierarchical_parents` columns rather
+  than the JSON document). This fixture change is test-only: the fixture previously never
+  exercised `getRoots` or the property js-tree, so the gap was invisible until these new tests
+  required it.
+- The rollout's first draft covered only 6 of 9 routes in the controller IT, treating
+  `jstree/children/{nodeid}` as adequately covered by the plain `jstree` route. It is not — the
+  two routes call different builder classes. Adding the missing route during review exposed a real
+  `NullPointerException` in `V1ChildrenJsTreeBuilder` (it called `.equals("true")` directly on a
+  possibly-null value, unlike the sibling `V1AncestorsJsTreeBuilder`, which already guards the
+  same fields null-safely). PR #1391 isolated the minimal fix and a focused regression test,
+  merged before this branch was rebased.
 
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -80,6 +80,8 @@ Controller ITs use the real Spring MVC controller path, real repository stack, a
 
 For the `V2OntologyController` pilot, the full-stack suite contains one representative happy path for each of its four routes.
 
+Before finalizing a controller IT suite, enumerate every route straight from the controller source and check off one thin case per route — do not substitute a "representative subset" chosen by eye. Two routes that look similar by name or description can still call entirely different production code; skipping one as redundant with the other proves nothing about the code path it actually owns. This is not hypothetical: the first `V1OntologyPropertyController` IT suite covered 6 of 9 routes, treating `jstree/children/{nodeid}` as adequately covered by the plain `jstree` test. It is not — the two routes use different builder classes (`V1ChildrenJsTreeBuilder` vs `V1AncestorsJsTreeBuilder`) — and the gap hid a real `NullPointerException` (fixed in PR #1391) until full route coverage was added during review of PR #1390.
+
 ### System regression tests
 
 The existing `test_api.sh` suite continues to own full OWL-to-dataload-to-database-to-API regression coverage. The new Maven suites must not rerun the complete dataload for every controller test.

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -541,6 +541,36 @@ Verified locally on 2026-09-02 with Java 17 and Rancher Desktop:
   zero in the legacy response. PR #1386 preserves the requested offset with a focused regression;
   it was isolated and merged before this test branch was rebased.
 
+## Implemented V1 ontology-property-controller baseline
+
+Verified locally on 2026-09-03 with Java 17 and Rancher Desktop:
+
+- Surefire runs 729 tests, including 7 direct `V1OntologyPropertyControllerTest` cases and 38
+  `V1OntologyPropertyControllerWIT` invocations. Two runs with a deliberately unavailable Docker
+  socket took Maven 22.888 and 11.392 seconds (wall-clock 24.86 and 12.26 seconds).
+- Failsafe runs 149 PostgreSQL tests, including 3 new ontology-scoped `V1PropertyRepositoryIT`
+  cases (bringing that suite to 10) and 6 thin `V1OntologyPropertyControllerIT` cases. Two
+  complete database-gate runs took Maven 1 minute 34 seconds each (wall-clock 96.17 and 95.47
+  seconds).
+- The clean `verify` lifecycle runs all 878 tests in Maven 1 minute 47 seconds (wall-clock 108.15
+  seconds).
+- Whole-backend JaCoCo coverage is 51.9% lines (2,481 of 4,785) and 41.6% branches (797 of 1,916).
+  The V1 ontology-property controller covers 56 of 62 executable lines and all 16 branches; its
+  repository covers 87 of 89 lines and 6 of 8 branches. No coverage failure threshold is
+  introduced.
+- The suites preserve all nine ontology-scoped property routes (list, roots, single, parents,
+  children, descendants, ancestors, jstree, and jstree children), legacy HAL fields, ontology and
+  language handling, identifier precedence, double-encoded IRI paths, pagination normalization,
+  and stable error fields. The existing three-record property fixture now carries a `directParent`
+  reference and populated `has_direct_parents`/`has_hierarchical_parents` columns for `EFO_0101`
+  without changing its record count, matching production behavior for both the js-tree ancestor
+  builder (which reads `directParent` from the entity's stored JSON) and the roots query (which
+  reads the real `has_direct_parents`/`has_hierarchical_parents` columns rather than the JSON
+  document).
+- This rollout is a test-only fixture extension, not a production defect fix: the fixture
+  previously never exercised `getRoots` or the property js-tree, so the gap was invisible until
+  these new tests required it. No production code changed.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary

- Continues the layered backend testing programme (docs/adr/0001-adopt-layered-backend-testing.md, docs/backend-testing-strategy.md) to `V1OntologyPropertyController` — the next best increment after PR #1389 (`V1OntologyIndividualController`), since it is the closest untested sibling: same identifier/pageable pattern, 9 routes, no external-service coupling, and a real PostgreSQL repository (`V1PropertyRepository`) whose non-scoped methods and repository IT suite already exist.
- `V1OntologyTermController` (24 routes) was deferred as too large a hierarchy surface for one focused PR; `V2LLMController`/`V2TextTaggerController` were deferred for external-service coupling; `V1ApiUnavailable`/`HealthCheckController`/`V2DefinedFieldsController` were deferred as too trivial to matter.

## Review round

A first pass of this PR was reviewed (Codex). Two categories of feedback were addressed and are now included:
1. **Coverage gap**: the controller-IT suite originally covered only 6 of 9 routes, treating `jstree/children/{nodeid}` as adequately covered by the plain `jstree` route. It wasn't — the two routes call different builder classes. Adding the missing route (plus `descendants`/`ancestors`) exposed a real `NullPointerException` in `V1ChildrenJsTreeBuilder`, isolated and fixed in a separate PR: **#1391** (merged). This branch is rebased on top of that fix.
2. **Contract-assertion gaps**: malformed `includeObsoletes`/`siblings` now assert the exact stable `message` field, not just `status`; malformed page/size and explicit `sort` coverage now extend to every pageable route (`children`, `descendants`, `ancestors`, `roots`), not just `list`/`roots`/`parents`.

`docs/backend-testing-strategy.md` now documents the "enumerate every route, don't substitute a representative subset" lesson directly, so future controllers in this programme don't repeat the gap.

## Testing layers added

- **Direct**: `V1OntologyPropertyControllerTest` — 7 cases covering identifier precedence (iri > short_form > obo_id), roots missing-resource handling, decoded 404, and delegated parents/children/descendants/ancestors/jstree calls.
- **WIT**: `V1OntologyPropertyControllerWIT` — 39 invocations covering all 9 routes, pagination defaults/boundaries/malformed values and explicit sort across every pageable route, identifier precedence and reserved-parameter compatibility, `includeObsoletes`/`siblings` binding (incl. malformed-boolean 400 with exact message), double-encoded IRIs, arbitrary V1 language passthrough, legacy HAL media type, stable 404/400/405 error fields.
- **Repository IT**: extended `V1PropertyRepositoryIT` (now backed by a new `V1OntologyPropertyRepositoryHandle`, mirroring the individual-controller precedent) with 4 new cases — ontology scoping of every identifier lookup, `getRoots`/`getParents`/`getChildren`/`getDescendants`/`getAncestors` against real `direct_parents`/`direct_ancestors` columns, the property js-tree via `V1JsTreeRepository.getJsTreeForProperty`, and its `getJsTreeChildrenForProperty` counterpart.
- **Controller IT**: new `V1OntologyPropertyControllerIT` — 9 thin happy-path cases, one per route, proving the real controller → repository → disposable PostgreSQL → HTTP path for all nine.

Test counts by layer: 7 direct + 39 WIT + 4 repository IT + 9 controller IT = **59 new tests**.

## Fixture change (test-only, no production code changed in this PR)

The roots query reads real `has_direct_parents`/`has_hierarchical_parents` PostgreSQL columns, and the js-tree builder reads a `directParent` array from the entity's own stored JSON — both distinct from the `direct_parents`/`direct_ancestors` array columns the fixture already populated. Neither signal existed in the fixture until these new tests needed it, so `PostgresIntegrationTestSupport.loadPropertyFixture` now also derives and sets those two columns, and `EFO_0101`'s stored JSON now carries `directParent`. Record count is unchanged (3). Verified this does not affect the sibling `PropertyRepositoryIT` (V2) or `V1PropertyControllerIT` (non-scoped) suites that share the same fixture loader.

## Local verification (Java 17, Rancher Desktop), on top of merged PR #1391

All commands run with `DOCKER_HOST`/`TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE`/`-Dapi.version=1.44` per docs/backend-testing-strategy.md.

- Focused unit + WIT: 46/46 pass.
- Focused PostgreSQL (incl. sibling V2/non-scoped suites sharing the fixture): 31/31 pass.
- Docker-free `mvn test`, run twice with an unavailable Docker socket: 732/732 pass both times.
- PostgreSQL-only `-Pintegration-tests-only verify`, run twice: 153/153 pass both times.
- Clean `mvn clean verify`: 885/885 pass, Maven 1m45s (wall-clock 105.87s).
- `test_api.sh` is unchanged and was not run locally.

## Coverage (JaCoCo, from the clean verify run)

- Whole-backend: 52.7% lines (2,520/4,785), 41.9% branches (802/1,916). No repository-wide threshold introduced.
- `V1OntologyPropertyController`: 56/62 lines, 16/16 branches.
- `V1PropertyRepository`: 87/89 lines, 6/8 branches.

Baseline recorded in docs/backend-testing-strategy.md under "Implemented V1 ontology-property-controller baseline".

## Defects

One found and isolated: PR #1391 (`V1ChildrenJsTreeBuilder` NullPointerException, merged). No production code changes in this PR.

## Graphify

`graphify update .` refreshed the local graph: 6425 nodes, 17880 edges, 294 communities. Same two pre-existing warnings as prior runs (two `Cargo.toml` files producing zero nodes; `frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme; will be reported separately once CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)