### PR TITLE
test: cover v2 health check controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerIT.java
@@ -1,0 +1,54 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+class HealthCheckControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.HealthCheckRepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createHealthCheckRepositories(POSTGRES);
+
+        HealthCheckController controller = new HealthCheckController();
+        controller.ontologyRepository = repositoryHandle.ontologyRepository();
+        controller.postgresClient = repositoryHandle.olsPostgresClient();
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void reportsAllSystemsOperationalThroughTheControllerAndPostgres() throws Exception {
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string("All systems are operational."));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerTest.java
@@ -1,0 +1,123 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HealthCheckControllerTest {
+
+    private RecordingOntologyRepository ontologyRepository;
+    private RecordingOlsPostgresClient postgresClient;
+    private HealthCheckController controller;
+
+    @BeforeEach
+    void setUp() {
+        ontologyRepository = new RecordingOntologyRepository();
+        postgresClient = new RecordingOlsPostgresClient();
+        controller = new HealthCheckController();
+        controller.ontologyRepository = ontologyRepository;
+        controller.postgresClient = postgresClient;
+    }
+
+    @Test
+    void reportsAllSystemsOperationalWhenSearchAndPostgresAreHealthy() {
+        ontologyRepository.totalElements = 4;
+        postgresClient.nodeCount = 10;
+
+        ResponseEntity<String> response = controller.checkHealth();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals("All systems are operational.", response.getBody());
+    }
+
+    @Test
+    void reportsSearchUnavailableWhenSearchReturnsNoResults() {
+        ontologyRepository.totalElements = 0;
+        postgresClient.nodeCount = 10;
+
+        ResponseEntity<String> response = controller.checkHealth();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("Search is not initialized.", response.getBody());
+    }
+
+    @Test
+    void reportsSearchUnavailableWhenSearchThrows() {
+        ontologyRepository.failure = new RuntimeException("search backend unreachable");
+        postgresClient.nodeCount = 10;
+
+        ResponseEntity<String> response = controller.checkHealth();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("Search is not initialized.", response.getBody());
+    }
+
+    @Test
+    void reportsPostgresUnavailableWhenSearchIsHealthyButNodeCountIsZero() {
+        ontologyRepository.totalElements = 4;
+        postgresClient.nodeCount = 0;
+
+        ResponseEntity<String> response = controller.checkHealth();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("Postgres is not initialized.", response.getBody());
+    }
+
+    @Test
+    void reportsPostgresUnavailableWhenSearchIsHealthyButPostgresThrows() {
+        ontologyRepository.totalElements = 4;
+        postgresClient.failure = new RuntimeException("postgres unreachable");
+
+        ResponseEntity<String> response = controller.checkHealth();
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("Postgres is not initialized.", response.getBody());
+    }
+
+    private static class RecordingOntologyRepository extends OntologyRepository {
+        private long totalElements;
+        private RuntimeException failure;
+
+        @Override
+        public OlsFacetedResultsPage<JsonElement> find(
+                Pageable pageable,
+                String lang,
+                String search,
+                String searchFields,
+                String boostFields,
+                boolean exactMatch,
+                Map<String, Collection<String>> properties,
+                JsonTransformOptions outputOpts) {
+            if (failure != null) {
+                throw failure;
+            }
+            return new OlsFacetedResultsPage<>(List.of(), Map.of(), pageable, totalElements);
+        }
+    }
+
+    private static class RecordingOlsPostgresClient extends OlsPostgresClient {
+        private long nodeCount;
+        private RuntimeException failure;
+
+        @Override
+        public long getDatabaseNodeCount() {
+            if (failure != null) {
+                throw failure;
+            }
+            return nodeCount;
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/HealthCheckControllerWIT.java
@@ -1,0 +1,120 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import com.google.gson.JsonElement;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.OntologyRepository;
+import uk.ac.ebi.spot.ols.repository.postgres.OlsPostgresClient;
+import uk.ac.ebi.spot.ols.repository.search.OlsFacetedResultsPage;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(HealthCheckController.class)
+@ContextConfiguration(classes = {
+        HealthCheckController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class HealthCheckControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private OntologyRepository ontologyRepository;
+
+    @MockitoBean
+    private OlsPostgresClient postgresClient;
+
+    @Test
+    void returnsAllSystemsOperationalWhenBothChecksPass() throws Exception {
+        stubSearch(4);
+        when(postgresClient.getDatabaseNodeCount()).thenReturn(10L);
+
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_PLAIN))
+                .andExpect(content().string("All systems are operational."));
+    }
+
+    @Test
+    void returns503WhenSearchHasNoResults() throws Exception {
+        stubSearch(0);
+        when(postgresClient.getDatabaseNodeCount()).thenReturn(10L);
+
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string("Search is not initialized."));
+    }
+
+    @Test
+    void returns503WhenSearchThrows() throws Exception {
+        when(ontologyRepository.find(
+                any(Pageable.class), any(), any(), any(), any(), anyBoolean(), any(), any()))
+                .thenThrow(new RuntimeException("search backend unreachable"));
+        when(postgresClient.getDatabaseNodeCount()).thenReturn(10L);
+
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string("Search is not initialized."));
+    }
+
+    @Test
+    void returns503WhenSearchIsHealthyButPostgresNodeCountIsZero() throws Exception {
+        stubSearch(4);
+        when(postgresClient.getDatabaseNodeCount()).thenReturn(0L);
+
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string("Postgres is not initialized."));
+    }
+
+    @Test
+    void returns503WhenSearchIsHealthyButPostgresThrows() throws Exception {
+        stubSearch(4);
+        when(postgresClient.getDatabaseNodeCount())
+                .thenThrow(new RuntimeException("postgres unreachable"));
+
+        mockMvc.perform(get("/api/v2/health"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().string("Postgres is not initialized."));
+    }
+
+    @Test
+    void respondsToNonGetHttpMethodsBecauseTheMappingIsMethodAgnostic() throws Exception {
+        // The route is declared with a bare @RequestMapping("/health") and no explicit
+        // method element, so Spring MVC matches every HTTP method rather than only GET.
+        // This is a real, observed contract detail (unlike the sibling V2 controllers,
+        // which use @GetMapping and reject other verbs with 405), not an assumption.
+        stubSearch(4);
+        when(postgresClient.getDatabaseNodeCount()).thenReturn(10L);
+
+        mockMvc.perform(post("/api/v2/health"))
+                .andExpect(status().isOk())
+                .andExpect(content().string("All systems are operational."));
+    }
+
+    private void stubSearch(long totalElements) throws Exception {
+        when(ontologyRepository.find(
+                any(Pageable.class), any(), any(), any(), any(), anyBoolean(), any(), any()))
+                .thenReturn(new OlsFacetedResultsPage<JsonElement>(
+                        List.of(), Map.of(), Pageable.ofSize(20), totalElements));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -107,6 +107,19 @@ public final class PostgresIntegrationTestSupport {
         return new RepositoryHandle(repository, postgresClient);
     }
 
+    public static HealthCheckRepositoryHandle createHealthCheckRepositories(PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        OlsPostgresClient olsPostgresClient = new OlsPostgresClient();
+        ReflectionTestUtils.setField(olsPostgresClient, "postgresClient", postgresClient);
+
+        OntologyRepository repository = new OntologyRepository();
+        ReflectionTestUtils.setField(repository, "searchClient", searchClient);
+        ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
+        return new HealthCheckRepositoryHandle(repository, olsPostgresClient, postgresClient);
+    }
+
     public static V1RepositoryHandle createV1Repository(PostgreSQLContainer<?> container) {
         PostgresClient postgresClient = createPostgresClient(container);
         OlsSearchClient searchClient = createSearchClient(postgresClient);
@@ -668,6 +681,17 @@ public final class PostgresIntegrationTestSupport {
 
     public record V1RepositoryHandle(
             V1OntologyRepository repository,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record HealthCheckRepositoryHandle(
+            OntologyRepository ontologyRepository,
+            OlsPostgresClient olsPostgresClient,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -643,6 +643,50 @@ Verified locally on 2026-09-04 with Java 17 and Rancher Desktop:
 
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
+## Implemented V2 health-check-controller baseline
+
+`HealthCheckController` has a single route, `GET /api/v2/health`, that autowires
+`OntologyRepository` and `OlsPostgresClient` directly (no service layer). It reports whether the
+search index and Postgres are initialized by running a small live query against each and catching
+any exception as an unhealthy result.
+
+Verified locally on 2026-09-07 with Java 17 and Rancher Desktop:
+
+- Surefire runs 798 tests, including 5 direct `HealthCheckControllerTest` cases and 6
+  `HealthCheckControllerWIT` invocations. Two Docker-free runs took wall-clock 17.07 and 14.83
+  seconds.
+- Failsafe runs 168 PostgreSQL tests, including 1 thin `HealthCheckControllerIT` case. No new
+  repository-IT class was added: the controller has no repository logic of its own beyond the
+  already-covered `OntologyRepository`/`OlsPostgresClient` wiring, so the one controller-IT case
+  is the only PostgreSQL-backed coverage this controller needs. Two complete database-gate runs
+  took wall-clock 116.50 and 117.14 seconds.
+- The clean `verify` lifecycle runs all 966 tests in wall-clock 2 minutes 0.98 seconds.
+- Whole-backend JaCoCo coverage is 56.4% lines (2,702 of 4,787) and 44.6% branches (854 of 1,916).
+  `HealthCheckController` covers all 28 of its executable lines and all 8 branches. No coverage
+  failure threshold is introduced.
+- The unit and WIT suites exercise both private branches (`checkSearch`/`checkPostgres`) through
+  their public effect: a healthy search and a positive Postgres node count return 200 "All systems
+  are operational."; a search with zero results returns 503 "Search is not initialized."; a
+  healthy search with a zero Postgres node count returns 503 "Postgres is not initialized."; and
+  either collaborator throwing behaves identically to it returning its unhealthy value, since the
+  controller catches and logs the exception in both `checkSearch` and `checkPostgres`. The WIT
+  suite also records that the route is declared with a bare `@RequestMapping("/health")` with no
+  method element, so — unlike sibling `@GetMapping` V2 controllers, which reject other verbs with
+  405 — every HTTP method reaches the same handler; this is an observed contract detail, not a
+  defect, and a dedicated WIT case proves a POST request is served identically to a GET.
+- The bare `ResponseEntity<String>` body serializes as `text/plain`, but the exact charset differs
+  between the `@WebMvcTest`-sliced context (Spring Boot autoconfiguration defaults to UTF-8) and
+  the `standaloneSetup` MockMvc harness the controller IT uses (plain Spring MVC defaults to
+  ISO-8859-1 without that autoconfiguration). Both suites assert
+  `contentTypeCompatibleWith(MediaType.TEXT_PLAIN)` rather than an exact charset so the tests do
+  not couple to that harness difference.
+- `PostgresIntegrationTestSupport` gained a new `createHealthCheckRepositories(...)` factory
+  returning both a real `OntologyRepository` and the `OlsPostgresClient` it shares, wired against
+  disposable Postgres. No existing factory exposed both collaborators together: `createRepository`
+  wires an internal `OlsPostgresClient` into `OntologyRepository` but does not return it, and
+  `HealthCheckController` needs both as independent autowired fields. No production defect was
+  discovered by this rollout.
+
 ## Out of scope for the pilot
 
 - Connecting GitHub-hosted CI to production or internal databases.


### PR DESCRIPTION
## Summary

- Continues the layered backend testing programme (docs/backend-testing-strategy.md) to `HealthCheckController` — the next best increment per the handoff, listed alongside `V2DefinedFieldsController` in PR #1393 as "too trivial to matter" at the time but now the first of two remaining untested controllers besides the external-dependency `V2TextTaggerController`/`V2LLMController` (out of scope, need a separate scoping conversation).
- `HealthCheckController` has a single route, `GET /api/v2/health`. It autowires `OntologyRepository` and `OlsPostgresClient` directly (no service layer) and reports whether the search index and Postgres are initialized by running a small live query against each, catching any exception as an unhealthy result.

## Testing layers added

- **Direct**: `HealthCheckControllerTest` — 5 cases covering both private branches (`checkSearch`/`checkPostgres`) via their public effect: healthy/healthy → 200; search returns zero results → 503 "Search is not initialized."; search throws → same 503; search healthy + Postgres node count zero → 503 "Postgres is not initialized."; Postgres throws → same 503. Uses hand-rolled fake subclasses of `OntologyRepository`/`OlsPostgresClient` (no Mockito), matching the `RecordingOntologyRepository`/`RecordingEntityRepository` idiom used elsewhere in this programme.
- **WIT**: `HealthCheckControllerWIT` — 6 invocations covering the same branches through real Spring MVC binding with `@MockitoBean` collaborators, plus one case documenting that the route's bare `@RequestMapping("/health")` (no method element) matches every HTTP method rather than only GET — unlike sibling `@GetMapping` V2 controllers, which reject other verbs with 405. This is real, observed framework behavior, not an assumption.
- **Controller IT**: new `HealthCheckControllerIT` — 1 thin happy-path case proving the real controller → repository → disposable PostgreSQL → HTTP path. No new repository-IT class: the controller has no repository logic of its own beyond the already-covered `OntologyRepository`/`OlsPostgresClient` wiring.

Test counts by layer: 5 direct + 6 WIT + 1 controller IT = **12 new tests**.

## A test-harness content-type wrinkle, not a production defect

The controller returns a bare `ResponseEntity<String>`, which serializes as `text/plain`, but the exact charset differs between the `@WebMvcTest`-sliced context (Spring Boot autoconfiguration defaults to UTF-8) and the `standaloneSetup` MockMvc harness the controller IT uses (plain Spring MVC without that autoconfiguration defaults to ISO-8859-1). Both suites assert `contentTypeCompatibleWith(MediaType.TEXT_PLAIN)` instead of an exact charset so the tests don't couple to that harness difference.

## Test-support change (test-only, no production code changed)

`PostgresIntegrationTestSupport` gained a new `createHealthCheckRepositories(...)` factory returning both a real `OntologyRepository` and the `OlsPostgresClient` it shares, wired against disposable Postgres. No existing factory exposed both collaborators together — `createRepository` wires an internal `OlsPostgresClient` into `OntologyRepository` but never returns it, and `HealthCheckController` needs both as independent autowired fields.

## Local verification (Java 17, Rancher Desktop)

All commands run with `JAVA_HOME` pointed at the Java 17 install and, for Postgres-backed runs, `DOCKER_HOST=unix:///Users/haideri/.rd/docker.sock` / `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock` / `-Dapi.version=1.44` per docs/backend-testing-strategy.md. Pass/fail counts read from the actual `target/surefire-reports`/`target/failsafe-reports` `.txt` files, not just exit codes.

- Docker-free `mvn test`, run twice: 798/798 pass both times (baseline 786 + 12 new), wall-clock 17.07s and 14.83s.
- PostgreSQL-only `verify -Dsurefire.skip=true -Dapi.version=1.44`, run twice: 168/168 pass both times (baseline 167 + 1 new), wall-clock 116.50s and 117.14s.
- Clean `mvn clean verify -Dapi.version=1.44`: 966/966 pass, wall-clock 2m0.98s.

## Coverage (JaCoCo, from the clean verify run)

- Whole-backend: 56.4% lines (2,702/4,787), 44.6% branches (854/1,916). No repository-wide threshold introduced.
- `HealthCheckController`: 28/28 lines, 8/8 branches.

Baseline recorded in `docs/backend-testing-strategy.md` under "Implemented V2 health-check-controller baseline".

## Defects

None found. Both dependency checks and the "any HTTP method" behavior were verified as real, not defects — no separate bug-fix PR needed.

## Graphify

`graphify update .` refreshed the local graph: 6526 nodes, 18346 edges, 301 communities. Same two pre-existing warnings as prior runs (two `Cargo.toml` files producing zero nodes; `frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme).
- `test_api.sh` full system regression (CI-only; unaffected — no production code changed).

## Out of scope, per the handoff

- `V2TextTaggerController` and `V2LLMController` — external-dependency controllers, need a separate scoping conversation before anyone writes tests for them.
- PR #1395 (`V1OntologyTermController` milestone 2) is unrelated in-flight work and was not touched or merged.

This PR is **not to be merged** without explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
