### PR TITLE
fix: restrict V1 term hierarchy lookups to class entities

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepository.java
@@ -36,9 +36,17 @@ public class V1TermRepository {
     @Autowired
     OlsSearchClient searchClient;
 
+    // Restricts direct-parent/child/ancestor/descendant hierarchy lookups to class entities.
+    // Without this, an individual or property whose direct_parents/direct_ancestors array
+    // happens to reference the same IRI (a normal RDF pattern — e.g. an individual's transitive
+    // class ancestor) would be returned alongside the actual class hierarchy. ClassRepository
+    // (V2) was patched for the identical leak in PR #1373; this mirrors that fix for V1.
+    private static final Map<String, String> CLASS_NODE_PROPERTIES = Map.of("type", "OntologyClass");
+
     public Page<V1Term> getParents(String ontologyId, String iri, String lang, Pageable pageable) {
 
-        return this.postgresClient.getDirectParents(ontologyId + "+class+" + iri, Map.of(), pageable)
+        return this.postgresClient.getDirectParents(
+                ontologyId + "+class+" + iri, CLASS_NODE_PROPERTIES, pageable)
                 .map(node -> V1TermMapper.mapTerm(node, lang));
     }
 
@@ -56,7 +64,8 @@ public class V1TermRepository {
 
     public Page<V1Term> getChildren(String ontologyId, String iri, String lang, Pageable pageable) {
 
-        return this.postgresClient.getDirectChildren(ontologyId + "+class+" + iri, Map.of(), pageable)
+        return this.postgresClient.getDirectChildren(
+                ontologyId + "+class+" + iri, CLASS_NODE_PROPERTIES, pageable)
                 .map(record -> V1TermMapper.mapTerm(record, lang));
     }
 
@@ -75,13 +84,15 @@ public class V1TermRepository {
 
     public Page<V1Term> getDescendants(String ontologyId, String iri, String lang, Pageable pageable) {
 
-        return this.postgresClient.getDescendants(ontologyId + "+class+" + iri, Map.of(), pageable)
+        return this.postgresClient.getDescendants(
+                ontologyId + "+class+" + iri, CLASS_NODE_PROPERTIES, pageable)
                 .map(record -> V1TermMapper.mapTerm(record, lang));
     }
 
     public Page<V1Term> getAncestors(String ontologyId, String iri, String lang, Pageable pageable) {
 
-        return this.postgresClient.getAncestors(ontologyId + "+class+" + iri, Map.of(), pageable)
+        return this.postgresClient.getAncestors(
+                ontologyId + "+class+" + iri, CLASS_NODE_PROPERTIES, pageable)
                 .map(record -> V1TermMapper.mapTerm(record, lang));
     }
 

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryHierarchyTypeFilterIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryHierarchyTypeFilterIT.java
@@ -1,0 +1,80 @@
+package uk.ac.ebi.spot.ols.repository.v1;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.service.PostgresClient;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The committed class fixture also carries a synthetic individual (EFO_I100) whose
+ * direct_ancestors array points at the same root class (EFO_0001) used for hierarchy tests —
+ * modelling a real RDF pattern where an individual has a transitive class ancestor. V2's
+ * {@code ClassRepository} was patched in PR #1373 to restrict hierarchy lookups to
+ * {@code type = OntologyClass} after this exact cross-type leak was found. V1TermRepository's
+ * getParents/getChildren/getDescendants/getAncestors never received that fix: they call the raw
+ * Postgres hierarchy lookups with an empty node-property filter, so a class's children/descendants
+ * can include individuals (or properties) that merely share the same ancestor IRI.
+ */
+@Testcontainers
+class V1TermRepositoryHierarchyTypeFilterIT {
+
+    private static final String ROOT_IRI = "http://example.org/EFO_0001";
+    private static final String CHILD_IRI = "http://example.org/EFO_1001";
+    private static final String INDIVIDUAL_IRI = "http://example.org/EFO_I100";
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    @Test
+    void hierarchyRoutesDoNotLeakNonClassEntitiesSharingTheSameAncestorIri() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+
+        PostgresClient postgresClient = new PostgresClient();
+        ReflectionTestUtils.setField(postgresClient, "host", POSTGRES.getHost());
+        ReflectionTestUtils.setField(postgresClient, "port", POSTGRES.getMappedPort(5432));
+        ReflectionTestUtils.setField(postgresClient, "database", POSTGRES.getDatabaseName());
+        ReflectionTestUtils.setField(postgresClient, "user", POSTGRES.getUsername());
+        ReflectionTestUtils.setField(postgresClient, "password", POSTGRES.getPassword());
+        ReflectionTestUtils.setField(postgresClient, "schema", "public");
+        ReflectionTestUtils.setField(postgresClient, "maxPoolSize", 3);
+        ReflectionTestUtils.setField(postgresClient, "minIdle", 0);
+        postgresClient.init();
+
+        OlsSearchClient searchClient = new OlsSearchClient();
+        ReflectionTestUtils.setField(searchClient, "postgresClient", postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        V1TermRepository repository = new V1TermRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
+
+        try {
+            PageRequest pageable = PageRequest.of(0, 20);
+
+            Page<V1Term> children = repository.getChildren("efo", ROOT_IRI, "en", pageable);
+            Page<V1Term> descendants = repository.getDescendants("efo", ROOT_IRI, "en", pageable);
+
+            assertThat(children).extracting(term -> term.iri)
+                    .containsExactly(CHILD_IRI, "http://example.org/EFO_1999")
+                    .doesNotContain(INDIVIDUAL_IRI);
+            assertThat(descendants).extracting(term -> term.iri)
+                    .containsExactly(CHILD_IRI, "http://example.org/EFO_1999")
+                    .doesNotContain(INDIVIDUAL_IRI);
+        } finally {
+            postgresClient.close();
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- `V1TermRepository.getParents/getChildren/getDescendants/getAncestors` call the raw Postgres hierarchy lookups (`OlsPostgresClient.getDirectParents/getDirectChildren/getDescendants/getAncestors`) with an **empty** node-property filter. Those lookups match purely by array containment (`direct_parents`/`direct_ancestors`) plus `ontology_id` — with no restriction on the matched entity's own type. So an individual or property whose `direct_parents`/`direct_ancestors` array happens to reference the same IRI as a class gets returned alongside the actual class hierarchy.
- This is the identical leak `ClassRepository` (V2) hit and was patched for in PR #1373 (`classNodeProperties(includeObsolete)` → `Map.of("type", "OntologyClass", ...)`). V1's equivalent methods never received that fix.
- A normal RDF pattern triggers this in production: an individual can have a transitive class ancestor via `rdf:type` + `rdfs:subClassOf` chains, so a class's `/children` or `/descendants` route could return individual instances mixed in as if they were subclasses.

## How this was found

While adding real-PostgreSQL coverage for `V1OntologyTermController` (`test-v1-ontology-term-controller`), a `getDescendants`/`getChildren` repository test against the committed class fixture failed: the fixture already carries a synthetic individual (`EFO_I100`) with a `direct_ancestors` entry pointing at the same root class (`EFO_0001`) used for hierarchy tests — added earlier for a different (V2) test purpose, but it happens to exercise this exact cross-type scenario for V1 too.

## Fix

Mirrors `ClassRepository`'s existing pattern exactly: a `private static final Map<String, String> CLASS_NODE_PROPERTIES = Map.of("type", "OntologyClass")` constant, passed as the `nodeProps` argument to the four hierarchy lookups. `getHierarchicalParents/Children/Descendants/Ancestors` share the identical gap but are intentionally left unfixed here — no test in this repo exercises them yet, and per the layered-testing programme's rule, production fixes should be tied to a demonstrated red test rather than applied speculatively. Whichever future milestone first adds real coverage for those routes will hit and fix the same gap.

## Test added

`V1TermRepositoryHierarchyTypeFilterIT` (new, self-contained — no changes to shared test infrastructure or the existing `V1TermRepositoryIT`, to keep this PR isolated): wires a `V1TermRepository` directly against the existing committed class fixture (`initializeClassDatabase`, unmodified) and asserts `getChildren`/`getDescendants` of the root class return only the two synthetic child classes, not the individual.

## Local verification (Java 17, Rancher Desktop)

- Regression test confirmed **red** before the fix (returned 3 results including the individual), **green** after (returns exactly the 2 class children).
- Focused Postgres (`V1TermRepositoryHierarchyTypeFilterIT,V1TermRepositoryIT,ClassRepositoryIT,V2ClassControllerIT`): 28/28 pass — confirms no regression in the existing V1 term suite or the V2 classes this pattern originated from.
- Docker-free `mvn test`: 732/732 pass (unchanged — this is a Failsafe-only `*IT` addition, not Surefire).
- Clean `mvn clean verify`: 732 + 154 = 886/886 pass.
- `test_api.sh` unchanged, not run locally.

## Scope

Test-only regression + a 4-line production fix (same pattern already established elsewhere in the codebase) + one new constant. No unrelated changes. Standalone defect PR, separate from the `test-v1-ontology-term-controller` testing PR that exposed it — once merged, that testing branch will be rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)