### PR TITLE
fix: lowercase ontology id before identifier lookup in V1 term shortcuts

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermController.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermController.java
@@ -543,11 +543,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getChildren(ontologyId, target.iri, lang, pageable);
@@ -581,11 +581,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getDescendants(ontologyId, target.iri, lang, pageable);
@@ -619,11 +619,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getHierarchicalChildren(ontologyId, target.iri, lang, pageable);
@@ -657,11 +657,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getHierarchicalDescendants(ontologyId, target.iri, lang, pageable);
@@ -695,11 +695,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getParents(ontologyId, target.iri, lang, pageable);
@@ -733,11 +733,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getAncestors(ontologyId, target.iri, lang, pageable);
@@ -771,11 +771,11 @@ public class V1OntologyTermController {
 
 
         id = getIdFromMultipleOptions(iri, shortForm, oboId, id);
+        ontologyId = ontologyId.toLowerCase();
         if (id == null) {
             return new ResponseEntity<>( assembler.toModel(new PageImpl<V1Term>(Collections.emptyList()), termAssembler), HttpStatus.OK);
         }
         V1Term target = getOneById(ontologyId, id, lang);
-        ontologyId = ontologyId.toLowerCase();
         if (target == null) throw new ResourceNotFoundException("No resource with " + id + " in " + ontologyId);
 
         Page<V1Term>  terms = termRepository.getHierarchicalAncestors(ontologyId, target.iri, lang, pageable);

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerShortcutOntologyCaseTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerShortcutOntologyCaseTest.java
@@ -1,0 +1,70 @@
+package uk.ac.ebi.spot.ols.controller.api.v1;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PagedResourcesAssembler;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.ac.ebi.spot.ols.model.v1.V1Term;
+import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * The seven ontology-root-level shortcut routes (/{onto}/children, /{onto}/descendants,
+ * /{onto}/parents, /{onto}/ancestors, and their three hierarchical* counterparts) resolved the
+ * requested term by calling getOneById(ontologyId, id, lang) with the ontology id exactly as
+ * received from the URL, then lowercased it only afterward — for the final delegated repository
+ * call and the 404 message, but too late for the identifier lookup itself. Every other route on
+ * this controller (termsByOntology, the per-term {iri} routes) lowercases first. Since
+ * ontology_id is always stored lowercase (see OlsSearchQuery's own comment on this), a request
+ * using the ontology's conventional uppercase acronym (e.g. "EFO", matching how ontologies are
+ * commonly referred to) would silently 404 on these seven routes alone, even though the same
+ * casing works on every other V1 route.
+ */
+class V1OntologyTermControllerShortcutOntologyCaseTest {
+
+    private V1OntologyTermController controller;
+    private V1TermRepository termRepository;
+    private Pageable pageable;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        termRepository = mock(V1TermRepository.class);
+        pageable = PageRequest.of(0, 1000);
+
+        controller = new V1OntologyTermController();
+        ReflectionTestUtils.setField(controller, "termRepository", termRepository);
+        controller.termAssembler = mock(V1TermAssembler.class);
+    }
+
+    @Test
+    void resolvesTheIdentifierRegardlessOfTheRequestedOntologyIdCasing() {
+        V1Term term = new V1Term();
+        term.iri = "http://example.org/EFO_1001";
+        term.related = List.of();
+        when(termRepository.findByOntologyAndIri("efo", "http://example.org/EFO_1001", "en"))
+                .thenReturn(term);
+        when(termRepository.getChildren(
+                "efo", "http://example.org/EFO_1001", "en", pageable))
+                .thenReturn(new PageImpl<>(List.of(term)));
+
+        PagedResourcesAssembler<V1Term> assembler = mock(PagedResourcesAssembler.class);
+
+        controller.termChildrenByOntology(
+                "EFO", "http://example.org/EFO_1001", null, null, null, "en", pageable, assembler);
+
+        verify(termRepository).findByOntologyAndIri(
+                "efo", "http://example.org/EFO_1001", "en");
+        verify(termRepository).getChildren(
+                "efo", "http://example.org/EFO_1001", "en", pageable);
+    }
+}


### PR DESCRIPTION
## Summary

- The seven ontology-root-level shortcut routes on `V1OntologyTermController` — `/{onto}/children`, `/{onto}/descendants`, `/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*` counterparts — resolve the requested term via `getOneById(ontologyId, id, lang)` using the ontology id **exactly as received from the URL**, then lowercase it only afterward. That's too late for the identifier lookup itself, though in time for the final delegated repository call and the 404 message.
- Every other route on this controller (`termsByOntology`, the per-term `{iri}` routes) lowercases the ontology id **before** calling `getOneById`/the repository.
- Since `ontology_id` is always stored lowercase (see `OlsSearchQuery`'s own comment on this), a request using the ontology's conventional uppercase acronym (e.g. `EFO`) silently 404s on these seven routes alone, even though the identical casing works on every other V1 route in this controller and its siblings (`V1OntologyPropertyController`, `V1OntologyIndividualController`).

## How this was found

While adding WIT/IT coverage for these seven shortcut routes on `test-v1-ontology-term-controller-hierarchy-shortcuts` (milestone 2 of the term-controller testing programme), tests using `EFO` (uppercase, the same convention used throughout every prior test in this programme) failed to resolve an identifier that the other routes resolve correctly. Checked `test_api.sh`'s committed expected-output baseline first (per the lesson from PR #1392) — these seven routes aren't exercised there at all, so there's no committed contract this could be intentionally preserving.

## Fix

Move `ontologyId = ontologyId.toLowerCase();` before the `getOneById` call, matching the pattern every other route on this controller already uses. Identical three-line change applied to all seven methods (verified as textually identical before applying a single `replace_all` edit).

## Test added

`V1OntologyTermControllerShortcutOntologyCaseTest` (new, direct unit test — controller-level bug, no database involved): confirms `termChildrenByOntology` resolves an identifier correctly when `{onto}` is passed in uppercase. Confirmed **red** before the fix (threw `ResourceNotFoundException`), **green** after.

## Local verification (Java 17, Rancher Desktop)

- Docker-free `mvn test`: 733/733 pass (baseline 732).
- Clean `mvn clean verify` (Docker-free + PostgreSQL): 733 + 153 = 886/886 pass, no regressions.
- `test_api.sh` unchanged, not run locally — will watch `Build & Test API` on this PR specifically before merging, given PR #1392's lesson.

## Scope

One-line-per-method production fix (7 identical occurrences) + one new regression test. No unrelated changes. Standalone defect PR, separate from the milestone-2 testing branch that found it — once merged, that branch will be rebased onto it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)