### PR TITLE
fix: null-safe hasChildren check in V1ChildrenJsTreeBuilder

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1ChildrenJsTreeBuilder.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1ChildrenJsTreeBuilder.java
@@ -37,8 +37,8 @@ public class V1ChildrenJsTreeBuilder {
             jstreeEntry.put("text", JsonHelper.getString(child.getAsJsonObject(), LABEL.getText()));
             jstreeEntry.put("state", Map.of("opened", false));
             jstreeEntry.put("children",
-	    	JsonHelper.getString(child.getAsJsonObject(), HAS_DIRECT_CHILDREN.getText()).equals("true")
-		|| JsonHelper.getString(child.getAsJsonObject(), HAS_HIERARCHICAL_CHILDREN.getText()).equals("true")
+	    	Objects.equals(JsonHelper.getString(child.getAsJsonObject(), HAS_DIRECT_CHILDREN.getText()), "true")
+		|| Objects.equals(JsonHelper.getString(child.getAsJsonObject(), HAS_HIERARCHICAL_CHILDREN.getText()), "true")
 	    );
 
             Map<String,Object> attrObj = new LinkedHashMap<>();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1ChildrenJsTreeBuilderTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1ChildrenJsTreeBuilderTest.java
@@ -1,0 +1,54 @@
+package uk.ac.ebi.spot.ols.repository.v1;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class V1ChildrenJsTreeBuilderTest {
+
+    @Test
+    void treatsAMissingHasChildrenFlagAsFalseInsteadOfThrowing() {
+        JsonObject parent = JsonParser.parseString(
+                "{\"iri\":\"http://example.org/parent\"}").getAsJsonObject();
+        JsonObject childWithoutHasChildrenFlags = JsonParser.parseString("""
+                {"iri":"http://example.org/child","label":"Child"}
+                """).getAsJsonObject();
+
+        V1ChildrenJsTreeBuilder builder = new V1ChildrenJsTreeBuilder(
+                base64("http://example.org/parent"), parent, List.of(childWithoutHasChildrenFlags));
+
+        List<Map<String, Object>> tree = builder.buildJsTree();
+
+        assertThat(tree).singleElement().satisfies(entry -> {
+            assertThat(entry).containsEntry("iri", "http://example.org/child");
+            assertThat(entry).containsEntry("children", false);
+        });
+    }
+
+    @Test
+    void reportsHasChildrenTrueWhenTheFlagIsSet() {
+        JsonObject parent = JsonParser.parseString(
+                "{\"iri\":\"http://example.org/parent\"}").getAsJsonObject();
+        JsonObject childWithChildren = JsonParser.parseString("""
+                {"iri":"http://example.org/child","label":"Child","hasDirectChildren":"true"}
+                """).getAsJsonObject();
+
+        V1ChildrenJsTreeBuilder builder = new V1ChildrenJsTreeBuilder(
+                base64("http://example.org/parent"), parent, List.of(childWithChildren));
+
+        List<Map<String, Object>> tree = builder.buildJsTree();
+
+        assertThat(tree).singleElement()
+                .satisfies(entry -> assertThat(entry).containsEntry("children", true));
+    }
+
+    private static String base64(String value) {
+        return java.util.Base64.getEncoder().encodeToString(
+                value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a `NullPointerException` in `V1ChildrenJsTreeBuilder.buildJsTree()` that produces an HTTP 500 on the `/{onto}/properties/{iri}/jstree/children/{nodeid}` route (and its class/individual siblings, which share the same builder) whenever a child entity's stored JSON has no `hasDirectChildren`/`hasHierarchicalChildren` key.
- `.equals("true")` was called directly on `JsonHelper.getString(...)`, which returns `null` when the key is absent — an ordinary case for entities that were never computed with that flag. The sibling `V1AncestorsJsTreeBuilder` already guards the identical fields with `Objects.equals(...)`; this brings `V1ChildrenJsTreeBuilder` in line with that established null-safe pattern.

## How this was found

While adding real-PostgreSQL coverage for `V1OntologyPropertyController`'s `jstree/children/{nodeid}` route on the `test-v1-ontology-property-controller` branch (in response to code review requesting that missing route be covered), the new controller-IT and repository-IT tests both hit this NPE against the real synthetic fixture, where `EFO_0101` has no `hasDirectChildren` field set. Confirmed causally by writing a focused unit test for the builder directly (no mocking needed — it's a plain POJO) and reproducing the NPE before the fix.

## Fix

One-line change: `Objects.equals(x, "true")` instead of `x.equals("true")`, for both the direct and hierarchical children flags. No behavior change for the case where the flag is present.

## Test added

`V1ChildrenJsTreeBuilderTest` (new, 2 cases):
- `treatsAMissingHasChildrenFlagAsFalseInsteadOfThrowing` — reproduces the NPE pre-fix, asserts `children: false` post-fix.
- `reportsHasChildrenTrueWhenTheFlagIsSet` — confirms the true case still works.

## Local verification (Java 17, Rancher Desktop)

- Focused test confirmed **red** before the fix (NPE), **green** after.
- Docker-free `mvn test`: 686/686 pass (684 baseline + 2 new).
- Clean `mvn clean verify` (Docker-free + PostgreSQL): 686 + 140 = 826/826 pass, no regressions.
- `test_api.sh` unchanged, not run locally.

## Scope

Test-only regression + the minimal one-line production fix. No unrelated changes. This is a standalone defect PR, separate from the `test-v1-ontology-property-controller` testing PR (#1390) that exposed it — once merged, that testing branch will be rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)