### PR TITLE
test: cover v1 ontology term controller (milestone 2 of 2)

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerIT.java
@@ -32,6 +32,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Covers all of V1OntologyTermController's routes against real Postgres: the core
+ * list/roots/preferredRoots/single/parents/children/descendants/ancestors/jstree routes
+ * (milestone 1, PR #1393), plus the hierarchical-variant routes, /graph, /related and the
+ * ontology-root-level shortcut routes (milestone 2, PR #1395).
+ */
 @Testcontainers
 class V1OntologyTermControllerIT {
 
@@ -52,6 +58,29 @@ class V1OntologyTermControllerIT {
     // from a prior /jstree response and echoes back to expand that node's children.
     private static final URI JS_TREE_CHILDREN_URI = URI.create(
             PARENT_URI + "/jstree/children/aHR0cDovL2V4YW1wbGUub3JnL0VGT18wMDAx");
+    private static final URI HIERARCHICAL_PARENTS_URI =
+            URI.create(TERM_URI + "/hierarchicalParents");
+    private static final URI HIERARCHICAL_ANCESTORS_URI =
+            URI.create(TERM_URI + "/hierarchicalAncestors");
+    private static final URI HIERARCHICAL_CHILDREN_URI =
+            URI.create(PARENT_URI + "/hierarchicalChildren");
+    private static final URI HIERARCHICAL_DESCENDANTS_URI =
+            URI.create(PARENT_URI + "/hierarchicalDescendants");
+    private static final URI GRAPH_URI = URI.create(TERM_URI + "/graph");
+    private static final URI RELATED_URI = URI.create(
+            "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_0002"
+                    + "/http%253A%252F%252Fexample.org%252Frelated");
+    private static final URI SHORTCUT_CHILDREN_URI = URI.create("/api/ontologies/EFO/children");
+    private static final URI SHORTCUT_DESCENDANTS_URI =
+            URI.create("/api/ontologies/EFO/descendants");
+    private static final URI SHORTCUT_PARENTS_URI = URI.create("/api/ontologies/EFO/parents");
+    private static final URI SHORTCUT_ANCESTORS_URI = URI.create("/api/ontologies/EFO/ancestors");
+    private static final URI SHORTCUT_HIERARCHICAL_CHILDREN_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalChildren");
+    private static final URI SHORTCUT_HIERARCHICAL_DESCENDANTS_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalDescendants");
+    private static final URI SHORTCUT_HIERARCHICAL_ANCESTORS_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalAncestors");
 
     @Container
     private static final PostgreSQLContainer<?> POSTGRES =
@@ -70,6 +99,7 @@ class V1OntologyTermControllerIT {
         ReflectionTestUtils.setField(
                 controller, "termRepository", repositoryHandle.termRepository());
         controller.jsTreeRepository = repositoryHandle.jsTreeRepository();
+        controller.graphRepository = repositoryHandle.graphRepository();
         controller.termAssembler = new V1TermAssembler();
         controller.preferredRootTermAssembler = new V1PreferredRootTermAssembler();
 
@@ -190,6 +220,136 @@ class V1OntologyTermControllerIT {
                 .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$[0].iri").value("http://example.org/EFO_1001"))
                 .andExpect(jsonPath("$[0].text").value("Clinical liver child"));
+    }
+
+    @Test
+    void getsHierarchicalParentsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsHierarchicalAncestorsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsHierarchicalChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsHierarchicalDescendantsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsTheClassGraphThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(GRAPH_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.nodes[*].iri").isArray())
+                .andExpect(jsonPath("$.edges[0].source")
+                        .value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$.edges[0].target")
+                        .value("http://example.org/EFO_0001"))
+                .andExpect(jsonPath("$.edges[0].uri")
+                        .value("http://www.w3.org/2000/01/rdf-schema#subClassOf"));
+    }
+
+    @Test
+    void getsRelatedEntitiesThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(RELATED_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsShortcutChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_CHILDREN_URI).param("iri", "http://example.org/EFO_0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsShortcutDescendantsThroughTheRealDatabase() throws Exception {
+        // Delegates to the same getDescendants used by the direct /terms/{iri}/descendants route
+        // above, which includes the fixture's synthetic individual (EFO_I100) alongside the two
+        // classes — confirmed intended V1 behavior there, not a defect.
+        mockMvc.perform(get(SHORTCUT_DESCENDANTS_URI)
+                        .param("iri", "http://example.org/EFO_0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(3))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsShortcutParentsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_PARENTS_URI).param("iri", "http://example.org/EFO_1001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsShortcutAncestorsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_ANCESTORS_URI).param("iri", "http://example.org/EFO_1001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
+    }
+
+    @Test
+    void getsShortcutHierarchicalChildrenThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_CHILDREN_URI)
+                        .param("iri", "http://example.org/EFO_0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsShortcutHierarchicalDescendantsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_DESCENDANTS_URI)
+                        .param("iri", "http://example.org/EFO_0001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(2))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_1001"));
+    }
+
+    @Test
+    void getsShortcutHierarchicalAncestorsThroughTheRealDatabase() throws Exception {
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_ANCESTORS_URI)
+                        .param("iri", "http://example.org/EFO_1001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.page.totalElements").value(1))
+                .andExpect(jsonPath("$._embedded.terms[0].iri")
+                        .value("http://example.org/EFO_0001"));
     }
 
     private static MappingJackson2HttpMessageConverter halMessageConverter() {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.hateoas.PagedModel;
 import org.springframework.test.util.ReflectionTestUtils;
 import uk.ac.ebi.spot.ols.model.v1.V1Term;
 import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.v1.V1GraphRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
 
@@ -27,11 +28,18 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Covers all of V1OntologyTermController's 23 routes: the core list/roots/preferredRoots/single/
+ * parents/children/descendants/ancestors/jstree routes (milestone 1, PR #1393), plus the
+ * hierarchical-variant per-term routes, /graph, the dynamic related-by-property route, and the
+ * seven ontology-root-level shortcut routes (milestone 2, PR #1395).
+ */
 class V1OntologyTermControllerTest {
 
     private V1OntologyTermController controller;
     private V1TermRepository termRepository;
     private V1JsTreeRepository jsTreeRepository;
+    private V1GraphRepository graphRepository;
     private V1TermAssembler termAssembler;
     private V1PreferredRootTermAssembler preferredRootTermAssembler;
     private PagedResourcesAssembler<V1Term> termResourcesAssembler;
@@ -42,6 +50,7 @@ class V1OntologyTermControllerTest {
     void setUp() {
         termRepository = mock(V1TermRepository.class);
         jsTreeRepository = mock(V1JsTreeRepository.class);
+        graphRepository = mock(V1GraphRepository.class);
         termAssembler = mock(V1TermAssembler.class);
         preferredRootTermAssembler = mock(V1PreferredRootTermAssembler.class);
         termResourcesAssembler = mock(PagedResourcesAssembler.class);
@@ -52,6 +61,7 @@ class V1OntologyTermControllerTest {
         controller.termAssembler = termAssembler;
         controller.preferredRootTermAssembler = preferredRootTermAssembler;
         controller.jsTreeRepository = jsTreeRepository;
+        controller.graphRepository = graphRepository;
     }
 
     @Test
@@ -274,6 +284,226 @@ class V1OntologyTermControllerTest {
                 "http://example.org/EFO_0001", "node-1", "efo", "fr");
         org.assertj.core.api.Assertions.assertThat(response.getBody())
                 .contains("http://example.org/EFO_1001", "Clinical liver child");
+    }
+
+    @Test
+    void delegatesDecodedHierarchicalParentsChildrenDescendantsAndAncestors() {
+        PageImpl<V1Term> page = new PageImpl<>(List.of(term()));
+        when(termRepository.getHierarchicalParents(
+                "efo", "http://example.org/EFO_1001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getHierarchicalChildren(
+                "efo", "http://example.org/EFO_0001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getHierarchicalDescendants(
+                "efo", "http://example.org/EFO_0001", "fr", pageable)).thenReturn(page);
+        when(termRepository.getHierarchicalAncestors(
+                "efo", "http://example.org/EFO_1001", "fr", pageable)).thenReturn(page);
+
+        controller.getHierarchicalParents(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr", pageable,
+                termResourcesAssembler);
+        controller.getHierarchicalChildren(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0001", "fr", pageable,
+                termResourcesAssembler);
+        controller.getHierarchicalDescendants(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0001", "fr", pageable,
+                termResourcesAssembler);
+        controller.getHierarchicalAncestors(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr", pageable,
+                termResourcesAssembler);
+
+        verify(termRepository).getHierarchicalParents(
+                "efo", "http://example.org/EFO_1001", "fr", pageable);
+        verify(termRepository).getHierarchicalChildren(
+                "efo", "http://example.org/EFO_0001", "fr", pageable);
+        verify(termRepository).getHierarchicalDescendants(
+                "efo", "http://example.org/EFO_0001", "fr", pageable);
+        verify(termRepository).getHierarchicalAncestors(
+                "efo", "http://example.org/EFO_1001", "fr", pageable);
+    }
+
+    @Test
+    void reportsMissingResourceForEachHierarchicalRouteWithItsOwnMessage() {
+        when(termRepository.getHierarchicalParents("efo", "missing", "en", pageable))
+                .thenReturn(null);
+        ResourceNotFoundException parentsError = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getHierarchicalParents(
+                        "EFO", "missing", "en", pageable, termResourcesAssembler));
+        assertEquals("No parents could be found for efo and missing", parentsError.getMessage());
+
+        when(termRepository.getHierarchicalAncestors("efo", "missing", "en", pageable))
+                .thenReturn(null);
+        ResourceNotFoundException ancestorsError = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getHierarchicalAncestors(
+                        "EFO", "missing", "en", pageable, termResourcesAssembler));
+        assertEquals(
+                "No ancestors could be found for efo and missing", ancestorsError.getMessage());
+
+        when(termRepository.getHierarchicalChildren("efo", "missing", "en", pageable))
+                .thenReturn(null);
+        ResourceNotFoundException childrenError = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getHierarchicalChildren(
+                        "EFO", "missing", "en", pageable, termResourcesAssembler));
+        assertEquals(
+                "No hierarchical children could be found for efo and missing",
+                childrenError.getMessage());
+
+        when(termRepository.getHierarchicalDescendants("efo", "missing", "en", pageable))
+                .thenReturn(null);
+        ResourceNotFoundException descendantsError = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.getHierarchicalDescendants(
+                        "EFO", "missing", "en", pageable, termResourcesAssembler));
+        assertEquals(
+                "No hierarchical descendants could be found for efo and missing",
+                descendantsError.getMessage());
+    }
+
+    @Test
+    void serializesTheDecodedClassGraph() {
+        when(graphRepository.getGraphForClass("http://example.org/EFO_1001", "efo", "fr"))
+                .thenReturn(Map.of(
+                        "nodes", List.of(Map.of("iri", "http://example.org/EFO_1001")),
+                        "edges", List.of()));
+
+        var response = controller.graphJson(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_1001", "fr");
+
+        verify(graphRepository).getGraphForClass("http://example.org/EFO_1001", "efo", "fr");
+        org.assertj.core.api.Assertions.assertThat(response.getBody())
+                .contains("http://example.org/EFO_1001", "nodes", "edges");
+    }
+
+    @Test
+    void delegatesDecodedRelatedByPropertyWithoutRequiringAResult() {
+        PageImpl<V1Term> page = new PageImpl<>(List.of(term()));
+        when(termRepository.getRelated(
+                "efo", "http://example.org/EFO_0002", "fr",
+                "http://example.org/related", pageable))
+                .thenReturn(page);
+
+        controller.related(
+                "EFO", "http%3A%2F%2Fexample.org%2FEFO_0002",
+                "http%3A%2F%2Fexample.org%2Frelated", "fr", pageable, termResourcesAssembler);
+
+        verify(termRepository).getRelated(
+                "efo", "http://example.org/EFO_0002", "fr",
+                "http://example.org/related", pageable);
+    }
+
+    @Test
+    void shortcutRoutesReturnAnEmptyPageWithoutCallingTheRepositoryWhenNoIdentifierIsSupplied() {
+        when(termResourcesAssembler.toModel(org.mockito.ArgumentMatchers.any(), eq(termAssembler)))
+                .thenReturn(PagedModel.empty());
+
+        controller.termChildrenByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termDescendantsByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termHierarchicalChildrenByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termHierarchicalDescendantsByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termParentsByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termAncestorsByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+        controller.termHierarchicalAncestorsByOntology(
+                "EFO", null, null, null, null, "en", pageable, termResourcesAssembler);
+
+        verify(termRepository, never()).getChildren(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never()).getDescendants(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never())
+                .getHierarchicalChildren(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never())
+                .getHierarchicalDescendants(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never()).getParents(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never()).getAncestors(anyStr(), anyStr(), anyStr(), any());
+        verify(termRepository, never())
+                .getHierarchicalAncestors(anyStr(), anyStr(), anyStr(), any());
+    }
+
+    @Test
+    void shortcutRoutesResolveTheIdentifierThenReportMissingResource() {
+        ResourceNotFoundException error = assertThrows(
+                ResourceNotFoundException.class,
+                () -> controller.termChildrenByOntology(
+                        "EFO", "missing", null, null, null, "en", pageable,
+                        termResourcesAssembler));
+        assertEquals("No resource with missing in efo", error.getMessage());
+    }
+
+    @Test
+    void eachShortcutRouteDelegatesToItsMatchingHierarchyMethodOnTheResolvedTerm() {
+        // getOneById receives the ontology id exactly as passed in (not yet lowercased) — see
+        // OlsSearchQuery's "ontology_id" special case, which lowercases the filter value itself,
+        // so the real search-client-backed lookup resolves regardless of case. The delegated
+        // hierarchy call below receives the already-lowercased value (assigned right after).
+        when(termRepository.findByOntologyAndIri("EFO", "EFO_1001", "en")).thenReturn(term());
+        PageImpl<V1Term> page = new PageImpl<>(List.of(term()));
+        when(termRepository.getChildren("efo", "http://example.org/EFO_1001", "en", pageable))
+                .thenReturn(page);
+        when(termRepository.getDescendants("efo", "http://example.org/EFO_1001", "en", pageable))
+                .thenReturn(page);
+        when(termRepository.getHierarchicalChildren(
+                "efo", "http://example.org/EFO_1001", "en", pageable)).thenReturn(page);
+        when(termRepository.getHierarchicalDescendants(
+                "efo", "http://example.org/EFO_1001", "en", pageable)).thenReturn(page);
+        when(termRepository.getParents("efo", "http://example.org/EFO_1001", "en", pageable))
+                .thenReturn(page);
+        when(termRepository.getAncestors("efo", "http://example.org/EFO_1001", "en", pageable))
+                .thenReturn(page);
+        when(termRepository.getHierarchicalAncestors(
+                "efo", "http://example.org/EFO_1001", "en", pageable)).thenReturn(page);
+
+        controller.termChildrenByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getChildren("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termDescendantsByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getDescendants("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termHierarchicalChildrenByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getHierarchicalChildren("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termHierarchicalDescendantsByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getHierarchicalDescendants("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termParentsByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getParents("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termAncestorsByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getAncestors("efo", "http://example.org/EFO_1001", "en", pageable);
+
+        controller.termHierarchicalAncestorsByOntology(
+                "EFO", "EFO_1001", null, null, null, "en", pageable, termResourcesAssembler);
+        verify(termRepository)
+                .getHierarchicalAncestors("efo", "http://example.org/EFO_1001", "en", pageable);
+    }
+
+    private static String anyStr() {
+        return org.mockito.ArgumentMatchers.anyString();
+    }
+
+    private static Pageable any() {
+        return org.mockito.ArgumentMatchers.any();
+    }
+
+    private static <T> T eq(T value) {
+        return org.mockito.ArgumentMatchers.eq(value);
     }
 
     private static V1Term term() {

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v1/V1OntologyTermControllerWIT.java
@@ -6,7 +6,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.hateoas.MediaTypes;
@@ -33,8 +32,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -44,6 +41,12 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Covers all of V1OntologyTermController's 23 routes: the core list/roots/preferredRoots/single/
+ * parents/children/descendants/ancestors/jstree routes (milestone 1, PR #1393), plus the
+ * hierarchical-variant per-term routes, /graph, the dynamic related-by-property route, and the
+ * seven ontology-root-level shortcut routes (milestone 2, PR #1395).
+ */
 @WebMvcTest(V1OntologyTermController.class)
 @ContextConfiguration(classes = {
         V1OntologyTermController.class,
@@ -62,6 +65,8 @@ class V1OntologyTermControllerWIT {
             URI.create("/api/ontologies/EFO/terms/preferredRoots");
     private static final URI TERM_URI = URI.create(
             "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_1001");
+    private static final URI PARENT_URI = URI.create(
+            "/api/ontologies/EFO/terms/http%253A%252F%252Fexample.org%252FEFO_0001");
     private static final URI PARENTS_URI = URI.create(TERM_URI + "/parents");
     private static final URI CHILDREN_URI = URI.create(TERM_URI + "/children");
     private static final URI DESCENDANTS_URI = URI.create(TERM_URI + "/descendants");
@@ -69,6 +74,28 @@ class V1OntologyTermControllerWIT {
     private static final URI JS_TREE_URI = URI.create(TERM_URI + "/jstree");
     private static final URI JS_TREE_CHILDREN_URI = URI.create(
             TERM_URI + "/jstree/children/node-1");
+    private static final URI HIERARCHICAL_PARENTS_URI =
+            URI.create(TERM_URI + "/hierarchicalParents");
+    private static final URI HIERARCHICAL_ANCESTORS_URI =
+            URI.create(TERM_URI + "/hierarchicalAncestors");
+    private static final URI HIERARCHICAL_CHILDREN_URI =
+            URI.create(PARENT_URI + "/hierarchicalChildren");
+    private static final URI HIERARCHICAL_DESCENDANTS_URI =
+            URI.create(PARENT_URI + "/hierarchicalDescendants");
+    private static final URI GRAPH_URI = URI.create(TERM_URI + "/graph");
+    private static final URI RELATED_URI = URI.create(
+            TERM_URI + "/http%253A%252F%252Fexample.org%252Frelated");
+    private static final URI SHORTCUT_CHILDREN_URI = URI.create("/api/ontologies/EFO/children");
+    private static final URI SHORTCUT_DESCENDANTS_URI =
+            URI.create("/api/ontologies/EFO/descendants");
+    private static final URI SHORTCUT_PARENTS_URI = URI.create("/api/ontologies/EFO/parents");
+    private static final URI SHORTCUT_ANCESTORS_URI = URI.create("/api/ontologies/EFO/ancestors");
+    private static final URI SHORTCUT_HIERARCHICAL_CHILDREN_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalChildren");
+    private static final URI SHORTCUT_HIERARCHICAL_DESCENDANTS_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalDescendants");
+    private static final URI SHORTCUT_HIERARCHICAL_ANCESTORS_URI =
+            URI.create("/api/ontologies/EFO/hierarchicalAncestors");
 
     @Autowired
     private MockMvc mockMvc;
@@ -113,6 +140,23 @@ class V1OntologyTermControllerWIT {
         when(termRepository.getAncestors(anyString(), anyString(), anyString(), any()))
                 .thenAnswer(invocation -> termPage(
                         invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getHierarchicalParents(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getHierarchicalAncestors(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getHierarchicalChildren(anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getHierarchicalDescendants(
+                anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(3), invocation.getArgument(2)));
+        when(termRepository.getRelated(
+                anyString(), anyString(), anyString(), anyString(), any()))
+                .thenAnswer(invocation -> termPage(
+                        invocation.getArgument(4), invocation.getArgument(2)));
         when(jsTreeRepository.getJsTreeForClass(anyString(), anyString(), anyString()))
                 .thenReturn(List.of(Map.of(
                         "id", "term-node",
@@ -129,6 +173,11 @@ class V1OntologyTermControllerWIT {
                         "parent", "term-node",
                         "iri", TERM_IRI,
                         "text", "Clinical liver child")));
+        when(graphRepository.getGraphForClass(anyString(), anyString(), anyString()))
+                .thenReturn(Map.of(
+                        "nodes", List.of(Map.of("iri", TERM_IRI, "label", "Clinical liver child")),
+                        "edges", List.of(Map.of(
+                                "source", TERM_IRI, "target", PARENT_IRI, "label", "is a"))));
     }
 
     @Test
@@ -502,14 +551,236 @@ class V1OntologyTermControllerWIT {
     }
 
     @Test
+    void delegatesHierarchicalParentsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_PARENTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$.page.size").value(1000));
+
+        mockMvc.perform(get(HIERARCHICAL_PARENTS_URI)
+                        .param("lang", "fr").param("page", "1").param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getHierarchicalParents(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void delegatesHierarchicalAncestorsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(HIERARCHICAL_ANCESTORS_URI)
+                        .param("lang", "fr").param("page", "1").param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getHierarchicalAncestors(
+                "efo", TERM_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void delegatesHierarchicalChildrenWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(HIERARCHICAL_CHILDREN_URI)
+                        .param("lang", "fr").param("page", "1").param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getHierarchicalChildren(
+                "efo", PARENT_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @Test
+    void delegatesHierarchicalDescendantsWithDefaultsAndExplicitOptions() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI));
+
+        mockMvc.perform(get(HIERARCHICAL_DESCENDANTS_URI)
+                        .param("lang", "fr").param("page", "1").param("size", "3")
+                        .param("sort", "iri,desc"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getHierarchicalDescendants(
+                "efo", PARENT_IRI, "fr", PageRequest.of(1, 3,
+                        org.springframework.data.domain.Sort.Direction.DESC, "iri"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "hierarchicalParents, -1, 20, 0, 20",
+            "hierarchicalParents, 0, 0, 0, 1000",
+            "hierarchicalParents, 0, 1001, 0, 1000",
+            "hierarchicalAncestors, -1, 20, 0, 20",
+            "hierarchicalChildren, -1, 20, 0, 20",
+            "hierarchicalDescendants, -1, 20, 0, 20"
+    })
+    void normalizesPaginationBoundariesAcrossHierarchicalRoutes(
+            String route, int requestedPage, int requestedSize, int expectedPage, int expectedSize)
+            throws Exception {
+        mockMvc.perform(get(route(route))
+                        .param("page", Integer.toString(requestedPage))
+                        .param("size", Integer.toString(requestedSize)))
+                .andExpect(status().isOk());
+
+        Pageable expected = PageRequest.of(expectedPage, expectedSize);
+        switch (route) {
+            case "hierarchicalParents" -> verify(termRepository)
+                    .getHierarchicalParents("efo", TERM_IRI, "en", expected);
+            case "hierarchicalAncestors" -> verify(termRepository)
+                    .getHierarchicalAncestors("efo", TERM_IRI, "en", expected);
+            case "hierarchicalChildren" -> verify(termRepository)
+                    .getHierarchicalChildren("efo", PARENT_IRI, "en", expected);
+            case "hierarchicalDescendants" -> verify(termRepository)
+                    .getHierarchicalDescendants("efo", PARENT_IRI, "en", expected);
+            default -> throw new IllegalArgumentException("Unknown route: " + route);
+        }
+    }
+
+    @Test
+    void returnsTheClassGraphWithDoubleEncodedIriAndExplicitLanguage() throws Exception {
+        mockMvc.perform(get(GRAPH_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.nodes[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$.edges[0].source").value(TERM_IRI))
+                .andExpect(jsonPath("$.edges[0].target").value(PARENT_IRI));
+
+        verify(graphRepository).getGraphForClass(TERM_IRI, "efo", "fr");
+    }
+
+    @Test
+    void returnsRelatedEntitiesForADoubleEncodedTermAndPropertyIri() throws Exception {
+        mockMvc.perform(get(RELATED_URI).param("lang", "fr"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$._embedded.terms[0].iri").value(TERM_IRI))
+                .andExpect(jsonPath("$._embedded.terms[0].lang").value("fr"));
+
+        verify(termRepository).getRelated(
+                "efo", TERM_IRI, "fr", "http://example.org/related", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void shortcutRoutesReturnAnEmptyContractWhenNoIdentifierIsSupplied() throws Exception {
+        for (URI uri : List.of(
+                SHORTCUT_CHILDREN_URI, SHORTCUT_DESCENDANTS_URI, SHORTCUT_PARENTS_URI,
+                SHORTCUT_ANCESTORS_URI, SHORTCUT_HIERARCHICAL_CHILDREN_URI,
+                SHORTCUT_HIERARCHICAL_DESCENDANTS_URI, SHORTCUT_HIERARCHICAL_ANCESTORS_URI)) {
+            mockMvc.perform(get(uri))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.page.totalElements").value(0));
+        }
+
+        verify(termRepository, never()).getChildren(anyString(), anyString(), anyString(), any());
+        verify(termRepository, never())
+                .getDescendants(anyString(), anyString(), anyString(), any());
+        verify(termRepository, never()).getParents(anyString(), anyString(), anyString(), any());
+        verify(termRepository, never())
+                .getAncestors(anyString(), anyString(), anyString(), any());
+    }
+
+    @Test
+    void shortcutRoutesResolveTheIdentifierAndReportMissingResource() throws Exception {
+        when(termRepository.findByOntologyAndIri("EFO", "missing", "en")).thenReturn(null);
+
+        // The controller's own @ExceptionHandler(ResourceNotFoundException.class) catches this
+        // before GlobalExceptionHandler does, discarding the exception's own message (proven at
+        // the direct-test layer) in favor of the fixed legacy servlet reason and an empty body —
+        // the same stable V1 contract already covered for the single-term 404 above.
+        mockMvc.perform(get(SHORTCUT_CHILDREN_URI).param("iri", "missing"))
+                .andExpect(status().isNotFound())
+                .andExpect(result -> assertEquals(
+                        "EntityModel not found", result.getResponse().getErrorMessage()))
+                .andExpect(content().string(""));
+    }
+
+    @Test
+    void eachShortcutRouteResolvesTheIdentifierAndDelegatesToItsMatchingHierarchyMethod()
+            throws Exception {
+        mockMvc.perform(get(SHORTCUT_CHILDREN_URI).param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).getChildren("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_DESCENDANTS_URI).param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).getDescendants("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_PARENTS_URI).param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).getParents("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_ANCESTORS_URI).param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository).getAncestors("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_CHILDREN_URI)
+                        .param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository)
+                .getHierarchicalChildren("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_DESCENDANTS_URI)
+                        .param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository)
+                .getHierarchicalDescendants("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+
+        mockMvc.perform(get(SHORTCUT_HIERARCHICAL_ANCESTORS_URI)
+                        .param("iri", TERM_IRI).param("lang", "fr"))
+                .andExpect(status().isOk());
+        verify(termRepository)
+                .getHierarchicalAncestors("efo", TERM_IRI, "fr", PageRequest.of(0, 1000));
+    }
+
+    @Test
+    void shortcutRoutesResolveIdentifierByShortFormAndOboIdWhenIriIsAbsent() throws Exception {
+        // getOneById receives the ontology id exactly as passed in the URL (here "EFO",
+        // unlowered) — see OlsSearchQuery's "ontology_id" special case, which lowercases the
+        // filter value itself, so this resolves correctly against real Postgres regardless.
+        when(termRepository.findByOntologyAndIri("EFO", "EFO_1001", "en")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("EFO", "EFO_1001", "en"))
+                .thenReturn(term("en"));
+        mockMvc.perform(get(SHORTCUT_CHILDREN_URI).param("short_form", "EFO_1001"))
+                .andExpect(status().isOk());
+        verify(termRepository).getChildren("efo", TERM_IRI, "en", PageRequest.of(0, 1000));
+
+        when(termRepository.findByOntologyAndIri("EFO", "EFO:1001", "en")).thenReturn(null);
+        when(termRepository.findByOntologyAndShortForm("EFO", "EFO:1001", "en")).thenReturn(null);
+        when(termRepository.findByOntologyAndOboId("EFO", "EFO:1001", "en"))
+                .thenReturn(term("en"));
+        mockMvc.perform(get(SHORTCUT_PARENTS_URI).param("obo_id", "EFO:1001"))
+                .andExpect(status().isOk());
+        verify(termRepository).getParents("efo", TERM_IRI, "en", PageRequest.of(0, 1000));
+    }
+
+    @Test
     void supportsLegacyHalMediaTypeOnEveryHalRoute() throws Exception {
         for (URI uri : List.of(
                 LIST_URI, ROOTS_URI, PREFERRED_ROOTS_URI, TERM_URI, PARENTS_URI,
-                CHILDREN_URI, DESCENDANTS_URI, ANCESTORS_URI, JS_TREE_URI)) {
+                CHILDREN_URI, DESCENDANTS_URI, ANCESTORS_URI, JS_TREE_URI,
+                HIERARCHICAL_PARENTS_URI, HIERARCHICAL_ANCESTORS_URI, HIERARCHICAL_CHILDREN_URI,
+                HIERARCHICAL_DESCENDANTS_URI, RELATED_URI)) {
             mockMvc.perform(get(uri).accept(MediaTypes.HAL_JSON))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
         }
+        mockMvc.perform(get(SHORTCUT_CHILDREN_URI).param("iri", TERM_IRI)
+                        .accept(MediaTypes.HAL_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaTypes.HAL_JSON));
     }
 
     @Test
@@ -538,6 +809,19 @@ class V1OntologyTermControllerWIT {
     }
 
     @Test
+    void returnsStableBadRequestFieldsForUnsupportedSortOnAHierarchicalRoute() throws Exception {
+        Pageable pageable = PageRequest.of(
+                0, 1000, org.springframework.data.domain.Sort.by("bad"));
+        when(termRepository.getHierarchicalParents("efo", TERM_IRI, "en", pageable))
+                .thenThrow(new IllegalArgumentException("Unsupported sort field: bad"));
+
+        mockMvc.perform(get(HIERARCHICAL_PARENTS_URI).param("sort", "bad"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value("Unsupported sort field: bad"));
+    }
+
+    @Test
     void rejectsUnsupportedHttpMethodWithStableErrorFields() throws Exception {
         mockMvc.perform(post(LIST_URI))
                 .andExpect(status().isMethodNotAllowed())
@@ -555,6 +839,10 @@ class V1OntologyTermControllerWIT {
             case "children" -> CHILDREN_URI;
             case "descendants" -> DESCENDANTS_URI;
             case "ancestors" -> ANCESTORS_URI;
+            case "hierarchicalParents" -> HIERARCHICAL_PARENTS_URI;
+            case "hierarchicalAncestors" -> HIERARCHICAL_ANCESTORS_URI;
+            case "hierarchicalChildren" -> HIERARCHICAL_CHILDREN_URI;
+            case "hierarchicalDescendants" -> HIERARCHICAL_DESCENDANTS_URI;
             default -> throw new IllegalArgumentException("Unknown route: " + route);
         };
     }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1TermRepositoryIT.java
@@ -28,6 +28,7 @@ class V1TermRepositoryIT {
     private static PostgresIntegrationTestSupport.V1OntologyTermRepositoryHandle repositoryHandle;
     private static V1TermRepository repository;
     private static V1JsTreeRepository jsTreeRepository;
+    private static V1GraphRepository graphRepository;
 
     @BeforeAll
     static void setUpDatabase() {
@@ -35,6 +36,7 @@ class V1TermRepositoryIT {
         repositoryHandle = PostgresIntegrationTestSupport.createV1OntologyTermRepositories(POSTGRES);
         repository = repositoryHandle.termRepository();
         jsTreeRepository = repositoryHandle.jsTreeRepository();
+        graphRepository = repositoryHandle.graphRepository();
     }
 
     @AfterAll
@@ -269,5 +271,90 @@ class V1TermRepositoryIT {
                 "http://example.org/EFO_1001",
                 "http://example.org/EFO_1999");
         assertThat(children.get(0)).containsEntry("parent", parentNodeId);
+    }
+
+    @Test
+    void returnsHierarchicalRelationshipsFromProductionColumns() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        // Unlike direct parents/ancestors (see V1TermRepositoryHierarchyTypeFilterIT, and PR #1392's
+        // reverted fix), the hierarchical_parents/hierarchical_ancestors columns are populated only
+        // for genuine subClassOf relationships in this fixture, not for the individual's
+        // instance-of-style direct ancestor — so no equivalent cross-type leak arises here.
+        assertThat(repository.getHierarchicalParents(
+                "efo", "http://example.org/EFO_1001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getHierarchicalAncestors(
+                "efo", "http://example.org/EFO_1001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getHierarchicalChildren(
+                "efo", "http://example.org/EFO_0001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999");
+        assertThat(repository.getHierarchicalDescendants(
+                "efo", "http://example.org/EFO_0001", "en", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly(
+                        "http://example.org/EFO_1001",
+                        "http://example.org/EFO_1999");
+    }
+
+    @Test
+    void returnsRelatedEntitiesRegardlessOfTheRequestedPropertyIri() {
+        PageRequest pageable = PageRequest.of(0, 20);
+
+        // getRelated's `relation` (property IRI) parameter is not used to filter the query — it
+        // returns every related_to target regardless of which specific relation was requested.
+        // Documented here as observed behavior; no committed system-regression baseline exercises
+        // this route, so there is no evidence either way of the intended contract.
+        assertThat(repository.getRelated(
+                "efo", "http://example.org/EFO_0002", "en",
+                "http://www.w3.org/2000/01/rdf-schema#seeAlso", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+        assertThat(repository.getRelated(
+                "efo", "http://example.org/EFO_0002", "en",
+                "http://purl.obolibrary.org/obo/RO_0000052", pageable))
+                .extracting(term -> term.iri)
+                .containsExactly("http://example.org/EFO_0001");
+    }
+
+    @Test
+    void buildsTheClassGraphFromRealPostgresRelationships() {
+        Map<String, Object> parentGraph = graphRepository.getGraphForClass(
+                "http://example.org/EFO_1001", "efo", "en");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> parentNodes =
+                (List<Map<String, Object>>) parentGraph.get("nodes");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> parentEdges =
+                (List<Map<String, Object>>) parentGraph.get("edges");
+
+        assertThat(parentNodes).extracting(node -> node.get("iri")).containsExactlyInAnyOrder(
+                "http://example.org/EFO_1001", "http://example.org/EFO_0001");
+        assertThat(parentEdges).singleElement().satisfies(edge -> {
+            assertThat(edge.get("source")).isEqualTo("http://example.org/EFO_1001");
+            assertThat(edge.get("target")).isEqualTo("http://example.org/EFO_0001");
+            assertThat(edge.get("uri")).isEqualTo("http://www.w3.org/2000/01/rdf-schema#subClassOf");
+        });
+
+        Map<String, Object> relatedGraph = graphRepository.getGraphForClass(
+                "http://example.org/EFO_0002", "efo", "en");
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> relatedEdges =
+                (List<Map<String, Object>>) relatedGraph.get("edges");
+
+        assertThat(relatedEdges).singleElement().satisfies(edge -> {
+            assertThat(edge.get("source")).isEqualTo("http://example.org/EFO_0002");
+            assertThat(edge.get("target")).isEqualTo("http://example.org/EFO_0001");
+            assertThat(edge.get("label")).isEqualTo("related to");
+            assertThat(edge).doesNotContainKey("uri");
+        });
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -14,6 +14,7 @@ import uk.ac.ebi.spot.ols.repository.OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
 import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.repository.v1.V1GraphRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1IndividualRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1JsTreeRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
@@ -263,8 +264,11 @@ public final class PostgresIntegrationTestSupport {
         V1JsTreeRepository jsTreeRepository = new V1JsTreeRepository();
         ReflectionTestUtils.setField(jsTreeRepository, "postgresClient", olsPostgresClient);
 
+        V1GraphRepository graphRepository = new V1GraphRepository();
+        ReflectionTestUtils.setField(graphRepository, "postgresClient", postgresClient);
+
         return new V1OntologyTermRepositoryHandle(
-                termRepository, jsTreeRepository, postgresClient);
+                termRepository, jsTreeRepository, graphRepository, postgresClient);
     }
 
     private static PostgresClient createPostgresClient(PostgreSQLContainer<?> container) {
@@ -781,6 +785,7 @@ public final class PostgresIntegrationTestSupport {
     public record V1OntologyTermRepositoryHandle(
             V1TermRepository termRepository,
             V1JsTreeRepository jsTreeRepository,
+            V1GraphRepository graphRepository,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -582,44 +582,62 @@ review exposed:
   same fields null-safely). PR #1391 isolated the minimal fix and a focused regression test,
   merged before this branch was rebased.
 
-## Implemented V1 ontology-term-controller baseline (milestone 1 of 2+)
+## Implemented V1 ontology-term-controller baseline (complete, 2 milestones)
 
-`V1OntologyTermController` has 23 routes — too large a hierarchy surface for one focused PR. This
-milestone covers the 10 core per-term routes (`terms` list, `roots`, `preferredRoots`, single
-`{iri}` get, `parents`, `children`, `descendants`, `ancestors`, `jstree`,
-`jstree/children/{nodeid}`), the same shape already proven for
-`V1OntologyPropertyController`/`V1OntologyIndividualController`. Deferred to a future milestone:
-`hierarchicalParents`/`hierarchicalChildren`/`hierarchicalAncestors`/`hierarchicalDescendants`,
-`/graph`, the dynamic `/{iri}/{property_iri}` related-by-property route, and the seven
-ontology-root-level shortcut routes (`/{onto}/children`, `/{onto}/descendants`,
-`/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*` counterparts).
+`V1OntologyTermController` has 23 routes — too large a hierarchy surface for one focused PR, so
+coverage was split into two milestones. Milestone 1 (PR #1393, merged) covers the 10 core
+per-term routes (`terms` list, `roots`, `preferredRoots`, single `{iri}` get, `parents`,
+`children`, `descendants`, `ancestors`, `jstree`, `jstree/children/{nodeid}`), the same shape
+already proven for `V1OntologyPropertyController`/`V1OntologyIndividualController`. Milestone 2
+(PR #1395) covers the remaining 13 routes: the four hierarchical-variant per-term routes
+(`hierarchicalParents`, `hierarchicalAncestors`, `hierarchicalChildren`,
+`hierarchicalDescendants`), `/graph`, the dynamic `/{iri}/{property_iri}` related-by-property
+route, and the seven ontology-root-level shortcut routes (`/{onto}/children`,
+`/{onto}/descendants`, `/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*`
+counterparts). Combined, all 23 routes are covered by all four test layers.
 
-Verified locally on 2026-09-04 with Java 17 and Rancher Desktop:
+Milestone 2 branched directly from `dev` while milestone 1 was still an open PR (its routes don't
+depend on milestone 1's fixture changes, so branching independently was safe — see "never stack on
+an open PR"). Once milestone 1 merged, milestone 2 picked up rebase conflicts against `dev` in the
+shared support file and the two files milestone 1 had already created with the same names
+(`V1OntologyTermControllerTest`, `V1OntologyTermControllerWIT`, `V1OntologyTermControllerIT`) —
+expected per that same rule, and resolved by combining both milestones' fields, stubs, and test
+methods into one file per layer rather than picking a side. One genuine method-name collision
+surfaced during that merge: both milestones independently wrote a
+`supportsLegacyHalMediaTypeOnEveryHalRoute` WIT test with different URI lists; resolved by folding
+milestone 2's HAL-route list into milestone 1's existing test rather than keeping two near-duplicate
+methods.
 
-- Surefire runs 787 tests, including 11 direct `V1OntologyTermControllerTest` cases and 44
-  `V1OntologyTermControllerWIT` invocations. Two Docker-free runs both passed cleanly.
-- Failsafe runs 167 PostgreSQL tests, including 4 new ontology-scoped `V1TermRepositoryIT` cases
-  (bringing that suite to 11, now loading the class fixture via `initializeClassDatabase` instead
-  of the shared-entity-only `initializeDatabase`) and 10 thin `V1OntologyTermControllerIT` cases —
-  one per route. Two complete database-gate runs both passed cleanly.
-- The clean `verify` lifecycle runs all 954 tests in Maven 1 minute 51 seconds (wall-clock 112.36
-  seconds).
-- Whole-backend JaCoCo coverage is 55.7% lines (2,667 of 4,785) and 44.1% branches (845 of 1,916).
-  `V1OntologyTermController` covers 72 of 171 lines and 30 of 66 branches — low relative to other
-  controllers because this milestone exercises only 10 of its 23 routes; the deferred
-  hierarchical/graph/related/shortcut routes make up the uncovered remainder. Its repository
-  covers 100 of 123 lines and 9 of 12 branches, missing only the hierarchical-variant methods and
-  two pre-existing dead methods (`getInstances`, `getPreferredRootTermCount`, both hardcoded to
-  throw). No coverage failure threshold is introduced.
-- The suites preserve the `id`/`iri`/`short_form`/`obo_id` identifier cascade (`getIdFromMultipleOptions`
-  tries `id` first, falling back through `iri` → `short_form` → `obo_id`; `getOneById` then tries
-  the resolved value as an IRI, then a short form, then an OBO ID in turn) — a materially different
-  precedence model from the explicit per-parameter branching `V1OntologyPropertyController` and
-  `V1OntologyIndividualController` use. Also covered: the `obsoletes` collection filter (nullable
-  `Boolean`, stable 400 on a malformed value), `includeObsoletes` on both `roots` and
-  `preferredRoots`, explicit `sort` binding on every pageable route, pagination boundaries and
-  malformed-numeric defaults, double-encoded IRI paths, legacy HAL fields, arbitrary V1 language
-  passthrough, and stable error contract fields (message included, not just status).
+Verified locally on 2026-09-04 with Java 17 and Rancher Desktop, after rebasing and combining both
+milestones:
+
+- Surefire runs [TOTAL_SUREFIRE] tests, including [TOTAL_DIRECT] direct `V1OntologyTermControllerTest`
+  cases and [TOTAL_WIT] `V1OntologyTermControllerWIT` invocations. Two Docker-free runs both passed
+  cleanly.
+- Failsafe runs [TOTAL_FAILSAFE] PostgreSQL tests, including [TOTAL_REPO_IT] `V1TermRepositoryIT`
+  cases and 23 thin `V1OntologyTermControllerIT` cases — one per route. Two complete database-gate
+  runs both passed cleanly.
+- The clean `verify` lifecycle runs all [TOTAL_VERIFY] tests in Maven [VERIFY_TIME].
+- Whole-backend JaCoCo coverage is [COVERAGE_LINES]% lines and [COVERAGE_BRANCHES]% branches.
+  `V1OntologyTermController` covers all 23 routes across both milestones. `V1TermRepository` and
+  `V1JsTreeRepository` coverage combines both milestones' exercised methods; `V1GraphRepository` —
+  previously completely untested anywhere in the codebase — covers its `getGraphForClass` path. No
+  coverage failure threshold is introduced.
+- The suites preserve the `id`/`iri`/`short_form`/`obo_id` identifier cascade
+  (`getIdFromMultipleOptions` tries `id` first, falling back through `iri` → `short_form` →
+  `obo_id`; `getOneById` then tries the resolved value as an IRI, then a short form, then an OBO ID
+  in turn) — a materially different precedence model from the explicit per-parameter branching
+  `V1OntologyPropertyController` and `V1OntologyIndividualController` use — across both the
+  per-term routes and the milestone-2 shortcut routes. Also covered: the `obsoletes` collection
+  filter, `includeObsoletes` on `roots`/`preferredRoots`, explicit `sort` binding on every pageable
+  route (core and hierarchical), pagination boundaries and malformed-numeric defaults,
+  double-encoded IRI paths, legacy HAL fields across all 23 routes, arbitrary V1 language
+  passthrough, hierarchical relationships against real `hierarchical_parents`/
+  `hierarchical_ancestors` Postgres columns, the full `V1GraphRepository.getGraphForClass`
+  node/edge shape, the `related`-by-property route's actual behavior of ignoring its own
+  `{property_iri}` path segment (documented, not fixed — no committed `test_api.sh` baseline
+  exercises this route either way), and the seven shortcut routes' empty-page no-identifier case
+  and delegation to the correct matching hierarchy method.
 - The committed class fixture gained two production-schema columns it never previously populated:
   `has_direct_parents`/`has_hierarchical_parents` (real boolean columns the `getRoots` query filters
   on — previously left at their schema default of `false` for every row, so `getRoots` could not
@@ -630,16 +648,28 @@ Verified locally on 2026-09-04 with Java 17 and Rancher Desktop:
   PR #1390; record counts are unchanged. Extending `V1TermRepositoryIT`'s existing suite to the full
   class fixture also required updating its two pre-existing count-dependent assertions (4 → 6 total
   class records, `findAllByIsDefiningOntology` 3 → 5).
-- A `V1TermRepository.getDescendants`/`getChildren` investigation briefly suspected a defect
-  mirroring PR #1373's V2 `ClassRepository` type-leak fix (V1 passes an empty node-property filter
-  to the same underlying Postgres hierarchy lookups, so a class's children/descendants can include
-  non-class entities sharing the same ancestor IRI). A fix was drafted, but the full system-regression
-  gate (`Build & Test API`, PR #1392) failed: the committed `test_api.sh` baseline for
-  `owl2primer-class-assertion` explicitly and deliberately expects an individual asserted into a
-  class to appear in that class's V1 `children`/`descendants` listing — a real, tested V1 legacy
-  contract, not an oversight. The fix was reverted and the PR closed; this milestone's tests assert
-  the actual (correct) current behavior instead, including the individual where the shared class
-  fixture's data makes it reachable. No production code changed in this milestone.
+- Two suspected defects were investigated and reverted across the two milestones; both are
+  documented in detail because the investigation process itself is the durable lesson:
+  - A `V1TermRepository.getDescendants`/`getChildren` hierarchy type-leak mirroring PR #1373's V2
+    `ClassRepository` fix (V1 passes an empty node-property filter to the same underlying Postgres
+    hierarchy lookups, so a class's children/descendants can include non-class entities sharing the
+    same ancestor IRI). A fix was drafted, but the full system-regression gate (`Build & Test API`,
+    PR #1392) failed: the committed `test_api.sh` baseline for `owl2primer-class-assertion`
+    explicitly and deliberately expects an individual asserted into a class to appear in that
+    class's V1 `children`/`descendants` listing — a real, tested V1 legacy contract, not an
+    oversight. The fix was reverted and the PR closed; the tests assert the actual (correct)
+    current behavior instead. For the *hierarchical* variant specifically, no leak actually occurs
+    with this fixture's data, because the individual's `hierarchicalAncestors` is empty even though
+    its `directAncestors` is not — so no fix was needed or attempted there either.
+  - A genuine-looking case-sensitivity bug in the seven shortcut routes: they call
+    `getOneById(ontologyId, id, lang)` with the ontology id exactly as received (not yet
+    lowercased), unlike every other route on this controller. A controller-mock unit test "proved"
+    this would silently 404 for a client using an uppercase ontology id. It doesn't: `OlsSearchQuery`
+    has an explicit `"ontology_id".equals(column)` special case that lowercases the filter input
+    itself, so the real search-client-backed lookup resolves correctly regardless of case — proven
+    directly with a real-Postgres controller-IT test against the *unmodified* code. The mock's
+    exact-string matching doesn't replicate that normalization, which is what made the unit test
+    misleading. No production code changed in either milestone.
 
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -611,18 +611,19 @@ methods.
 Verified locally on 2026-09-04 with Java 17 and Rancher Desktop, after rebasing and combining both
 milestones:
 
-- Surefire runs [TOTAL_SUREFIRE] tests, including [TOTAL_DIRECT] direct `V1OntologyTermControllerTest`
-  cases and [TOTAL_WIT] `V1OntologyTermControllerWIT` invocations. Two Docker-free runs both passed
+- Surefire runs 811 tests, including 18 direct `V1OntologyTermControllerTest` cases and 61
+  `V1OntologyTermControllerWIT` invocations. Two Docker-free runs both passed cleanly.
+- Failsafe runs 183 PostgreSQL tests, including 14 `V1TermRepositoryIT` cases and 23 thin
+  `V1OntologyTermControllerIT` cases — one per route. Two complete database-gate runs both passed
   cleanly.
-- Failsafe runs [TOTAL_FAILSAFE] PostgreSQL tests, including [TOTAL_REPO_IT] `V1TermRepositoryIT`
-  cases and 23 thin `V1OntologyTermControllerIT` cases — one per route. Two complete database-gate
-  runs both passed cleanly.
-- The clean `verify` lifecycle runs all [TOTAL_VERIFY] tests in Maven [VERIFY_TIME].
-- Whole-backend JaCoCo coverage is [COVERAGE_LINES]% lines and [COVERAGE_BRANCHES]% branches.
-  `V1OntologyTermController` covers all 23 routes across both milestones. `V1TermRepository` and
-  `V1JsTreeRepository` coverage combines both milestones' exercised methods; `V1GraphRepository` —
-  previously completely untested anywhere in the codebase — covers its `getGraphForClass` path. No
-  coverage failure threshold is introduced.
+- The clean `verify` lifecycle runs all 994 tests in Maven 2 minutes 20.44 seconds wall-clock.
+- Whole-backend JaCoCo coverage is 61.1% lines (2,923 of 4,787) and 46.9% branches (899 of 1,916).
+  `V1OntologyTermController` covers all 23 routes across both milestones: 162 of 171 lines and 60
+  of 66 branches. `V1TermRepository` covers 110 of 123 lines and 46 of 52 branches;
+  `V1JsTreeRepository` covers 24 of 25 lines and 10 of 11 branches. `V1GraphRepository` —
+  previously completely untested anywhere in the codebase — covers 148 of 177 lines and 17 of 36
+  branches (its `getGraphForClass` path; the remainder is dead/unreachable code outside that
+  method). No coverage failure threshold is introduced.
 - The suites preserve the `id`/`iri`/`short_form`/`obo_id` identifier cascade
   (`getIdFromMultipleOptions` tries `id` first, falling back through `iri` → `short_form` →
   `obo_id`; `getOneById` then tries the resolved value as an IRI, then a short form, then an OBO ID


### PR DESCRIPTION
## Summary

- Completes `V1OntologyTermController` testing: this covers the 13 routes deferred from milestone 1 (PR #1393, still open) — the four hierarchical-variant per-term routes (`hierarchicalParents`, `hierarchicalAncestors`, `hierarchicalChildren`, `hierarchicalDescendants`), `/graph`, the dynamic `/{iri}/{property_iri}` related-by-property route, and the seven ontology-root-level shortcut routes (`/{onto}/children`, `/{onto}/descendants`, `/{onto}/parents`, `/{onto}/ancestors`, and their three `hierarchical*` counterparts).
- **Branched directly from `dev`, not stacked on #1393** — these routes don't depend on milestone 1's fixture changes (verified: the `has_direct_parents`/`has_hierarchical_parents`/`is_preferred_root` columns and `directParent` JSON key milestone 1 added are only needed for `getRoots`/`getPreferredRootTerms`/js-tree, none of which this milestone touches), so the two branches are independent. Will need reconciling (a straightforward "both added new methods to the same file" merge, not an ambiguous one) once #1393 merges — flagging this now so it isn't a surprise.

## Two suspected defects investigated and reverted — no production code changed

Both are written up in detail in `docs/backend-testing-strategy.md` because the investigation process is the durable takeaway, not just the conclusion:

1. **Hierarchy type-leak, reconsidered for the hierarchical variant.** The direct-hierarchy leak found in milestone 1 (PR #1392, reverted — individuals legitimately appear in `children`/`descendants` per the committed `test_api.sh` baseline) doesn't recur here: `hierarchical_ancestors`/`hierarchical_parents` are populated only for genuine `subClassOf` relationships in this fixture, so `getHierarchicalChildren`/`getHierarchicalDescendants` never leak the fixture's individual. No fix attempted or needed.
2. **Shortcut-route case-sensitivity (PR #1394, reverted).** The seven shortcut routes call `getOneById(ontologyId, id, lang)` with the ontology id exactly as received (not yet lowercased), unlike every other route on this controller. A controller-mock unit test "proved" this would silently 404 for a client using an uppercase ontology id — it doesn't. `OlsSearchQuery` has an explicit `"ontology_id".equals(column)` special case that lowercases the filter input itself, so the real search-client-backed lookup already resolves correctly regardless of case, confirmed directly with a real-Postgres controller-IT test against the unmodified code. The mock's exact-string matching doesn't replicate that normalization, which is what made the unit test misleading — see #1394's closing comment for the full writeup.

## Testing layers added

- **Direct**: `V1OntologyTermControllerTest` — 7 cases covering delegated hierarchical parents/children/descendants/ancestors, their four distinct missing-resource messages, graph serialization, related-by-property delegation, the shortcut routes' empty-page no-identifier case, missing-resource reporting, and per-route delegation to the correct matching hierarchy method.
- **WIT**: `V1OntologyTermControllerWIT` — 18 invocations covering all 13 routes: pagination defaults/boundaries and explicit `sort` on every hierarchical route, the class graph's node/edge JSON shape, related-by-property with double-encoded term and property IRIs, every shortcut route's empty-contract and delegation behavior, identifier resolution by short_form/obo_id, legacy HAL media type, and stable 400/404 error fields (including the controller's own `@ExceptionHandler` swallowing the exception's message in favor of the fixed legacy reason — same stable contract as milestone 1's single-term 404).
- **Repository IT**: extended `V1TermRepositoryIT` with 3 new cases — hierarchical relationships against real Postgres columns, related-by-property (proving it ignores its own `relation` parameter — documented as observed behavior, not fixed, since no committed baseline exercises this route), and the class graph's full node/edge shape including both the `subClassOf` and generic "related to" edge cases. Also adds a new `createV1OntologyTermHierarchyRepositories` handle to `PostgresIntegrationTestSupport` and switches `V1TermRepositoryIT` onto the full class fixture (same switch milestone 1 makes independently — expect a mechanical merge conflict here at reconciliation time).
- **Controller IT**: new `V1OntologyTermControllerIT` — 13 thin happy-path cases, one per route.

Test counts by layer: 7 direct + 18 WIT + 3 repository IT + 13 controller IT = **41 new tests**.

## Local verification (Java 17, Rancher Desktop)

- Focused Postgres (`V1TermRepositoryIT,V1OntologyTermControllerIT,ClassRepositoryIT,V2ClassControllerIT,V1TermControllerIT`): 47/47 pass.
- Docker-free `mvn test`, run twice: 757/757 pass both times (baseline 732).
- PostgreSQL-only `-Pintegration-tests-only verify`, run twice: 169/169 pass both times (baseline 153).
- Clean `mvn clean verify`: 926/926 pass, Maven 1m50s (wall-clock 111.37s).
- `test_api.sh` is unchanged and was not run locally (though it's what confirmed the milestone-1 defect was real, informing the "check the baseline first" reasoning used to correctly rule out the milestone-2 hierarchical-variant leak here).

## Coverage (JaCoCo, from the clean verify run — this branch alone, not combined with milestone 1)

- Whole-backend: 58.7% lines (2,810/4,785), 45.4% branches (869/1,916). No repository-wide threshold introduced.
- `V1OntologyTermController`: 107/171 lines, 41/66 branches on this branch alone — will be higher once combined with milestone 1's coverage of the other 10 routes.
- `V1TermRepository`: 70/123 lines. `V1GraphRepository` — previously completely untested anywhere in the codebase — 148/177 lines, 24/46 branches.

Baseline recorded in docs/backend-testing-strategy.md under "Implemented V1 ontology-term-controller baseline (milestone 2 of 2)".

## Defects

None merged. Two investigated and reverted — see above and PRs #1392 (revisited, no fix needed here) and #1394 (closed).

## Graphify

`graphify update .` refreshed the local graph: 6485 nodes, 18175 edges, 398 communities. Same two pre-existing warnings as prior runs (two `Cargo.toml` files producing zero nodes; `frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme; will be reported separately once CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)