### PR TITLE
test: cover v2 text tagger controller

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerIT.java
@@ -1,0 +1,97 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Thin controller-IT coverage for {@link V2TextTaggerController} against a real, unconfigured
+ * {@code TextTaggerService} bean and a real disposable Postgres.
+ *
+ * <p>See the "Implemented V2 text-tagger-controller baseline" section of
+ * {@code docs/backend-testing-strategy.md} for the scoping decision this suite follows: the
+ * {@code ols_text_tagger} table exists in the production schema but no fixture here inserts a row
+ * into it, so {@code TextTaggerService.downloadTextTaggerDb()} genuinely returns {@code null} and
+ * {@code isAvailable()} genuinely settles to {@code false} &ndash; this is real behaviour of the
+ * real bean against a real (empty-of-this-one-table) database, not a mock standing in for it.</p>
+ *
+ * <p>Timing note: {@code available} is a field that defaults to {@code false} at construction and
+ * is only ever set {@code true} inside {@code startProcess()}, which {@code downloadTextTaggerDb()}
+ * never reaches when the table has no row. So {@code isAvailable()} is already correct the instant
+ * the bean is constructed, before {@link uk.ac.ebi.spot.ols.service.TextTaggerService#init()}'s
+ * background thread even runs, let alone finishes &ndash; there is no async race for these
+ * assertions to be sensitive to. {@code init()} is still invoked below so this suite exercises the
+ * bean's real lifecycle, not just its field defaults.</p>
+ */
+@Testcontainers
+class V2TextTaggerControllerIT {
+
+    @Container
+    private static final PostgreSQLContainer<?> POSTGRES =
+            PostgresIntegrationTestSupport.newContainer();
+
+    private static PostgresIntegrationTestSupport.TextTaggerRepositoryHandle repositoryHandle;
+    private static MockMvc mockMvc;
+
+    @BeforeAll
+    static void setUpApplicationPath() {
+        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        repositoryHandle = PostgresIntegrationTestSupport.createTextTaggerRepositories(POSTGRES);
+        repositoryHandle.textTaggerService().init();
+
+        V2TextTaggerController controller = new V2TextTaggerController();
+        controller.textTaggerService = repositoryHandle.textTaggerService();
+        controller.searchClient = repositoryHandle.searchClient();
+        mockMvc = org.springframework.test.web.servlet.setup.MockMvcBuilders
+                .standaloneSetup(controller)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @AfterAll
+    static void closeDatabaseClient() {
+        repositoryHandle.close();
+    }
+
+    @Test
+    void tagTextReturns503ThroughTheRealUnconfiguredService() throws Exception {
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("Text tagger service is not available"))
+                .andExpect(jsonPath("$.message").value(
+                        "The text tagger database has not been configured or the binary is not on the PATH"));
+    }
+
+    @Test
+    void tagTextStatusReportsUnavailableThroughTheRealService() throws Exception {
+        mockMvc.perform(get("/api/v2/tag_text"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.available").value(false));
+    }
+
+    @Test
+    void curationSourcesReturnsTheRealSearchClientResultThroughPostgres() throws Exception {
+        mockMvc.perform(get("/api/v2/curation_sources"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$").isArray())
+                .andExpect(jsonPath("$.length()").value(0));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerTest.java
@@ -1,0 +1,311 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.service.TextTaggerService;
+import uk.ac.ebi.spot.ols.service.TextTaggerService.TaggedEntity;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class V2TextTaggerControllerTest {
+
+    private RecordingTextTaggerService textTaggerService;
+    private RecordingOlsSearchClient searchClient;
+    private V2TextTaggerController controller;
+
+    @BeforeEach
+    void setUp() {
+        textTaggerService = new RecordingTextTaggerService();
+        searchClient = new RecordingOlsSearchClient();
+        controller = new V2TextTaggerController();
+        controller.textTaggerService = textTaggerService;
+        controller.searchClient = searchClient;
+    }
+
+    // ------------------------------------------------------------------
+    // POST /tag_text
+    // ------------------------------------------------------------------
+
+    @Test
+    void tagTextReturns503AndDoesNotCallTheServiceWhenUnavailable() {
+        textTaggerService.available = false;
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", "insulin resistance"),
+                null, null, null, 3, true, false);
+
+        assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());
+        assertEquals("Text tagger service is not available", response.getBody().get("error"));
+        assertEquals("The text tagger database has not been configured or the binary is not on the PATH",
+                response.getBody().get("message"));
+        assertNull(textTaggerService.lastText, "an unavailable service must never be asked to tag text");
+    }
+
+    @Test
+    void tagTextReturns400WhenTextFieldIsAbsent() {
+        textTaggerService.available = true;
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of(), null, null, null, 3, true, false);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Missing required field: text", response.getBody().get("error"));
+        assertNull(textTaggerService.lastText);
+    }
+
+    @Test
+    void tagTextReturns400WhenTextFieldIsNull() {
+        textTaggerService.available = true;
+
+        Map<String, Object> requestBody = new LinkedHashMap<>();
+        requestBody.put("text", null);
+
+        ResponseEntity<Map<String, Object>> response = post(requestBody, null, null, null, 3, true, false);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Missing required field: text", response.getBody().get("error"));
+    }
+
+    @Test
+    void tagTextReturns400WhenTextFieldIsEmpty() {
+        textTaggerService.available = true;
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", ""), null, null, null, 3, true, false);
+
+        assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
+        assertEquals("Missing required field: text", response.getBody().get("error"));
+    }
+
+    @Test
+    void tagTextForwardsEveryParameterToTheService() {
+        textTaggerService.available = true;
+        List<String> ontologyIds = List.of("efo", "hp");
+        List<String> sources = List.of("sssom-mappings");
+
+        post(Map.of("text", "insulin resistance"), ontologyIds, sources, "|", 5, false, false);
+
+        assertEquals("insulin resistance", textTaggerService.lastText);
+        assertEquals(ontologyIds, textTaggerService.lastOntologyIds);
+        assertEquals(sources, textTaggerService.lastSources);
+        assertEquals("|", textTaggerService.lastDelimiters);
+        assertEquals(5, textTaggerService.lastMinLength);
+        assertFalse(textTaggerService.lastIncludeSubstrings);
+    }
+
+    @Test
+    void tagTextMapsAllFieldsAndOmitsOptionalFieldsWhenAbsent() {
+        textTaggerService.available = true;
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                0, 7, "insulin", "http://purl.obolibrary.org/obo/CHEBI_5931", "chebi",
+                "exact", "sssom-mappings", List.of("chemical", "hormone"), true));
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                8, 18, "resistance", "http://example.org/HP_0000001", "hp",
+                null, null, null, false));
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", "insulin resistance"),
+                null, null, null, 3, true, true);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        Map<String, Object> body = response.getBody();
+        assertEquals("insulin resistance", body.get("text"));
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> entities = (List<Map<String, Object>>) body.get("entities");
+        assertEquals(2, entities.size());
+
+        Map<String, Object> withOptionalFields = entities.get(0);
+        assertEquals(0, withOptionalFields.get("start"));
+        assertEquals(7, withOptionalFields.get("end"));
+        assertEquals("insulin", withOptionalFields.get("term_label"));
+        assertEquals("http://purl.obolibrary.org/obo/CHEBI_5931", withOptionalFields.get("term_iri"));
+        assertEquals("chebi", withOptionalFields.get("ontology_id"));
+        assertEquals("exact", withOptionalFields.get("string_type"));
+        assertEquals("sssom-mappings", withOptionalFields.get("source"));
+        assertEquals(List.of("chemical", "hormone"), withOptionalFields.get("subject_categories"));
+        assertEquals(Boolean.TRUE, withOptionalFields.get("is_obsolete"));
+
+        Map<String, Object> withoutOptionalFields = entities.get(1);
+        assertEquals(8, withoutOptionalFields.get("start"));
+        assertEquals(18, withoutOptionalFields.get("end"));
+        assertEquals("resistance", withoutOptionalFields.get("term_label"));
+        assertEquals("hp", withoutOptionalFields.get("ontology_id"));
+        assertFalse(withoutOptionalFields.containsKey("string_type"),
+                "a null string_type must not appear in the response");
+        assertFalse(withoutOptionalFields.containsKey("source"),
+                "a null source must not appear in the response");
+        assertFalse(withoutOptionalFields.containsKey("subject_categories"),
+                "a null subject_categories must not appear in the response");
+        assertFalse(withoutOptionalFields.containsKey("is_obsolete"),
+                "is_obsolete must be omitted, not set to false, when the entity is not obsolete");
+    }
+
+    @Test
+    void tagTextExcludesObsoleteEntitiesByDefault() {
+        textTaggerService.available = true;
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                0, 7, "insulin", "http://purl.obolibrary.org/obo/CHEBI_5931", "chebi",
+                null, null, null, true));
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                8, 18, "resistance", "http://example.org/HP_0000001", "hp",
+                null, null, null, false));
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", "insulin resistance"),
+                null, null, null, 3, true, false);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> entities = (List<Map<String, Object>>) response.getBody().get("entities");
+        assertEquals(1, entities.size());
+        assertEquals("resistance", entities.get(0).get("term_label"));
+    }
+
+    @Test
+    void tagTextIncludesObsoleteEntitiesWhenRequested() {
+        textTaggerService.available = true;
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                0, 7, "insulin", "http://purl.obolibrary.org/obo/CHEBI_5931", "chebi",
+                null, null, null, true));
+        textTaggerService.entitiesToReturn.add(new TaggedEntity(
+                8, 18, "resistance", "http://example.org/HP_0000001", "hp",
+                null, null, null, false));
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", "insulin resistance"),
+                null, null, null, 3, true, true);
+
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> entities = (List<Map<String, Object>>) response.getBody().get("entities");
+        assertEquals(2, entities.size());
+    }
+
+    @Test
+    void tagTextReturnsEmptyEntitiesListWhenTheServiceFindsNoMatches() {
+        textTaggerService.available = true;
+
+        ResponseEntity<Map<String, Object>> response = post(Map.of("text", "no matches here"),
+                null, null, null, 3, true, false);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(((List<?>) response.getBody().get("entities")).isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // GET /tag_text
+    // ------------------------------------------------------------------
+
+    @Test
+    void tagTextStatusReportsAvailableTrue() {
+        textTaggerService.available = true;
+
+        @SuppressWarnings("unchecked")
+        ResponseEntity<Map<String, Object>> response =
+                (ResponseEntity<Map<String, Object>>) controller.tagTextStatus();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.TRUE, response.getBody().get("available"));
+    }
+
+    @Test
+    void tagTextStatusReportsAvailableFalse() {
+        textTaggerService.available = false;
+
+        @SuppressWarnings("unchecked")
+        ResponseEntity<Map<String, Object>> response =
+                (ResponseEntity<Map<String, Object>>) controller.tagTextStatus();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(Boolean.FALSE, response.getBody().get("available"));
+    }
+
+    // ------------------------------------------------------------------
+    // GET /curation_sources
+    // ------------------------------------------------------------------
+
+    @Test
+    void getCurationSourcesReturnsTheSearchClientsDistinctSources() {
+        searchClient.curatedSources = List.of("sssom-mappings", "manual-curation");
+
+        @SuppressWarnings("unchecked")
+        ResponseEntity<List<String>> response = (ResponseEntity<List<String>>) controller.getCurationSources();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(List.of("sssom-mappings", "manual-curation"), response.getBody());
+    }
+
+    @Test
+    void getCurationSourcesReturnsAnEmptyListWhenNoneAreCurated() {
+        searchClient.curatedSources = List.of();
+
+        @SuppressWarnings("unchecked")
+        ResponseEntity<List<String>> response = (ResponseEntity<List<String>>) controller.getCurationSources();
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertTrue(response.getBody().isEmpty());
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    @SuppressWarnings("unchecked")
+    private ResponseEntity<Map<String, Object>> post(
+            Map<String, Object> requestBody,
+            List<String> ontologyIds,
+            List<String> sources,
+            String delimiters,
+            int minLength,
+            boolean includeSubstrings,
+            boolean includeObsoleteEntities) {
+        return (ResponseEntity<Map<String, Object>>) controller.tagText(
+                requestBody, ontologyIds, sources, delimiters, minLength, includeSubstrings, includeObsoleteEntities);
+    }
+
+    // ------------------------------------------------------------------
+    // Hand-rolled fakes (this repo's unit-test idiom; see HealthCheckControllerTest)
+    // ------------------------------------------------------------------
+
+    private static class RecordingTextTaggerService extends TextTaggerService {
+        private boolean available;
+        private final List<TaggedEntity> entitiesToReturn = new ArrayList<>();
+
+        private String lastText;
+        private List<String> lastOntologyIds;
+        private List<String> lastSources;
+        private String lastDelimiters;
+        private int lastMinLength;
+        private boolean lastIncludeSubstrings;
+
+        @Override
+        public boolean isAvailable() {
+            return available;
+        }
+
+        @Override
+        public List<TaggedEntity> tagText(String text, List<String> priorityOntologyIds, List<String> sources,
+                                           String delimiters, int minLength, boolean includeSubstrings) {
+            this.lastText = text;
+            this.lastOntologyIds = priorityOntologyIds;
+            this.lastSources = sources;
+            this.lastDelimiters = delimiters;
+            this.lastMinLength = minLength;
+            this.lastIncludeSubstrings = includeSubstrings;
+            return new ArrayList<>(entitiesToReturn);
+        }
+    }
+
+    private static class RecordingOlsSearchClient extends OlsSearchClient {
+        private List<String> curatedSources = new ArrayList<>();
+
+        @Override
+        public List<String> getDistinctCuratedSources() {
+            return curatedSources;
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2TextTaggerControllerWIT.java
@@ -1,0 +1,302 @@
+package uk.ac.ebi.spot.ols.controller.api.v2;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.ac.ebi.spot.ols.config.WebConfig;
+import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
+import uk.ac.ebi.spot.ols.repository.search.OlsSearchClient;
+import uk.ac.ebi.spot.ols.service.TextTaggerService;
+import uk.ac.ebi.spot.ols.service.TextTaggerService.TaggedEntity;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(V2TextTaggerController.class)
+@ContextConfiguration(classes = {
+        V2TextTaggerController.class,
+        GlobalExceptionHandler.class,
+        WebConfig.class
+})
+class V2TextTaggerControllerWIT {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private TextTaggerService textTaggerService;
+
+    @MockitoBean
+    private OlsSearchClient searchClient;
+
+    // ------------------------------------------------------------------
+    // POST /tag_text
+    // ------------------------------------------------------------------
+
+    @Test
+    void postTagTextReturns503WhenServiceUnavailable() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(false);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}"))
+                .andExpect(status().isServiceUnavailable())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("Text tagger service is not available"))
+                .andExpect(jsonPath("$.message").value(
+                        "The text tagger database has not been configured or the binary is not on the PATH"));
+
+        verify(textTaggerService, never()).tagText(
+                anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), anyInt(), anyBoolean());
+    }
+
+    @Test
+    void postTagTextReturns400WhenTextFieldIsMissing() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.error").value("Missing required field: text"));
+    }
+
+    @Test
+    void postTagTextReturns400WhenTextFieldIsEmpty() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"\"}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.error").value("Missing required field: text"));
+    }
+
+    @Test
+    void postTagTextUsesDefaultsWhenOptionalParametersAreOmitted() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+        when(textTaggerService.tagText(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), anyInt(), anyBoolean()))
+                .thenReturn(new ArrayList<>());
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.text").value("insulin resistance"))
+                .andExpect(jsonPath("$.entities").isArray())
+                .andExpect(jsonPath("$.entities.length()").value(0));
+
+        verify(textTaggerService).tagText(
+                eq("insulin resistance"), isNull(), isNull(), isNull(), eq(3), eq(true));
+    }
+
+    @Test
+    void postTagTextForwardsRepeatedOntologyIdAndSourceAndEveryOtherParameter() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+        when(textTaggerService.tagText(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), anyInt(), anyBoolean()))
+                .thenReturn(new ArrayList<>());
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}")
+                        .param("ontologyId", "efo")
+                        .param("ontologyId", "hp")
+                        .param("source", "sssom-mappings")
+                        .param("source", "manual-curation")
+                        .param("delimiters", "|")
+                        .param("minLength", "5")
+                        .param("includeSubstrings", "false"))
+                .andExpect(status().isOk());
+
+        verify(textTaggerService).tagText(
+                eq("insulin resistance"),
+                eq(List.of("efo", "hp")),
+                eq(List.of("sssom-mappings", "manual-curation")),
+                eq("|"),
+                eq(5),
+                eq(false));
+    }
+
+    @Test
+    void postTagTextMapsAllFieldsAndOmitsOptionalFieldsWhenAbsent() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+        when(textTaggerService.tagText(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), anyInt(), anyBoolean()))
+                .thenReturn(new ArrayList<>(List.of(
+                        new TaggedEntity(0, 7, "insulin", "http://purl.obolibrary.org/obo/CHEBI_5931", "chebi",
+                                "exact", "sssom-mappings", List.of("chemical", "hormone"), true),
+                        new TaggedEntity(8, 18, "resistance", "http://example.org/HP_0000001", "hp",
+                                null, null, null, false))));
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}")
+                        .param("includeObsoleteEntities", "true"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.text").value("insulin resistance"))
+                .andExpect(jsonPath("$.entities.length()").value(2))
+                .andExpect(jsonPath("$.entities[0].start").value(0))
+                .andExpect(jsonPath("$.entities[0].end").value(7))
+                .andExpect(jsonPath("$.entities[0].term_label").value("insulin"))
+                .andExpect(jsonPath("$.entities[0].term_iri")
+                        .value("http://purl.obolibrary.org/obo/CHEBI_5931"))
+                .andExpect(jsonPath("$.entities[0].ontology_id").value("chebi"))
+                .andExpect(jsonPath("$.entities[0].string_type").value("exact"))
+                .andExpect(jsonPath("$.entities[0].source").value("sssom-mappings"))
+                .andExpect(jsonPath("$.entities[0].subject_categories[0]").value("chemical"))
+                .andExpect(jsonPath("$.entities[0].subject_categories[1]").value("hormone"))
+                .andExpect(jsonPath("$.entities[0].is_obsolete").value(true))
+                .andExpect(jsonPath("$.entities[1].term_label").value("resistance"))
+                .andExpect(jsonPath("$.entities[1].string_type").doesNotExist())
+                .andExpect(jsonPath("$.entities[1].source").doesNotExist())
+                .andExpect(jsonPath("$.entities[1].subject_categories").doesNotExist())
+                .andExpect(jsonPath("$.entities[1].is_obsolete").doesNotExist());
+    }
+
+    @Test
+    void postTagTextExcludesObsoleteEntitiesByDefault() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+        when(textTaggerService.tagText(anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any(),
+                org.mockito.ArgumentMatchers.any(), anyInt(), anyBoolean()))
+                .thenReturn(new ArrayList<>(List.of(
+                        new TaggedEntity(0, 7, "insulin", "http://example.org/CHEBI_5931", "chebi",
+                                null, null, null, true),
+                        new TaggedEntity(8, 18, "resistance", "http://example.org/HP_0000001", "hp",
+                                null, null, null, false))));
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.entities.length()").value(1))
+                .andExpect(jsonPath("$.entities[0].term_label").value("resistance"));
+    }
+
+    @Test
+    void postTagTextRejectsMalformedMinLengthWithStableErrorFields() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}")
+                        .param("minLength", "not-a-number"))
+                .andExpect(status().isBadRequest())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'minLength': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'int'; "
+                                + "For input string: \"not-a-number\""));
+    }
+
+    @Test
+    void postTagTextRejectsMalformedIncludeSubstringsWithStableErrorFields() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}")
+                        .param("includeSubstrings", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'includeSubstrings': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+    }
+
+    @Test
+    void postTagTextRejectsMalformedIncludeObsoleteEntitiesWithStableErrorFields() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(post("/api/v2/tag_text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"text\":\"insulin resistance\"}")
+                        .param("includeObsoleteEntities", "not-a-boolean"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.status").value(400))
+                .andExpect(jsonPath("$.message").value(
+                        "Method parameter 'includeObsoleteEntities': Failed to convert value of type "
+                                + "'java.lang.String' to required type 'boolean'; "
+                                + "Invalid boolean value [not-a-boolean]"));
+    }
+
+    @Test
+    void tagTextRouteReturnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(delete("/api/v2/tag_text"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.status").value(405));
+    }
+
+    // ------------------------------------------------------------------
+    // GET /tag_text
+    // ------------------------------------------------------------------
+
+    @Test
+    void getTagTextReportsAvailableTrue() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(true);
+
+        mockMvc.perform(get("/api/v2/tag_text"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.available").value(true));
+    }
+
+    @Test
+    void getTagTextReportsAvailableFalse() throws Exception {
+        when(textTaggerService.isAvailable()).thenReturn(false);
+
+        mockMvc.perform(get("/api/v2/tag_text"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.available").value(false));
+    }
+
+    // ------------------------------------------------------------------
+    // GET /curation_sources
+    // ------------------------------------------------------------------
+
+    @Test
+    void getCurationSourcesReturnsTheSearchClientsDistinctSources() throws Exception {
+        when(searchClient.getDistinctCuratedSources())
+                .thenReturn(List.of("sssom-mappings", "manual-curation"));
+
+        mockMvc.perform(get("/api/v2/curation_sources"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.length()").value(2))
+                .andExpect(jsonPath("$[0]").value("sssom-mappings"))
+                .andExpect(jsonPath("$[1]").value("manual-curation"));
+    }
+
+    @Test
+    void curationSourcesRouteReturnsMethodNotAllowedForUnsupportedMethod() throws Exception {
+        mockMvc.perform(post("/api/v2/curation_sources"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.status").value(405));
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -21,6 +21,7 @@ import uk.ac.ebi.spot.ols.repository.v1.V1OntologyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1PropertyRepository;
 import uk.ac.ebi.spot.ols.repository.v1.V1TermRepository;
 import uk.ac.ebi.spot.ols.service.PostgresClient;
+import uk.ac.ebi.spot.ols.service.TextTaggerService;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -119,6 +120,16 @@ public final class PostgresIntegrationTestSupport {
         ReflectionTestUtils.setField(repository, "searchClient", searchClient);
         ReflectionTestUtils.setField(repository, "postgresClient", olsPostgresClient);
         return new HealthCheckRepositoryHandle(repository, olsPostgresClient, postgresClient);
+    }
+
+    public static TextTaggerRepositoryHandle createTextTaggerRepositories(PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+        OlsSearchClient searchClient = createSearchClient(postgresClient);
+
+        TextTaggerService textTaggerService = new TextTaggerService();
+        ReflectionTestUtils.setField(textTaggerService, "postgresClient", postgresClient);
+
+        return new TextTaggerRepositoryHandle(textTaggerService, searchClient, postgresClient);
     }
 
     public static V1RepositoryHandle createV1Repository(PostgreSQLContainer<?> container) {
@@ -679,6 +690,18 @@ public final class PostgresIntegrationTestSupport {
 
         @Override
         public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record TextTaggerRepositoryHandle(
+            TextTaggerService textTaggerService,
+            OlsSearchClient searchClient,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            textTaggerService.destroy();
             postgresClient.close();
         }
     }

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -753,6 +753,78 @@ Verified locally on 2026-09-07 with Java 17 and Rancher Desktop:
   `HealthCheckController` needs both as independent autowired fields. No production defect was
   discovered by this rollout.
 
+## Implemented V2 text-tagger-controller baseline
+
+`V2TextTaggerController` has three routes: `POST /tag_text` (annotate free text with matching
+ontology terms), `GET /tag_text` (status check, `{"available": <bool>}`), and
+`GET /curation_sources` (`List<String>` of curated source names via
+`OlsSearchClient.getDistinctCuratedSources()`). It autowires two collaborators:
+`TextTaggerService` and `OlsSearchClient`.
+
+**Scoping decision.** `TextTaggerService` wraps an external `ols_text_tagger` CLI binary via
+`ProcessBuilder`, which is why this controller was held back from earlier rollouts in this
+programme — it does not fit the "real Postgres, no mocks" doctrine as cleanly as a pure-repository
+controller. The binary is not installed on this development machine or in CI, so exercising
+genuine tagging output is explicitly and permanently out of scope for this suite — that is a
+deliberate limitation of this layer of coverage, not a TODO or a gap, and it will remain true for
+any environment that does not ship the binary.
+
+What full-stack IT coverage *can* prove, and does: the `ols_text_tagger` table (single column
+`tagger_db_oid`) exists in the production schema
+(`dataload/create_postgres_schema.py`), but no fixture in this suite — or anywhere else in the
+committed test suite — inserts a row into it. Consequently the real, unmodified
+`TextTaggerService` bean's `@PostConstruct init()` genuinely finds nothing to download,
+`startProcess()` is never reached, and `isAvailable()` genuinely settles to `false` against a real
+disposable Postgres — this is not a mock standing in for integration behaviour, it is the actual
+behaviour a deployment with no tagger database configured exhibits. `available` also defaults to
+`false` at field declaration and is only ever set `true` inside `startProcess()`, so this is true
+immediately at bean construction, before the background init thread even runs; there is no async
+timing race for these assertions to be sensitive to, confirmed by two clean repeat runs of the
+database gate below.
+
+Verified locally on 2026-09-08 with Java 17 and Rancher Desktop:
+
+- Surefire runs 856 tests, including 13 direct `V2TextTaggerControllerTest` cases and 15
+  `V2TextTaggerControllerWIT` cases. Two Docker-free runs took wall-clock 12.76 and 13.76 seconds.
+- Failsafe runs 187 PostgreSQL tests, including 3 thin `V2TextTaggerControllerIT` cases against
+  the real, unconfigured `TextTaggerService` bean and the real `OlsSearchClient`. No new
+  repository-IT class was added: `TextTaggerService` is not a repository, and there is no
+  repository-level behaviour left to prove beyond what the controller-IT's unavailable-branch case
+  already exercises against real Postgres; `OlsSearchClient.getDistinctCuratedSources()` is
+  exercised by the controller-IT's third case and has no other untested repository behaviour of
+  its own. Two complete database-gate runs took wall-clock 115.60 and 119.34 seconds.
+- The clean `verify` lifecycle runs all 1,043 tests in wall-clock 2 minutes 1.68 seconds.
+- Whole-backend JaCoCo coverage is 64.1% lines (3,068 of 4,787) and 48.6% branches (932 of 1,916),
+  up from the most recently documented baseline of 56.4% lines and 44.6% branches.
+  `V2TextTaggerController` itself covers all 38 of its executable lines and all 18 branches. As
+  expected, `TextTaggerService` shows low coverage on its own — 31 of 194 lines (16.0%) and 5 of
+  112 branches (4.5%) — because its process-management internals (`startProcess`, `ensureRunning`,
+  response parsing, priority and substring filtering) are unreachable without the real binary; the
+  covered lines come almost entirely from the real bean's `init()`/`downloadTextTaggerDb()`
+  unavailable path exercised by the controller IT. This is expected and not chased further. No
+  coverage failure threshold is introduced.
+- The unit test and WIT enumerate every route (`POST /tag_text`, `GET /tag_text`,
+  `GET /curation_sources`), every declared parameter (`ontologyId`, `source`, `delimiters`,
+  `minLength`, `includeSubstrings`, `includeObsoleteEntities`) including repeated `ontologyId`/
+  `source` values, the missing/empty `text` 400 branch, the service-unavailable 503 branch,
+  malformed typed-parameter 400s for `minLength`/`includeSubstrings`/`includeObsoleteEntities` with
+  the exact conversion-error message, and the full field-by-field response mapping — including the
+  conditional `string_type`, `source`, `subject_categories`, and `is_obsolete` fields, which are
+  only present when the tagger actually returns them. The unit test uses this repo's hand-rolled
+  fake idiom (subclasses of `TextTaggerService`/`OlsSearchClient` overriding just the methods under
+  test, the same idiom as `HealthCheckControllerTest`); the WIT uses `@MockitoBean` for both
+  collaborators, the same idiom as `HealthCheckControllerWIT`.
+- `PostgresIntegrationTestSupport` gained a new `createTextTaggerRepositories(...)` factory
+  returning the real `TextTaggerService` (wired to disposable Postgres via reflection, matching
+  every other repository/client factory in this file) alongside the existing
+  `createSearchClient(...)`-backed `OlsSearchClient`. No existing factory wired
+  `TextTaggerService`.
+- `curation_sources` currently returns an empty list against the shared fixture: no fixture record
+  populates the `curated_from_sources` column (it defaults to `'{}'` in the production schema), so
+  the real-Postgres controller-IT case asserts an empty array rather than a guessed value — observed
+  by running the suite, not assumed ahead of time. No production defect was discovered by this
+  rollout.
+
 ## Out of scope for the pilot
 
 - Connecting GitHub-hosted CI to production or internal databases.


### PR DESCRIPTION
## Summary

- Continues the layered backend testing programme (docs/backend-testing-strategy.md) to `V2TextTaggerController`, per `HANDOFF_v2_text_tagger_controller_testing.md`. This controller was previously deferred because `TextTaggerService` wraps an external `ols_text_tagger` CLI binary via `ProcessBuilder`, which doesn't fit the "real Postgres, no mocks" doctrine as cleanly as a pure-repository controller.
- `V2TextTaggerController` has three routes: `POST /tag_text` (annotate free text with matching ontology terms), `GET /tag_text` (status check, `{"available": <bool>}`), and `GET /curation_sources` (`List<String>` via `OlsSearchClient.getDistinctCuratedSources()`). Two autowired collaborators: `TextTaggerService` and `OlsSearchClient`.

## Scoping decision (verified, not assumed)

The `ols_text_tagger` table (single column `tagger_db_oid`) exists in the production schema (`dataload/create_postgres_schema.py`), but no fixture anywhere in the committed test suite inserts a row into it. So the real, unmodified `TextTaggerService` bean's `@PostConstruct init()` genuinely finds nothing to download, `startProcess()` is never reached, and `isAvailable()` genuinely settles to `false` against a real disposable Postgres — this is real behavior of the real bean, not a mock standing in for it. `available` also defaults to `false` at field declaration and is only ever set `true` inside `startProcess()`, so this is already correct at bean construction, before the background init thread even runs — no async timing race for the IT assertions to be sensitive to.

Actually invoking the real `ols_text_tagger` binary to test genuine tagging output is **explicitly and permanently out of scope**: the binary isn't installed on this machine or in CI. This is documented in `docs/backend-testing-strategy.md` as a deliberate, permanent limitation, not a TODO.

## Testing layers added

- **Direct**: `V2TextTaggerControllerTest` — 13 cases covering: 503 when the service is unavailable (and that the service is never called); 400 for absent/null/empty `text`; every parameter forwarded correctly to `TextTaggerService.tagText(...)`; full field-by-field response mapping including the conditional `string_type`/`source`/`subject_categories`/`is_obsolete` fields (present only when non-null/true); `includeObsoleteEntities` filtering both ways; empty-entities happy path; both `isAvailable()` branches on the status route; and `getCurationSources()` passthrough. Uses this repo's hand-rolled fake idiom (subclasses of `TextTaggerService`/`OlsSearchClient` overriding just the methods under test), matching `HealthCheckControllerTest`.
- **WIT**: `V2TextTaggerControllerWIT` — 15 invocations covering the same branches through real Spring MVC binding with `@MockitoBean` collaborators: defaults when optional params are omitted, repeated `ontologyId`/`source` values plus every other parameter forwarded, full field mapping via `jsonPath`, obsolete-entity filtering, malformed `minLength`/`includeSubstrings`/`includeObsoleteEntities` with the exact Spring type-conversion error message, and 405 for unsupported methods on both routes.
- **Controller IT**: new `V2TextTaggerControllerIT` — 3 thin cases against the real, unconfigured `TextTaggerService` bean and the real `OlsSearchClient`: `POST /tag_text` asserts the genuine 503 contract, `GET /tag_text` asserts the genuine `{"available": false}`, and `GET /curation_sources` asserts the real result through Postgres (currently an empty array — no fixture record populates `curated_from_sources`, observed by running the suite rather than guessed ahead of time).
- **No repository-IT class added**: `TextTaggerService` is not a repository and there's no repository-level behavior left to prove beyond what the controller-IT's unavailable-branch case already exercises against real Postgres; `OlsSearchClient.getDistinctCuratedSources()` has no other untested repository behavior of its own.

Test counts by layer: 13 direct + 15 WIT + 3 controller IT = **31 new tests**.

## Test-support change (test-only, no production code changed)

`PostgresIntegrationTestSupport` gained a new `createTextTaggerRepositories(...)` factory returning the real `TextTaggerService` (wired to disposable Postgres via reflection, matching every other repository/client factory in this file) alongside the existing `createSearchClient(...)`-backed `OlsSearchClient`. No existing factory wired `TextTaggerService`.

## Local verification (Java 17, Rancher Desktop)

All commands run with `JAVA_HOME` pointed at the Java 17 install and, for Postgres-backed runs, `DOCKER_HOST=unix:///Users/haideri/.rd/docker.sock` / `TESTCONTAINERS_DOCKER_SOCKET_OVERRIDE=/var/run/docker.sock` / `-Dapi.version=1.44` per docs/backend-testing-strategy.md. Pass/fail counts read from the actual `target/surefire-reports`/`target/failsafe-reports` `.txt` files, not just exit codes.

- Docker-free `mvn test`, run twice: 856/856 pass both times, wall-clock 12.76s and 13.76s.
- PostgreSQL-only `verify -Dsurefire.skip=true -Dapi.version=1.44`, run twice: 187/187 pass both times, wall-clock 115.60s and 119.34s.
- Clean `mvn clean verify -Dapi.version=1.44`: 1,043/1,043 pass, wall-clock 2m1.68s.

## Coverage (JaCoCo, from the clean verify run)

- Whole-backend: 64.1% lines (3,068/4,787), 48.6% branches (932/1,916) — up from the most recently documented baseline of 56.4%/44.6%. No repository-wide threshold introduced.
- `V2TextTaggerController`: 38/38 lines, 18/18 branches.
- `TextTaggerService` itself: 31/194 lines (16.0%), 5/112 branches (4.5%) — as expected, since its process-management internals (`startProcess`, `ensureRunning`, response parsing, priority/substring filtering) are unreachable without the real binary. The covered lines come almost entirely from the real bean's `init()`/`downloadTextTaggerDb()` unavailable path exercised by the controller IT. Not chased further — documented in `docs/backend-testing-strategy.md` as the expected coverage shape for this controller.

Baseline recorded in `docs/backend-testing-strategy.md` under "Implemented V2 text-tagger-controller baseline".

## Defects

None found. No suspicious behavior surfaced during this rollout.

## Graphify

`graphify update .` refreshed the local graph: 6628 nodes, 18781 edges, 300 communities. Same two pre-existing warnings as prior runs in this programme (two `Cargo.toml` files producing zero nodes; `frontend/src/model/Model.ts` syntax error) — unrelated to this change.

## Not run locally

- Docker image publication (not a required gate per the testing programme).
- `test_api.sh` full system regression (CI-only; unaffected — no production code changed).

## Out of scope, per the handoff

- `V2LLMController` — depends on `EmbeddingServiceClient` (external HTTP embedding service) and pgvector similarity search with real production incident history; needs its own live scoping conversation with the user before anyone writes tests for it. Not touched.
- PR #1395 (`V1OntologyTermController` milestone 2), #1396 (`HealthCheckController`), and #1397 (`V2DefinedFieldsController`) were all already merged to `dev` (confirmed via `gh pr view`) by the time this branch was created off it — ahead of what the handoff document itself expected, which described them as still open. Nothing from those PRs was touched here; this branch simply builds on top of `dev` as it already stood.

This PR is **not to be merged** without explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
