### PR TITLE
test: cover v2 defined fields controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2DefinedFieldsControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2DefinedFieldsControllerTest.java
@@ -1,0 +1,36 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.ols.shared.DefinedFields;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class V2DefinedFieldsControllerTest {
+
+    private final V2DefinedFieldsController controller = new V2DefinedFieldsController();
+
+    @Test
+    void returnsOneEntryPerDefinedFieldsEnumMember() {
+        List<V2DefinedFieldsController.DefinedFieldDto> result = controller.getDefinedFields();
+
+        assertEquals(DefinedFields.values().length, result.size());
+    }
+
+    @Test
+    void mapsEveryEntryFromItsCorrespondingEnumMemberInDeclarationOrder() {
+        List<V2DefinedFieldsController.DefinedFieldDto> result = controller.getDefinedFields();
+
+        DefinedFields[] fields = DefinedFields.values();
+        for (int i = 0; i < fields.length; i++) {
+            DefinedFields field = fields[i];
+            V2DefinedFieldsController.DefinedFieldDto dto = result.get(i);
+
+            assertEquals(field.getText(), dto.getOls4FieldName(), "ols4FieldName for " + field);
+            assertEquals(field.getOls3Text(), dto.getOls3FieldName(), "ols3FieldName for " + field);
+            assertEquals(field.getDescription(), dto.getDescription(), "description for " + field);
+            assertEquals(field.getType(), dto.getDataType(), "dataType for " + field);
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2DefinedFieldsControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2DefinedFieldsControllerWIT.java
@@ -1,0 +1,69 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.ols.shared.DefinedFields;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V2DefinedFieldsController.class)
+@ContextConfiguration(classes = {
+        V2DefinedFieldsController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V2DefinedFieldsControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Test
+    void returnsOneJsonEntryPerDefinedFieldsEnumMember() throws Exception {
+        mockMvc.perform(get("/api/v2/defined-fields"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(DefinedFields.values().length));
+    }
+
+    @Test
+    void serializesTheDeclaredFieldNamesForTheFirstEntry() throws Exception {
+        DefinedFields first = DefinedFields.values()[0];
+
+        mockMvc.perform(get("/api/v2/defined-fields"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].ols4FieldName").value(first.getText()))
+                .andExpect(jsonPath("$[0].ols3FieldName").value(first.getOls3Text()))
+                .andExpect(jsonPath("$[0].description").value(first.getDescription()))
+                .andExpect(jsonPath("$[0].dataType").value(first.getType()));
+    }
+
+    @Test
+    void serializesAFullEntryWithANonEmptyOls3FieldName() throws Exception {
+        int index = DefinedFields.IS_OBSOLETE.ordinal();
+
+        mockMvc.perform(get("/api/v2/defined-fields"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[" + index + "].ols4FieldName").value(DefinedFields.IS_OBSOLETE.getText()))
+                .andExpect(jsonPath("$[" + index + "].ols3FieldName").value(DefinedFields.IS_OBSOLETE.getOls3Text()))
+                .andExpect(jsonPath("$[" + index + "].description").value(DefinedFields.IS_OBSOLETE.getDescription()))
+                .andExpect(jsonPath("$[" + index + "].dataType").value(DefinedFields.IS_OBSOLETE.getType()));
+    }
+
+    @Test
+    void returnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/v2/defined-fields"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405));
+    }
+}

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -643,6 +643,41 @@ Verified locally on 2026-09-04 with Java 17 and Rancher Desktop:
 
 Read-only production smoke monitoring is a separate future initiative for an internal or self-hosted environment. It is not part of the initial PR testing framework and must not become a merge-blocking production dependency.
 
+## Implemented V2 defined-fields-controller baseline
+
+`V2DefinedFieldsController` has a single route, `GET /api/v2/defined-fields`, with no autowired
+dependencies at all: it maps the static `uk.ac.ebi.ols.shared.DefinedFields` enum into a list of
+DTOs (`ols4FieldName`/`ols3FieldName`/`description`/`dataType`, read from `getText()`/
+`getOls3Text()`/`getDescription()`/`getType()`).
+
+Verified locally on 2026-09-07 with Java 17 and Rancher Desktop:
+
+- Surefire runs 793 tests, including 2 direct `V2DefinedFieldsControllerTest` cases and 4
+  `V2DefinedFieldsControllerWIT` invocations. Two Docker-free runs took wall-clock 18.98 and 15.10
+  seconds.
+- Failsafe runs the same 167 PostgreSQL tests as `dev`; no repository-IT or controller-IT class
+  was added. There is no repository, no Postgres dependency, and no database-backed behaviour a
+  real-database layer would additionally prove beyond what the WIT already proves by exercising
+  the real Spring MVC JSON serialization path — this controller has no applicable repository
+  behaviour, so the "applicable repository behaviour has PostgreSQL IT coverage" clause of the
+  controller definition of done is satisfied vacuously and the omission is deliberate, not an
+  oversight. Two complete database-gate runs both passed cleanly, wall-clock 119.86 and 109.52
+  seconds.
+- The clean `verify` lifecycle runs all 960 tests in wall-clock 2 minutes 6.86 seconds.
+- Whole-backend JaCoCo coverage is 56.1% lines (2,685 of 4,787) and 44.1% branches (845 of 1,916).
+  `V2DefinedFieldsController` covers all 8 of its executable lines (0 branches — the method has no
+  conditional logic) and its package-private `DefinedFieldDto` covers all 10 of its lines. No
+  coverage failure threshold is introduced.
+- The unit test loops over `DefinedFields.values()` (34 members as of this rollout, read from the
+  enum itself rather than hardcoded) and asserts each DTO's four fields against the corresponding
+  enum member's accessors in declaration order, rather than hand-writing one assertion per
+  constant. The WIT exercises the same contract through real Spring MVC JSON serialization: the
+  declared field names, the total array length against `DefinedFields.values().length`, the first
+  entry's full values, one full entry at an index derived from `DefinedFields.IS_OBSOLETE.ordinal()`
+  (an enum member with a non-empty `ols3Text`, rather than a guessed position) to prove the
+  non-empty-string case too, and the standard 405 method-not-allowed contract for a non-GET
+  request. No production defect was discovered by this rollout.
+
 ## Out of scope for the pilot
 
 - Connecting GitHub-hosted CI to production or internal databases.


### PR DESCRIPTION
## Summary

- Continues the layered backend testing programme (docs/backend-testing-strategy.md) to `V2DefinedFieldsController` — the second and final controller in this handoff, branched independently off `dev` per this repo's convention (one controller per PR, never stacked on another unmerged branch). Not stacked on `test-v2-healthcheck-controller` (PR #1396, still open/unmerged) — this branch is rooted directly at `dev`.
- `V2DefinedFieldsController` has a single route, `GET /api/v2/defined-fields`, with **no autowired dependencies at all**: it maps the static `uk.ac.ebi.ols.shared.DefinedFields` enum (34 members as of this rollout) into a list of DTOs (`ols4FieldName`/`ols3FieldName`/`description`/`dataType`, read from `getText()`/`getOls3Text()`/`getDescription()`/`getType()`).

## Testing layers added

- **Direct**: `V2DefinedFieldsControllerTest` — 2 cases. One asserts the returned list size equals `DefinedFields.values().length` (not a hardcoded count). The other loops over every enum member in declaration order and asserts all four DTO fields against the corresponding accessor, rather than hand-writing one assertion per constant.
- **WIT**: `V2DefinedFieldsControllerWIT` — 4 invocations covering the real Spring MVC route and JSON serialization: total array length against `DefinedFields.values().length`, the declared JSON field names and values for the first entry, one full entry at an index derived from `DefinedFields.IS_OBSOLETE.ordinal()` (a member with a non-empty `ols3Text`, to also prove that non-empty case — not a guessed array position), and the standard 405 method-not-allowed contract for a non-GET request.

Test counts by layer: 2 direct + 4 WIT = **6 new tests**.

## No repository-IT or controller-IT (deliberate, documented)

Per the handoff and `docs/backend-testing-strategy.md`'s controller definition of done: this controller has no repository and no Postgres dependency, so there is no database-backed behaviour a real-database layer would additionally prove beyond what the WIT already proves by exercising the real Spring MVC JSON serialization path. The "applicable repository behaviour has PostgreSQL IT coverage" clause is satisfied vacuously — noted explicitly in the doc update so the omission reads as deliberate, not an oversight.

## Local verification (Java 17, Rancher Desktop)

All commands run with `JAVA_HOME` pointed at the Java 17 install and, for Postgres-backed runs, `DOCKER_HOST=unix:///Users/haideri/.rd/docker.sock` / `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock` / `-Dapi.version=1.44` per docs/backend-testing-strategy.md. Pass/fail counts read from the actual `target/surefire-reports`/`target/failsafe-reports` `.txt` files after a clean build, not just exit codes (an initial run without `mvn clean` on this fresh branch picked up stale compiled test classes left over from a prior unrelated branch's `target/` directory — re-ran clean to get accurate counts).

- Docker-free `mvn test`, run twice: 793/793 pass both times (dev baseline 787 + 6 new), wall-clock 18.98s and 15.10s.
- PostgreSQL-only `verify -Dsurefire.skip=true -Dapi.version=1.44`, run twice: 167/167 pass both times (unchanged from `dev` — no new Postgres tests, as expected), wall-clock 119.86s and 109.52s.
- Clean `mvn clean verify -Dapi.version=1.44`: 960/960 pass, wall-clock 2m6.86s.

## Coverage (JaCoCo, from the clean verify run)

- Whole-backend: 56.1% lines (2,685/4,787), 44.1% branches (845/1,916). No repository-wide threshold introduced.
- `V2DefinedFieldsController`: 8/8 lines, 0/0 branches (the method has no conditional logic).
- `V2DefinedFieldsController.DefinedFieldDto`: 10/10 lines.

Baseline recorded in `docs/backend-testing-strategy.md` under "Implemented V2 defined-fields-controller baseline".

## Defects

None found. No production code changed.

## Graphify

`graphify update .` refreshed the local graph: 6506 nodes, 18253 edges, 295 communities. Same pre-existing warning as prior runs (`frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme).
- `test_api.sh` full system regression (CI-only; unaffected — no production code changed).

## Out of scope, per the handoff

- `V2TextTaggerController` and `V2LLMController` — external-dependency controllers, need a separate scoping conversation before anyone writes tests for them.
- PR #1395 (`V1OntologyTermController` milestone 2) is unrelated in-flight work and was not touched or merged.
- PR #1396 (`HealthCheckController`, the first controller in this handoff) is a sibling PR, independently branched off `dev`, not stacked with this one.

This PR is **not to be merged** without explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
