### PR TITLE
test: cover v1 ontology term controller (milestone 1 of 2+)

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerIT.java
@@ -1,0 +1,210 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.web.HateoasPageableHandlerMethodArgumentResolver;
+import org.springframework.data.web.PagedResourcesAssemblerArgumentResolver;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.mediatype.MessageResolver;
+import org.springframework.hateoas.mediatype.hal.CurieProvider;
+import org.springframework.hateoas.mediatype.hal.Jackson2HalModule;
+import org.springframework.hateoas.server.core.AnnotationLinkRelationProvider;
+import org.springframework.hateoas.server.core.DelegatingLinkRelationProvider;
+import org.springframework.hateoas.server.core.EvoInflectorLinkRelationProvider;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class V1OntologyTermControllerIT {
+
+    private static final URI TERM_URI = URI.create(
+            "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_1001");
+    private static final URI PARENT_URI = URI.create(
+            "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_0001");
+    private static final URI LIST_URI = URI.create("/api/ontologies/EFO/terms");
+    private static final URI ROOTS_URI = URI.create("/api/ontologies/EFO/terms/roots");
+    private static final URI PREFERRED_ROOTS_URI =
+            URI.create("/api/ontologies/EFO/terms/preferredRoots");
+    private static final URI PARENTS_URI = URI.create(TERM_URI + "/parents");
+    private static final URI CHILDREN_URI = URI.create(PARENT_URI + "/children");
+    private static final URI DESCENDANTS_URI = URI.create(PARENT_URI + "/descendants");
+    private static final URI ANCESTORS_URI = URI.create(TERM_URI + "/ancestors");
+    private static final URI JS_TREE_URI = URI.create(TERM_URI + "/jstree");
+    // Base64 encoding of "http://example.org/EFO_0001" — the opaque node id a client obtains
+    // from a prior /jstree response and echoes back to expand that node's children.
+    private static final URI JS_TREE_CHILDREN_URI = URI.create(
+            PARENT_URI + "/jstree/children/aHR0cDovL2V4YW1wbGUub3JnL0VGT18wMDAx");
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.V1OntologyTermRepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        repositoryHandle =
+                PostgresIntegrationTestSupport.createV1OntologyTermRepositories(POSTGRES);
+
+        V1OntologyTermController controller = new V1OntologyTermController();
+        ReflectionTestUtils.setField(
+                controller, "termRepository", repositoryHandle.termRepository());
+        controller.jsTreeRepository = repositoryHandle.jsTreeRepository();
+        controller.termAssembler = new V1TermAssembler();
+        controller.preferredRootTermAssembler = new V1PreferredRootTermAssembler();
+
+        HateoasPageableHandlerMethodArgumentResolver pageableResolver =
+                new HateoasPageableHandlerMethodArgumentResolver();
+        pageableResolver.setMaxPageSize(1000);
+        PagedResourcesAssemblerArgumentResolver assemblerResolver =
+                new PagedResourcesAssemblerArgumentResolver(pageableResolver);
+
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setCustomArgumentResolvers(pageableResolver, assemblerResolver)
+                .setMessageConverters(
+                        new StringHttpMessageConverter(StandardCharsets.UTF_8),
+                        halMessageConverter())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void listsOntologyTermsThroughControllerRepositoryAndPostgres() throws Exception {
+        mockMvc.perform(get(LIST_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(5))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsDoubleEncodedOntologyTermThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(TERM_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.iri").value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$.label").value("Clinical liver child"))
+                .andExpect(jsonPath("$.lang").value("fr"));
+    }
+
+    @Test
+    void getsRootsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsPreferredRootsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(PREFERRED_ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsDirectTermParentsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsDirectTermChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsTermDescendantsThroughTheRealDatabase() throws Exception {
+        // Includes the fixture's synthetic individual (EFO_I100), which shares EFO_0001 as an
+        // ancestor — confirmed against the committed system-regression baseline that V1's
+        // /descendants route intentionally includes individuals asserted into a class.
+        mockMvc.perform(get(DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsTermAncestorsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsTermJsTreeThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$[0].text").value("Liver disease"))
+                .andExpect(jsonPath("$[0].parent").value("#"))
+                .andExpect(jsonPath("$[1].iri").value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$[1].text").value("Clinical liver child"))
+                .andExpect(jsonPath("$[1].state.selected").value(true));
+    }
+
+    @Test
+    void getsTermJsTreeChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(JS_TREE_CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$[0].text").value("Clinical liver child"));
+    }
+
+    private static MappingJackson2HttpMessageConverter halMessageConverter() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jackson2HalModule());
+        objectMapper.setHandlerInstantiator(new Jackson2HalModule.HalHandlerInstantiator(
+                new DelegatingLinkRelationProvider(
+                        new AnnotationLinkRelationProvider(),
+                        new EvoInflectorLinkRelationProvider()),
+                CurieProvider.NONE,
+                MessageResolver.DEFAULTS_ONLY));
+
+        MappingJackson2HttpMessageConverter converter =
+                new MappingJackson2HttpMessageConverter(objectMapper);
+        converter.setSupportedMediaTypes(List.of(MediaType.APPLICATION_JSON, MediaTypes.HAL_JSON));
+        return converter;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerTest.java
@@ -1,0 +1,285 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.hateoas.EntityModel;
+import org.springframework.hateoas.PagedModel;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class V1OntologyTermControllerTest {
+
+    private V1OntologyTermController controller;
+    private V1TermRepository termRepository;
+    private V1JsTreeRepository jsTreeRepository;
+    private V1TermAssembler termAssembler;
+    private V1PreferredRootTermAssembler preferredRootTermAssembler;
+    private PagedResourcesAssembler<V1Term> termResourcesAssembler;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        termRepository = mock(V1TermRepository.class);
+        jsTreeRepository = mock(V1JsTreeRepository.class);
+        termAssembler = mock(V1TermAssembler.class);
+        preferredRootTermAssembler = mock(V1PreferredRootTermAssembler.class);
+        termResourcesAssembler = mock(PagedResourcesAssembler.class);
+        pageable = PageRequest.of(1, 7);
+
+        controller = new V1OntologyTermController();
+        ReflectionTestUtils.setField(controller, "termRepository", termRepository);
+        controller.termAssembler = termAssembler;
+        controller.preferredRootTermAssembler = preferredRootTermAssembler;
+        controller.jsTreeRepository = jsTreeRepository;
+    }
+
+    @Test
+    void listsOntologyTermsWhenNoIdentifierIsSupplied() {
+        OlsFacetedResultsPage<V1Term> terms = new OlsFacetedResultsPage<>(
+                List.of(term()), Map.of(), pageable, 1);
+        PagedModel<EntityModel<V1Term>> assembled = PagedModel.empty();
+        when(termRepository.findAllByOntology("efo", null, "fr", pageable))
+                .thenReturn(terms);
+        when(termResourcesAssembler.toModel(terms, termAssembler)).thenReturn(assembled);
+
+        var response = controller.termsByOntology(
+                "EFO", null, null, null, null, null, "fr", pageable, termResourcesAssembler);
+
+        assertSame(assembled, response.getBody());
+        verify(termRepository).findAllByOntology("efo", null, "fr", pageable);
+    }
+
+    @Test
+    void passesObsoletesFilterThrough() {
+        OlsFacetedResultsPage<V1Term> terms = new OlsFacetedResultsPage<>(
+                List.of(term()), Map.of(), pageable, 1);
+        when(termRepository.findAllByOntology("efo", Boolean.TRUE, "en", pageable))
+                .thenReturn(terms);
+
+        controller.termsByOntology(
+                "EFO", null, null, null, null, true, "en", pageable, termResourcesAssembler);
+
+        verify(termRepository).findAllByOntology("efo", true, "en", pageable);
+    }
+
+    @Test
+    void resolvesIdByTryingIriThenShortFormThenOboId() {
+        when(termRepository.findByOntologyAndIri("efo", "the-iri", "fr")).thenReturn(term());
+        controller.termsByOntology(
+                "EFO", "the-iri", null, null, null, null, "fr", pageable,
+                termResourcesAssembler);
+        verify(termRepository).findByOntologyAndIri("efo", "the-iri", "fr");
+        verify(termRepository, never()).findByOntologyAndShortForm("efo", "the-iri", "fr");
+
+        when(termRepository.findByOntologyAndIri("efo", "EFO_1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("efo", "EFO_1001", "fr"))
+                .thenReturn(term());
+        controller.termsByOntology(
+                "EFO", null, "EFO_1001", null, null, null, "fr", pageable,
+                termResourcesAssembler);
+        verify(termRepository).findByOntologyAndIri("efo", "EFO_1001", "fr");
+        verify(termRepository).findByOntologyAndShortForm("efo", "EFO_1001", "fr");
+
+        when(termRepository.findByOntologyAndIri("efo", "EFO:1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("efo", "EFO:1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndOboId("efo", "EFO:1001", "fr")).thenReturn(term());
+        controller.termsByOntology(
+                "EFO", null, null, "EFO:1001", null, null, "fr", pageable,
+                termResourcesAssembler);
+        verify(termRepository).findByOntologyAndOboId("efo", "EFO:1001", "fr");
+    }
+
+    @Test
+    void appliesIdentifierPrecedenceIdThenIriThenShortFormThenOboId() {
+        when(termRepository.findByOntologyAndIri("efo", "explicit-id", "en"))
+                .thenReturn(term());
+
+        controller.termsByOntology(
+                "EFO", "ignored-iri", "ignored-short-form", "ignored-obo-id", "explicit-id",
+                null, "en", pageable, termResourcesAssembler);
+
+        verify(termRepository).findByOntologyAndIri("efo", "explicit-id", "en");
+        verify(termRepository, never()).findByOntologyAndIri("efo", "ignored-iri", "en");
+    }
+
+    @Test
+    void reportsMissingResourceWhenNoIdentifierResolves() {
+        when(termRepository.findByOntologyAndIri("efo", "missing", "en")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("efo", "missing", "en")).thenReturn(null);
+        when(termRepository.findByOntologyAndOboId("efo", "missing", "en")).thenReturn(null);
+
+        ResourceNotFoundException error = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.termsByOntology(
+                        "EFO", "missing", null, null, null, null, "en", pageable,
+                        termResourcesAssembler));
+        assertEquals("No resource with missing in efo", error.getMessage());
+    }
+
+    @Test
+    void getsRootsAndPreferredRootsReportingMissingResource() {
+        PageImpl<V1Term> roots = new PageImpl<>(List.of(term()));
+        when(termRepository.getRoots("efo", false, "fr", pageable)).thenReturn(roots);
+        controller.getRoots("EFO", false, "fr", pageable, termResourcesAssembler);
+        verify(termRepository).getRoots("efo", false, "fr", pageable);
+
+        when(termRepository.getRoots("efo", true, "en", pageable)).thenReturn(null);
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.getRoots("EFO", true, "en", pageable, termResourcesAssembler));
+
+        PageImpl<V1Term> preferredRoots = new PageImpl<>(List.of(term()));
+        when(termRepository.getPreferredRootTerms("efo", false, "fr", pageable))
+                .thenReturn(preferredRoots);
+        controller.getPreferredRoots("EFO", false, "fr", pageable, termResourcesAssembler);
+        verify(termRepository).getPreferredRootTerms("efo", false, "fr", pageable);
+
+        when(termRepository.getPreferredRootTerms("efo", true, "en", pageable)).thenReturn(null);
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.getPreferredRoots(
+                        "EFO", true, "en", pageable, termResourcesAssembler));
+    }
+
+    @Test
+    void getsDecodedTermAndReportsMissingTerm() {
+        when(termRepository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_1001", "en"))
+                .thenReturn(term());
+        EntityModel<V1Term> assembled = EntityModel.of(term());
+        when(termAssembler.toModel(org.mockito.ArgumentMatchers.any())).thenReturn(assembled);
+
+        var response = controller.getTerm(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "en");
+
+        assertSame(assembled, response.getBody());
+        verify(termRepository).findByOntologyAndIri(
+                "efo", "http://example.org/EFO_1001", "en");
+
+        when(termRepository.findByOntologyAndIri("efo", "missing", "en")).thenReturn(null);
+        ResourceNotFoundException error = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getTerm("EFO", "missing", "en"));
+        assertEquals("No term with id missing in efo", error.getMessage());
+    }
+
+    @Test
+    void delegatesDecodedParentsChildrenDescendantsAndAncestors() {
+        PageImpl<V1Term> page = new PageImpl<>(List.of(term()));
+        when(termRepository.getParents(
+                "efo", "http://example.org/EFO_1001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getChildren(
+                "efo", "http://example.org/EFO_0001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getDescendants(
+                "efo", "http://example.org/EFO_0001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getAncestors(
+                "efo", "http://example.org/EFO_1001", "fr", pageable)).thenReturn(page);
+
+        controller.getParents(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr", pageable,
+                termResourcesAssembler);
+        controller.children(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0001", "fr", pageable,
+                termResourcesAssembler);
+        controller.descendants(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0001", "fr", pageable,
+                termResourcesAssembler);
+        controller.ancestors(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr", pageable,
+                termResourcesAssembler);
+
+        verify(termRepository).getParents(
+                "efo", "http://example.org/EFO_1001", "fr", pageable);
+        verify(termRepository).getChildren(
+                "efo", "http://example.org/EFO_0001", "fr", pageable);
+        verify(termRepository).getDescendants(
+                "efo", "http://example.org/EFO_0001", "fr", pageable);
+        verify(termRepository).getAncestors(
+                "efo", "http://example.org/EFO_1001", "fr", pageable);
+    }
+
+    @Test
+    void reportsMissingResourceForEachHierarchyRouteWhenRepositoryReturnsNull() {
+        when(termRepository.getParents("efo", "missing", "en", pageable)).thenReturn(null);
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.getParents("EFO", "missing", "en", pageable,
+                        termResourcesAssembler));
+
+        when(termRepository.getChildren("efo", "missing", "en", pageable)).thenReturn(null);
+        ResourceNotFoundException childrenError = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.children("EFO", "missing", "en", pageable,
+                        termResourcesAssembler));
+        assertEquals("No children could be found for efo and missing", childrenError.getMessage());
+
+        when(termRepository.getDescendants("efo", "missing", "en", pageable)).thenReturn(null);
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.descendants("EFO", "missing", "en", pageable,
+                        termResourcesAssembler));
+
+        when(termRepository.getAncestors("efo", "missing", "en", pageable)).thenReturn(null);
+        assertThrows(ResourceNotFoundException.class,
+                () -> controller.ancestors("EFO", "missing", "en", pageable,
+                        termResourcesAssembler));
+    }
+
+    @Test
+    void serializesTheDecodedTermJsTree() {
+        when(jsTreeRepository.getJsTreeForClass(
+                "http://example.org/EFO_1001", "efo", "fr"))
+                .thenReturn(List.of(Map.of(
+                        "iri", "http://example.org/EFO_1001",
+                        "text", "Clinical liver child")));
+
+        var response = controller.graphJsTree(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr", false, "PreferredRoots");
+
+        verify(jsTreeRepository).getJsTreeForClass(
+                "http://example.org/EFO_1001", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_1001", "Clinical liver child");
+    }
+
+    @Test
+    void serializesTheDecodedTermJsTreeChildren() {
+        when(jsTreeRepository.getJsTreeChildrenForClass(
+                "http://example.org/EFO_0001", "node-1", "efo", "fr"))
+                .thenReturn(List.of(Map.of(
+                        "iri", "http://example.org/EFO_1001",
+                        "text", "Clinical liver child")));
+
+        var response = controller.graphJsTreeChildren(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0001", "node-1", "fr");
+
+        verify(jsTreeRepository).getJsTreeChildrenForClass(
+                "http://example.org/EFO_0001", "node-1", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_1001", "Clinical liver child");
+    }
+
+    private static V1Term term() {
+        V1Term term = new V1Term();
+        term.iri = "http://example.org/EFO_1001";
+        term.related = List.of();
+        return term;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerWIT.java
@@ -1,0 +1,591 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.hateoas.server.EntityLinks;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1GraphRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
+import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
+import uk.ac.ebi.spot.ols.service.PostgresClient;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.Matchers.endsWith;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V1OntologyTermController.class)
+@ContextConfiguration(classes = {
+        V1OntologyTermController.class,
+        V1TermAssembler.class,
+        V1PreferredRootTermAssembler.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V1OntologyTermControllerWIT {
+
+    private static final String TERM_IRI = "http://example.org/EFO_1001";
+    private static final String PARENT_IRI = "http://example.org/EFO_0001";
+    private static final URI LIST_URI = URI.create("/api/ontologies/EFO/terms");
+    private static final URI ROOTS_URI = URI.create("/api/ontologies/EFO/terms/roots");
+    private static final URI PREFERRED_ROOTS_URI =
+            URI.create("/api/ontologies/EFO/terms/preferredRoots");
+    private static final URI TERM_URI = URI.create(
+            "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_1001");
+    private static final URI PARENTS_URI = URI.create(TERM_URI + "/parents");
+    private static final URI CHILDREN_URI = URI.create(TERM_URI + "/children");
+    private static final URI DESCENDANTS_URI = URI.create(TERM_URI + "/descendants");
+    private static final URI ANCESTORS_URI = URI.create(TERM_URI + "/ancestors");
+    private static final URI JS_TREE_URI = URI.create(TERM_URI + "/jstree");
+    private static final URI JS_TREE_CHILDREN_URI = URI.create(
+            TERM_URI + "/jstree/children/node-1");
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private V1TermRepository termRepository;
+
+    @MockitoBean
+    private V1JsTreeRepository jsTreeRepository;
+
+    @MockitoBean
+    private V1GraphRepository graphRepository;
+
+    @MockitoBean
+    private PostgresClient postgresClient;
+
+    @MockitoBean
+    private EntityLinks entityLinks;
+
+    @BeforeEach
+    void stubResponses() {
+        when(termRepository.findAllByOntology(anyString(), any(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.findByOntologyAndIri(anyString(), anyString(), anyString()))
+                .thenAnswer(invocation -> term(invocation.getArgument(2)));
+        when(termRepository.getRoots(anyString(), anyBoolean(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getPreferredRootTerms(anyString(), anyBoolean(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getParents(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getChildren(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getDescendants(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getAncestors(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(jsTreeRepository.getJsTreeForClass(anyString(), anyString(), anyString()))
+                .thenReturn(List.of(Map.of(
+                        "id", "term-node",
+                        "parent", "#",
+                        "iri", TERM_IRI,
+                        "text", "Clinical liver child",
+                        "state", Map.of("selected", true),
+                        "children", false,
+                        "ontology_name", "efo")));
+        when(jsTreeRepository.getJsTreeChildrenForClass(
+                anyString(), anyString(), anyString(), anyString()))
+                .thenReturn(List.of(Map.of(
+                        "id", "child-node",
+                        "parent", "term-node",
+                        "iri", TERM_IRI,
+                        "text", "Clinical liver child")));
+    }
+
+    @Test
+    void returnsDefaultOntologyTermListContract() throws Exception {
+        mockMvc.perform(get(LIST_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$._embedded.terms[0].label")
+                        .value("Clinical liver child"))
+                .andExpect(jsonPath("$._embedded.terms[0].ontology_name").value("efo"))
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("en"))
+                .andExpect(jsonPath("$._embedded.terms[0]._links.self.href")
+                        .value(endsWith("/api/ontologies/efo/terms/"
+                                + "http%253A%252F%252Fexample.org%252FEFO_1001?lang=en")))
+                .andExpect(jsonPath("$.page.size").value(1000))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$.page.totalPages").value(1))
+                .andExpect(jsonPath("$.page.number").value(0));
+
+        verify(termRepository).findAllByOntology("efo", null, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void bindsCollectionLanguagePageSizeAndSort() throws Exception {
+        mockMvc.perform(get(LIST_URI)
+                        .param("lang", "fr")
+                        .param("page", "2")
+                        .param("size", "7")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).findAllByOntology(
+                "efo", null, "fr", PageRequest.of(2, 7,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void bindsExplicitObsoletesFilter() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("obsoletes", "true"))
+                .andExpect(status().isOk());
+        verify(termRepository).findAllByOntology(
+                "efo", true, "en", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(LIST_URI).param("obsoletes", "false"))
+                .andExpect(status().isOk());
+        verify(termRepository).findAllByOntology(
+                "efo", false, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void rejectsMalformedObsoletesWithStableErrorFields() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("obsoletes", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'obsoletes': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'java.lang.Boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+    }
+
+    @Test
+    void routesEveryCollectionIdentifierWithCascadeAndPrecedence() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+        verify(termRepository).findByOntologyAndIri("efo", TERM_IRI, "fr");
+
+        when(termRepository.findByOntologyAndIri("efo", "EFO_1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("efo", "EFO_1001", "fr"))
+                .thenReturn(term("fr"));
+        mockMvc.perform(get(LIST_URI).param("short_form", "EFO_1001").param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).findByOntologyAndShortForm("efo", "EFO_1001", "fr");
+
+        when(termRepository.findByOntologyAndIri("efo", "EFO:1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("efo", "EFO:1001", "fr")).thenReturn(null);
+        when(termRepository.findByOntologyAndOboId("efo", "EFO:1001", "fr"))
+                .thenReturn(term("fr"));
+        mockMvc.perform(get(LIST_URI).param("obo_id", "EFO:1001").param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).findByOntologyAndOboId("efo", "EFO:1001", "fr");
+
+        mockMvc.perform(get(LIST_URI).param("id", "arbitrary-id").param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).findByOntologyAndIri("efo", "arbitrary-id", "fr");
+
+        mockMvc.perform(get(LIST_URI)
+                        .param("id", "explicit-id")
+                        .param("iri", "ignored-iri")
+                        .param("short_form", "ignored")
+                        .param("obo_id", "IGNORED:1")
+                        .param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).findByOntologyAndIri("efo", "explicit-id", "fr");
+        verify(termRepository, never()).findByOntologyAndIri("efo", "ignored-iri", "fr");
+    }
+
+    @Test
+    void ignoresUnsupportedReservedAndDynamicStyleCollectionParameters() throws Exception {
+        mockMvc.perform(get(LIST_URI)
+                        .param("search", "liver")
+                        .param("includeObsoleteEntities", "false")
+                        .param("subset", "core", "slim")
+                        .param("http://example.org/category", "clinical", "policy"))
+                .andExpect(status().isOk());
+
+        verify(termRepository).findAllByOntology("efo", null, "en", PageRequest.of(0, 1000));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "list, -1, 20, 0, 20",
+            "list, 0, 0, 0, 1000",
+            "list, 0, 1001, 0, 1000",
+            "roots, -1, 20, 0, 20",
+            "roots, 0, 0, 0, 1000",
+            "roots, 0, 1001, 0, 1000",
+            "preferredRoots, -1, 20, 0, 20",
+            "preferredRoots, 0, 0, 0, 1000",
+            "preferredRoots, 0, 1001, 0, 1000",
+            "parents, -1, 20, 0, 20",
+            "parents, 0, 0, 0, 1000",
+            "parents, 0, 1001, 0, 1000",
+            "children, -1, 20, 0, 20",
+            "children, 0, 0, 0, 1000",
+            "children, 0, 1001, 0, 1000",
+            "descendants, -1, 20, 0, 20",
+            "descendants, 0, 0, 0, 1000",
+            "descendants, 0, 1001, 0, 1000",
+            "ancestors, -1, 20, 0, 20",
+            "ancestors, 0, 0, 0, 1000",
+            "ancestors, 0, 1001, 0, 1000"
+    })
+    void normalizesPaginationBoundariesAcrossPagedRoutes(
+            String route,
+            int requestedPage,
+            int requestedSize,
+            int expectedPage,
+            int expectedSize) throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "list" -> verify(termRepository)
+                    .findAllByOntology("efo", null, "en", expected);
+            case "roots" -> verify(termRepository).getRoots("efo", false, "en", expected);
+            case "preferredRoots" -> verify(termRepository)
+                    .getPreferredRootTerms("efo", false, "en", expected);
+            case "parents" -> verify(termRepository).getParents("efo", TERM_IRI, "en", expected);
+            case "children" -> verify(termRepository)
+                    .getChildren("efo", TERM_IRI, "en", expected);
+            case "descendants" -> verify(termRepository)
+                    .getDescendants("efo", TERM_IRI, "en", expected);
+            case "ancestors" -> verify(termRepository)
+                    .getAncestors("efo", TERM_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void usesPaginationDefaultsForMalformedNumericValuesAcrossPagedRoutes() throws Exception {
+        Pageable defaults = PageRequest.of(0, 1000);
+
+        for (URI uri : List.of(
+                LIST_URI, ROOTS_URI, PREFERRED_ROOTS_URI, PARENTS_URI,
+                CHILDREN_URI, DESCENDANTS_URI, ANCESTORS_URI)) {
+            mockMvc.perform(get(uri).param("page", "bad").param("size", "bad"))
+                    .andExpect(status().isOk());
+        }
+
+        verify(termRepository).findAllByOntology("efo", null, "en", defaults);
+        verify(termRepository).getRoots("efo", false, "en", defaults);
+        verify(termRepository).getPreferredRootTerms("efo", false, "en", defaults);
+        verify(termRepository).getParents("efo", TERM_IRI, "en", defaults);
+        verify(termRepository).getChildren("efo", TERM_IRI, "en", defaults);
+        verify(termRepository).getDescendants("efo", TERM_IRI, "en", defaults);
+        verify(termRepository).getAncestors("efo", TERM_IRI, "en", defaults);
+    }
+
+    @Test
+    void returnsDoubleEncodedTermWithDefaultAndExplicitLanguage() throws Exception {
+        mockMvc.perform(get(TERM_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.iri").value(TERM_IRI))
+                .andExpect(jsonPath("$.label").value("Clinical liver child"))
+                .andExpect(jsonPath("$.ontology_name").value("efo"))
+                .andExpect(jsonPath("$.lang").value("en"));
+        verify(termRepository).findByOntologyAndIri("efo", TERM_IRI, "en");
+
+        mockMvc.perform(get(TERM_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.lang").value("fr"));
+        verify(termRepository).findByOntologyAndIri("efo", TERM_IRI, "fr");
+    }
+
+    @Test
+    void returnsRootsWithDefaultAndExplicitIncludeObsoletes() throws Exception {
+        mockMvc.perform(get(ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+        verify(termRepository).getRoots("efo", false, "en", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "true"))
+                .andExpect(status().isOk());
+        verify(termRepository).getRoots("efo", true, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void returnsPreferredRootsWithDefaultAndExplicitIncludeObsoletes() throws Exception {
+        mockMvc.perform(get(PREFERRED_ROOTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+        verify(termRepository).getPreferredRootTerms("efo", false, "en", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(PREFERRED_ROOTS_URI).param("includeObsoletes", "true"))
+                .andExpect(status().isOk());
+        verify(termRepository).getPreferredRootTerms("efo", true, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void rejectsMalformedIncludeObsoletesOnRootsAndPreferredRootsWithStableErrorFields()
+            throws Exception {
+        mockMvc.perform(get(ROOTS_URI).param("includeObsoletes", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'includeObsoletes': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+
+        mockMvc.perform(get(PREFERRED_ROOTS_URI).param("includeObsoletes", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'includeObsoletes': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+    }
+
+    @Test
+    void returnsParentsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$.page.size").value(1000));
+
+        mockMvc.perform(get(PARENTS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getParents(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsChildrenWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(CHILDREN_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getChildren(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsDescendantsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(DESCENDANTS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getDescendants(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsAncestorsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(ANCESTORS_URI)
+                        .param("lang", "fr")
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getAncestors(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void returnsDoubleEncodedTermJsTreeWithExplicitLanguage() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$[0].text").value("Clinical liver child"))
+                .andExpect(jsonPath("$[0].state.selected").value(true));
+
+        verify(jsTreeRepository).getJsTreeForClass(TERM_IRI, "efo", "fr");
+    }
+
+    @Test
+    void acceptsIgnoredSiblingsAndViewModeParametersOnJsTree() throws Exception {
+        mockMvc.perform(get(JS_TREE_URI)
+                        .param("siblings", "true")
+                        .param("viewMode", "All"))
+                .andExpect(status().isOk());
+
+        verify(jsTreeRepository).getJsTreeForClass(TERM_IRI, "efo", "en");
+    }
+
+    @Test
+    void returnsTermJsTreeChildrenForADecodedNode() throws Exception {
+        mockMvc.perform(get(JS_TREE_CHILDREN_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$[0].text").value("Clinical liver child"));
+
+        verify(jsTreeRepository).getJsTreeChildrenForClass(TERM_IRI, "node-1", "efo", "fr");
+    }
+
+    @Test
+    void preservesArbitraryV1LanguageCompatibilityAcrossRouteFamilies() throws Exception {
+        mockMvc.perform(get(LIST_URI).param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("en_US"));
+        mockMvc.perform(get(PARENTS_URI).param("lang", "en_US"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("en_US"));
+        mockMvc.perform(get(JS_TREE_URI).param("lang", "en_US"))
+                .andExpect(status().isOk());
+
+        verify(termRepository).findAllByOntology("efo", null, "en_US", PageRequest.of(0, 1000));
+        verify(termRepository).getParents("efo", TERM_IRI, "en_US", PageRequest.of(0, 1000));
+        verify(jsTreeRepository).getJsTreeForClass(TERM_IRI, "efo", "en_US");
+    }
+
+    @Test
+    void supportsLegacyHalMediaTypeOnEveryHalRoute() throws Exception {
+        for (URI uri : List.of(
+                LIST_URI, ROOTS_URI, PREFERRED_ROOTS_URI, TERM_URI, PARENTS_URI,
+                CHILDREN_URI, DESCENDANTS_URI, ANCESTORS_URI, JS_TREE_URI)) {
+            mockMvc.perform(get(uri).accept(MediaTypes.HAL_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
+        }
+    }
+
+    @Test
+    void returnsStableLegacyNotFoundStatusAndMessage() throws Exception {
+        when(termRepository.findByOntologyAndIri("efo", TERM_IRI, "en")).thenReturn(null);
+
+        mockMvc.perform(get(TERM_URI))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void returnsStableBadRequestFieldsForUnsupportedSort() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(termRepository.getParents("efo", TERM_IRI, "en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get(PARENTS_URI).param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
+    void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
+        mockMvc.perform(post(LIST_URI))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405))
+                .andExpect(jsonPath("$.message").isNotEmpty());
+    }
+
+    private static URI route(String route) {
+        return switch (route) {
+            case "list" -> LIST_URI;
+            case "roots" -> ROOTS_URI;
+            case "preferredRoots" -> PREFERRED_ROOTS_URI;
+            case "parents" -> PARENTS_URI;
+            case "children" -> CHILDREN_URI;
+            case "descendants" -> DESCENDANTS_URI;
+            case "ancestors" -> ANCESTORS_URI;
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        };
+    }
+
+    private static OlsFacetedResultsPage<V1Term> termPage(Pageable pageable, String lang) {
+        return new OlsFacetedResultsPage<>(List.of(term(lang)), Map.of(), pageable, 1);
+    }
+
+    private static V1Term term(String lang) {
+        V1Term term = new V1Term();
+        term.iri = TERM_IRI;
+        term.lang = lang;
+        term.label = "Clinical liver child";
+        term.description = new String[]{"A synthetic class used for hierarchy contract tests."};
+        term.synonyms = new String[]{"Active hierarchy child"};
+        term.ontologyName = "efo";
+        term.ontologyPrefix = "EFO";
+        term.ontologyIri = "http://www.ebi.ac.uk/efo";
+        term.isObsolete = false;
+        term.isDefiningOntology = true;
+        term.hasChildren = false;
+        term.isRoot = false;
+        term.isPreferredRoot = false;
+        term.shortForm = "EFO_1001";
+        term.oboId = "EFO:1001";
+        term.inSubsets = List.of("hierarchy");
+        term.annotation = Map.of();
+        term.oboDefinitionCitations = List.of();
+        term.oboXrefs = List.of();
+        term.oboSynonyms = List.of();
+        term.related = List.of();
+        return term;
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryIT.java
@@ -12,6 +12,9 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.ac.ebi.spot.ols.model.v1.V1Term;
 import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
 
+import java.util.List;
+import java.util.Map;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -22,14 +25,16 @@ class V1TermRepositoryIT {
     private static final PostgreSQLContainer<?> POSTGRES =
             PostgresIntegrationTestSupport.newContainer();
 
-    private static PostgresIntegrationTestSupport.V1TermRepositoryHandle repositoryHandle;
+    private static PostgresIntegrationTestSupport.V1OntologyTermRepositoryHandle repositoryHandle;
     private static V1TermRepository repository;
+    private static V1JsTreeRepository jsTreeRepository;
 
     @BeforeAll
     static void setUpDatabase() {
-        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
-        repositoryHandle = PostgresIntegrationTestSupport.createV1TermRepository(POSTGRES);
-        repository = repositoryHandle.repository();
+        PostgresIntegrationTestSupport.initializeClassDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createV1OntologyTermRepositories(POSTGRES);
+        repository = repositoryHandle.termRepository();
+        jsTreeRepository = repositoryHandle.jsTreeRepository();
     }
 
     @AfterAll
@@ -45,8 +50,10 @@ class V1TermRepositoryIT {
                 "http://example.org/DUO_0001",
                 "http://example.org/EFO_0001",
                 "http://example.org/EFO_0002",
-                "http://example.org/EFO_0999");
-        assertThat(page.getTotalElements()).isEqualTo(4);
+                "http://example.org/EFO_0999",
+                "http://example.org/EFO_1001",
+                "http://example.org/EFO_1999");
+        assertThat(page.getTotalElements()).isEqualTo(6);
         assertThat(page.getContent().get(1).label).isEqualTo("Liver disease");
     }
 
@@ -60,9 +67,11 @@ class V1TermRepositoryIT {
         assertThat(secondPage).extracting(term -> term.iri).containsExactly(
                 "http://example.org/EFO_0002",
                 "http://example.org/EFO_0999");
-        assertThat(secondPage.getTotalElements()).isEqualTo(4);
-        assertThat(secondPage.getTotalPages()).isEqualTo(2);
+        assertThat(secondPage.getTotalElements()).isEqualTo(6);
+        assertThat(secondPage.getTotalPages()).isEqualTo(3);
         assertThat(descending).extracting(term -> term.iri).containsExactly(
+                "http://example.org/EFO_1999",
+                "http://example.org/EFO_1001",
                 "http://example.org/EFO_0999",
                 "http://example.org/EFO_0002",
                 "http://example.org/EFO_0001",
@@ -117,7 +126,9 @@ class V1TermRepositoryIT {
                 .containsExactly(
                         "http://example.org/DUO_0001",
                         "http://example.org/EFO_0001",
-                        "http://example.org/EFO_0999");
+                        "http://example.org/EFO_0999",
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999");
         assertThat(repository.findAllByIriAndIsDefiningOntology(
                 "http://example.org/EFO_0002", "en", pageable)).isEmpty();
         assertThat(repository.findAllByShortFormAndIsDefiningOntology(
@@ -138,5 +149,125 @@ class V1TermRepositoryIT {
             assertThat(term.lang).isEqualTo("en_US");
             assertThat(term.label).isEqualTo("Data use permission");
         });
+    }
+
+    @Test
+    void scopesListsAndEveryIdentifierToOneOntology() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.findAllByOntology("efo", null, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0001",
+                        "http://example.org/EFO_0002",
+                        "http://example.org/EFO_0999",
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999");
+        assertThat(repository.findAllByOntology("efo", false, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0001",
+                        "http://example.org/EFO_0002",
+                        "http://example.org/EFO_1001");
+        assertThat(repository.findAllByOntology("efo", true, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0999",
+                        "http://example.org/EFO_1999");
+
+        assertThat(repository.findByOntologyAndIri(
+                "efo", "http://example.org/EFO_1001", "fr").lang).isEqualTo("fr");
+        assertThat(repository.findByOntologyAndShortForm("efo", "EFO_1001", "fr").iri)
+                .isEqualTo("http://example.org/EFO_1001");
+        assertThat(repository.findByOntologyAndOboId("efo", "EFO:1001", "fr").iri)
+                .isEqualTo("http://example.org/EFO_1001");
+        assertThat(repository.findByOntologyAndIri(
+                "duo", "http://example.org/EFO_1001", "en")).isNull();
+    }
+
+    @Test
+    void returnsRootsPreferredRootsAndHierarchyFromProductionColumns() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        assertThat(repository.getRoots("efo", false, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0001",
+                        "http://example.org/EFO_0002");
+        assertThat(repository.getRoots("efo", true, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_0001",
+                        "http://example.org/EFO_0002",
+                        "http://example.org/EFO_0999");
+        assertThat(repository.getRoots("duo", false, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/DUO_0001");
+
+        assertThat(repository.getPreferredRootTerms("efo", false, "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_1001");
+        assertThat(repository.getPreferredRootTerms("duo", false, "en", pageable)).isEmpty();
+
+        assertThat(repository.getParents(
+                "efo", "http://example.org/EFO_1001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getAncestors(
+                "efo", "http://example.org/EFO_1001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getChildren(
+                "efo", "http://example.org/EFO_0001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999");
+        // getDescendants has no type filter (unlike V2's ClassRepository, see PR #1373):
+        // any entity whose direct_ancestors array references EFO_0001 matches, regardless of
+        // its own type. EFO_I100 is a synthetic individual (added for a different, class-fixture
+        // suite's purpose) whose direct_ancestors already includes EFO_0001, so it is legitimately
+        // returned here too. Confirmed against the committed system-regression baseline
+        // (testcases_expected_output_api/ontologies/owl2primer-class-assertion) that V1's
+        // /terms/{iri}/children and /descendants routes intentionally include individuals
+        // asserted into a class — this is documented V1 legacy behavior, not a defect.
+        assertThat(repository.getDescendants(
+                "efo", "http://example.org/EFO_0001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999",
+                        "http://example.org/EFO_I100");
+    }
+
+    @Test
+    void buildsTheClassJsTreeFromRealPostgresAncestors() {
+        List<Map<String, Object>> tree = jsTreeRepository.getJsTreeForClass(
+                "http://example.org/EFO_1001", "efo", "en");
+
+        assertThat(tree).hasSize(2);
+        assertThat(tree.get(0))
+                .containsEntry("iri", "http://example.org/EFO_0001")
+                .containsEntry("text", "Liver disease")
+                .containsEntry("parent", "#");
+        assertThat(tree.get(1))
+                .containsEntry("iri", "http://example.org/EFO_1001")
+                .containsEntry("text", "Clinical liver child");
+        assertThat(((Map<?, ?>) tree.get(1).get("state")).get("selected"))
+                .isEqualTo(true);
+    }
+
+    @Test
+    void buildsTheClassJsTreeChildrenFromRealPostgresDirectChildren() {
+        String parentNodeId = java.util.Base64.getEncoder().encodeToString(
+                "http://example.org/EFO_0001".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+
+        List<Map<String, Object>> children = jsTreeRepository.getJsTreeChildrenForClass(
+                "http://example.org/EFO_0001", parentNodeId, "efo", "en");
+
+        assertThat(children).extracting(child -> (String) child.get("iri")).containsExactly(
+                "http://example.org/EFO_1001",
+                "http://example.org/EFO_1999");
+        assertThat(children.get(0)).containsEntry("parent", parentNodeId);
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -248,6 +248,25 @@ public final class PostgresIntegrationTestSupport {
                 propertyRepository, jsTreeRepository, postgresClient);
     }
 
+    public static V1OntologyTermRepositoryHandle createV1OntologyTermRepositories(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        V1TermRepository termRepository = new V1TermRepository();
+        ReflectionTestUtils.setField(termRepository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(termRepository, "postgresClient", olsPostgresClient);
+
+        V1JsTreeRepository jsTreeRepository = new V1JsTreeRepository();
+        ReflectionTestUtils.setField(jsTreeRepository, "postgresClient", olsPostgresClient);
+
+        return new V1OntologyTermRepositoryHandle(
+                termRepository, jsTreeRepository, postgresClient);
+    }
+
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
         PostgresClient postgresClient = new PostgresClient();
         ReflectionTestUtils.setField(postgresClient, "host", container.getHost());
@@ -513,9 +532,11 @@ public final class PostgresIntegrationTestSupport {
                     id, type, iri, ontology_id, _json, is_obsolete, label, search_type,
                     short_form, curie, obo_id, synonym, definition, is_defining_ontology,
                     subset, related_to, direct_parents, hierarchical_parents,
-                    direct_ancestors, hierarchical_ancestors, label_for_suggest,
+                    direct_ancestors, hierarchical_ancestors,
+                    has_direct_parents, has_hierarchical_parents, is_preferred_root,
+                    label_for_suggest,
                     filter_tags, filter_domain, "filter_http://example.org/category")
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (JsonElement element : fixture.getAsJsonArray("records")) {
@@ -540,10 +561,14 @@ public final class PostgresIntegrationTestSupport {
                 statement.setArray(18, textArray(connection, record.getAsJsonArray("hierarchicalParents")));
                 statement.setArray(19, textArray(connection, record.getAsJsonArray("directAncestors")));
                 statement.setArray(20, textArray(connection, record.getAsJsonArray("hierarchicalAncestors")));
-                statement.setString(21, record.getAsJsonArray("label").get(0).getAsString());
-                statement.setArray(22, textArray(connection, record.getAsJsonArray("tags")));
-                statement.setArray(23, textArray(connection, record.getAsJsonArray("domain")));
-                statement.setArray(24, textArray(
+                statement.setBoolean(21, !record.getAsJsonArray("directParents").isEmpty());
+                statement.setBoolean(22, !record.getAsJsonArray("hierarchicalParents").isEmpty());
+                statement.setBoolean(23, record.has("isPreferredRoot")
+                        && record.get("isPreferredRoot").getAsBoolean());
+                statement.setString(24, record.getAsJsonArray("label").get(0).getAsString());
+                statement.setArray(25, textArray(connection, record.getAsJsonArray("tags")));
+                statement.setArray(26, textArray(connection, record.getAsJsonArray("domain")));
+                statement.setArray(27, textArray(
                         connection,
                         record.getAsJsonArray("http://example.org/category")));
                 statement.addBatch();
@@ -744,6 +769,17 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1OntologyPropertyRepositoryHandle(
             V1PropertyRepository propertyRepository,
+            V1JsTreeRepository jsTreeRepository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record V1OntologyTermRepositoryHandle(
+            V1TermRepository termRepository,
             V1JsTreeRepository jsTreeRepository,
             PostgresClient postgresClient) implements AutoCloseable {
 

--- a/backend/src/test/resources/fixtures/classes/class-fixture.json
+++ b/backend/src/test/resources/fixtures/classes/class-fixture.json
@@ -19,6 +19,7 @@
       "hierarchicalParents": ["http://example.org/EFO_0001"],
       "directAncestors": ["http://example.org/EFO_0001"],
       "hierarchicalAncestors": ["http://example.org/EFO_0001"],
+      "isPreferredRoot": true,
       "tags": ["hierarchy"],
       "domain": ["biology"],
       "http://example.org/category": ["hierarchy"],
@@ -36,6 +37,7 @@
         "curie": "EFO:1001",
         "isObsolete": false,
         "isDefiningOntology": true,
+        "directParent": ["http://example.org/EFO_0001"],
         "hasDirectParents": true,
         "hasHierarchicalParents": true,
         "linkedEntities": {}
@@ -77,6 +79,7 @@
         "curie": "EFO:1999",
         "isObsolete": true,
         "isDefiningOntology": true,
+        "directParent": ["http://example.org/EFO_0001"],
         "hasDirectParents": true,
         "hasHierarchicalParents": true,
         "linkedEntities": {}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -582,6 +582,65 @@ review exposed:
   same fields null-safely). PR #1391 isolated the minimal fix and a focused regression test,
   merged before this branch was rebased.
 
+## Implemented V1 ontology-term-controller baseline (milestone 1 of 2+)
+
+`V1OntologyTermController` has 23 routes — too large a hierarchy surface for one focused PR. This
+milestone covers the 10 core per-term routes (`terms` list, `roots`, `preferredRoots`, single
+`{iri}` get, `parents`, `children`, `descendants`, `ancestors`, `jstree`,
+`jstree/children/{nodeid}`), the same shape already proven for
+`V1OntologyPropertyController`/`V1OntologyIndividualController`. Deferred to a future milestone:
+`hierarchicalParents`/`hierarchicalChildren`/`hierarchicalAncestors`/`hierarchicalDescendants`,
+`/graph`, the dynamic `/{iri}/{property_iri}` related-by-property route, and the seven
+ontology-root-level shortcut routes (`/{onto}/children`, `/{onto}/descendants`,
+`/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*` counterparts).
+
+Verified locally on 2026-09-04 with Java 17 and Rancher Desktop:
+
+- Surefire runs 787 tests, including 11 direct `V1OntologyTermControllerTest` cases and 44
+  `V1OntologyTermControllerWIT` invocations. Two Docker-free runs both passed cleanly.
+- Failsafe runs 167 PostgreSQL tests, including 4 new ontology-scoped `V1TermRepositoryIT` cases
+  (bringing that suite to 11, now loading the class fixture via `initializeClassDatabase` instead
+  of the shared-entity-only `initializeDatabase`) and 10 thin `V1OntologyTermControllerIT` cases —
+  one per route. Two complete database-gate runs both passed cleanly.
+- The clean `verify` lifecycle runs all 954 tests in Maven 1 minute 51 seconds (wall-clock 112.36
+  seconds).
+- Whole-backend JaCoCo coverage is 55.7% lines (2,667 of 4,785) and 44.1% branches (845 of 1,916).
+  `V1OntologyTermController` covers 72 of 171 lines and 30 of 66 branches — low relative to other
+  controllers because this milestone exercises only 10 of its 23 routes; the deferred
+  hierarchical/graph/related/shortcut routes make up the uncovered remainder. Its repository
+  covers 100 of 123 lines and 9 of 12 branches, missing only the hierarchical-variant methods and
+  two pre-existing dead methods (`getInstances`, `getPreferredRootTermCount`, both hardcoded to
+  throw). No coverage failure threshold is introduced.
+- The suites preserve the `id`/`iri`/`short_form`/`obo_id` identifier cascade (`getIdFromMultipleOptions`
+  tries `id` first, falling back through `iri` → `short_form` → `obo_id`; `getOneById` then tries
+  the resolved value as an IRI, then a short form, then an OBO ID in turn) — a materially different
+  precedence model from the explicit per-parameter branching `V1OntologyPropertyController` and
+  `V1OntologyIndividualController` use. Also covered: the `obsoletes` collection filter (nullable
+  `Boolean`, stable 400 on a malformed value), `includeObsoletes` on both `roots` and
+  `preferredRoots`, explicit `sort` binding on every pageable route, pagination boundaries and
+  malformed-numeric defaults, double-encoded IRI paths, legacy HAL fields, arbitrary V1 language
+  passthrough, and stable error contract fields (message included, not just status).
+- The committed class fixture gained two production-schema columns it never previously populated:
+  `has_direct_parents`/`has_hierarchical_parents` (real boolean columns the `getRoots` query filters
+  on — previously left at their schema default of `false` for every row, so `getRoots` could not
+  distinguish roots from non-roots) and `is_preferred_root` (queried by `getPreferredRootTerms`).
+  `EFO_1001`'s stored JSON also gained a `directParent` key, the signal the js-tree ancestor/children
+  builders read (a distinct mechanism from the `direct_parents`/`direct_ancestors` array columns).
+  All test-only, same gaps and same fix pattern already found and fixed for the property fixture in
+  PR #1390; record counts are unchanged. Extending `V1TermRepositoryIT`'s existing suite to the full
+  class fixture also required updating its two pre-existing count-dependent assertions (4 → 6 total
+  class records, `findAllByIsDefiningOntology` 3 → 5).
+- A `V1TermRepository.getDescendants`/`getChildren` investigation briefly suspected a defect
+  mirroring PR #1373's V2 `ClassRepository` type-leak fix (V1 passes an empty node-property filter
+  to the same underlying Postgres hierarchy lookups, so a class's children/descendants can include
+  non-class entities sharing the same ancestor IRI). A fix was drafted, but the full system-regression
+  gate (`Build & Test API`, PR #1392) failed: the committed `test_api.sh` baseline for
+  `owl2primer-class-assertion` explicitly and deliberately expects an individual asserted into a
+  class to appear in that class's V1 `children`/`descendants` listing — a real, tested V1 legacy
+  contract, not an oversight. The fix was reverted and the PR closed; this milestone's tests assert
+  the actual (correct) current behavior instead, including the individual where the shared class
+  fixture's data makes it reachable. No production code changed in this milestone.
+
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
 ## Out of scope for the pilot


### PR DESCRIPTION
## Summary

- Continues the layered backend testing programme to `V1OntologyTermController` — the next best increment after PR #1390 (`V1OntologyPropertyController`), since it's the last remaining substantial untested V1 controller. Deferred as too trivial to matter: `V1ApiUnavailable`, `HealthCheckController`, `V2DefinedFieldsController`. Deferred for external-service coupling: `V2LLMController`, `V2TextTaggerController`.
- `V1OntologyTermController` has **23 routes** — too large a hierarchy surface for one focused PR, so this is **milestone 1 of 2+**. It covers the 10 core per-term routes that mirror the exact shape already proven for `V1OntologyPropertyController`/`V1OntologyIndividualController`: `terms` list, `roots`, `preferredRoots`, single `{iri}` get, `parents`, `children`, `descendants`, `ancestors`, `jstree`, `jstree/children/{nodeid}`.
- **Deferred to a future milestone** (documented in `docs/backend-testing-strategy.md`): `hierarchicalParents`/`hierarchicalChildren`/`hierarchicalAncestors`/`hierarchicalDescendants`, `/graph`, the dynamic `/{iri}/{property_iri}` related-by-property route, and the seven ontology-root-level shortcut routes (`/{onto}/children`, `/{onto}/descendants`, `/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*` counterparts).

## A defect was investigated and reverted — no production code changed

While adding real-Postgres coverage for `children`/`descendants`, a test failure looked identical to the leak PR #1373 fixed for V2's `ClassRepository` (an individual sharing an ancestor IRI with a class showing up in that class's hierarchy listing, because `V1TermRepository` passes an empty node-property filter to the same underlying Postgres lookups). I drafted a fix mirroring PR #1373 exactly and opened it as PR #1392 — but the full system-regression gate (`Build & Test API`) failed: the **committed** `test_api.sh` baseline for `owl2primer-class-assertion` explicitly and deliberately expects an individual asserted into a class (`ClassAssertion(Person Mary)`) to appear in that class's V1 `children`/`descendants` listing, full response shape included. That's real, tested, intended V1 legacy behavior — not an oversight — and per `docs/backend-testing-strategy.md`, "V1 remains heavily used and must not receive breaking changes." I reverted the fix and closed PR #1392 without merging (see its final comment for the full writeup). This milestone's tests assert the actual, correct current behavior instead, including the individual where the shared class fixture's data makes it reachable.

## Testing layers added

- **Direct**: `V1OntologyTermControllerTest` — 11 cases covering the `id`/`iri`/`short_form`/`obo_id` identifier cascade (materially different from property/individual: `getIdFromMultipleOptions` resolves precedence, then `getOneById` tries the resolved value as an IRI, then a short form, then an OBO ID, in turn — not explicit per-parameter branching), the `obsoletes` filter passthrough, roots/preferredRoots missing-resource handling, decoded 404, and delegated parents/children/descendants/ancestors/jstree calls.
- **WIT**: `V1OntologyTermControllerWIT` — 44 invocations covering all 10 routes, the identifier cascade end-to-end through real Spring binding, the `obsoletes` (nullable `Boolean`) and `includeObsoletes` filters with malformed-value 400s asserting the exact stable message (not just status), pagination defaults/boundaries/malformed values and explicit `sort` binding across every pageable route, double-encoded IRIs, arbitrary V1 language passthrough, legacy HAL media type, and stable 404/400/405 error fields.
- **Repository IT**: extended `V1TermRepositoryIT` (now backed by a new `V1OntologyTermRepositoryHandle`, switched from the shared-entity-only `initializeDatabase` onto the full `initializeClassDatabase`) with 4 new cases — ontology scoping of every identifier lookup, `getRoots`/`getPreferredRootTerms`/`getParents`/`getChildren`/`getDescendants`/`getAncestors` against real Postgres columns, and the class js-tree/js-tree-children via `V1JsTreeRepository`.
- **Controller IT**: new `V1OntologyTermControllerIT` — 10 thin happy-path cases, one per route (learned from PR #1390's review: enumerate every route explicitly, never a "representative subset").

Test counts by layer: 11 direct + 44 WIT + 4 repository IT + 10 controller IT = **69 new tests**.

## Fixture changes (test-only, no production code changed)

- `has_direct_parents`/`has_hierarchical_parents` (real boolean columns `getRoots` filters on — previously left at their schema default of `false` for every row) and `is_preferred_root` (queried by `getPreferredRootTerms`) added to `loadClassFixture`'s INSERT. `EFO_1001`'s stored JSON gained a `directParent` key, the separate signal the js-tree builders read. Same gaps and same fix pattern already found and fixed for the property fixture in PR #1390; record counts unchanged.
- Switching `V1TermRepositoryIT` onto the full class fixture required updating its two pre-existing count-dependent assertions (4 → 6 total class records; `findAllByIsDefiningOntology` 3 → 5). Verified no regression in the sibling `ClassRepositoryIT`/`V2ClassControllerIT`/`V1TermControllerIT` suites sharing the same fixture loader.

## Local verification (Java 17, Rancher Desktop)

- Focused Postgres (`V1TermRepositoryIT,V1OntologyTermControllerIT,ClassRepositoryIT,V2ClassControllerIT,V1TermControllerIT`): 45/45 pass.
- Docker-free `mvn test`, run twice: 787/787 pass both times (baseline 732).
- PostgreSQL-only `-Pintegration-tests-only verify`, run twice: 167/167 pass both times (baseline 153).
- Clean `mvn clean verify`: 954/954 pass, Maven 1m51s (wall-clock 112.36s).
- `test_api.sh` is unchanged and was not run locally (though its CI run is what caught the reverted defect fix above).

## Coverage (JaCoCo, from the clean verify run)

- Whole-backend: 55.7% lines (2,667/4,785), 44.1% branches (845/1,916). No repository-wide threshold introduced.
- `V1OntologyTermController`: 72/171 lines, 30/66 branches — low relative to other controllers because this milestone exercises only 10 of 23 routes; the deferred routes make up the uncovered remainder.
- `V1TermRepository`: 100/123 lines, 9/12 branches — missing only the hierarchical-variant methods and two pre-existing dead methods (`getInstances`, `getPreferredRootTermCount`, both hardcoded to throw).

Baseline recorded in docs/backend-testing-strategy.md under "Implemented V1 ontology-term-controller baseline (milestone 1 of 2+)".

## Defects

None merged. One investigated, fixed, and reverted after the full system-regression gate showed it would break a real, tested V1 contract — see above and PR #1392.

## Graphify

`graphify update .` refreshed the local graph: 6495 nodes, 18211 edges, 298 communities. Same two pre-existing warnings as prior runs (two `Cargo.toml` files producing zero nodes; `frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme; will be reported separately once CI runs).
- `test_api.sh` full system regression (CI-only; see the defect investigation above for how it was used this round).

🤖 Generated with [Claude Code](https://claude.com/claude-code)