### PR TITLE
Fix class tree not showing individuals when expanding a class

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -68,6 +68,16 @@ jobs:
             type=ref,event=branch
             type=sha,prefix={{branch}}-
 
+      # Docker tags cannot contain "/", so branch names like feature/foo need
+      # sanitizing before they can be used as a tag. Branches without special
+      # characters (e.g. dev, stable) are left unchanged.
+      - name: Compute Docker-safe branch tag
+        id: branch_tag
+        env:
+          BRANCH_REF: ${{ github.head_ref || github.ref_name }}
+        run: |
+          echo "tag=$(printf '%s' "$BRANCH_REF" | sed -e 's/[^a-zA-Z0-9_.-]/-/g' -e 's/^[.-]*//' | cut -c1-128)" >> "$GITHUB_OUTPUT"
+
       - name: Build and push ols4 ${{ matrix.component }} Docker image
         uses: docker/build-push-action@v5
         with:
@@ -79,7 +89,7 @@ jobs:
           build-args: ${{ matrix.build-args }}
           tags: |
             ghcr.io/ebispot/ols4-${{ matrix.component }}:${{ github.sha }}
-            ghcr.io/ebispot/ols4-${{ matrix.component }}:${{ github.head_ref || github.ref_name }}
+            ghcr.io/ebispot/ols4-${{ matrix.component }}:${{ steps.branch_tag.outputs.tag }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/ClassRepository.java
@@ -118,7 +118,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
+        Map<String, String> nodeProps = classHierarchyMemberNodeProperties(includeObsolete);
 
         Page<JsonElement> result = isNullOrEmpty(search) ? this.postgresClient.getDirectChildren(
                 id, nodeProps, pageable) :
@@ -151,7 +151,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
+        Map<String, String> nodeProps = classHierarchyMemberNodeProperties(includeObsolete);
 
         return this.postgresClient.getDescendants(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -164,7 +164,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
+        Map<String, String> nodeProps = classHierarchyMemberNodeProperties(includeObsolete);
 
         return this.postgresClient.getHierarchicalDescendants(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -178,7 +178,7 @@ public class ClassRepository {
 
         String id = ontologyId + "+class+" + iri;
 
-        Map<String, String> nodeProps = classNodeProperties(includeObsolete);
+        Map<String, String> nodeProps = classHierarchyMemberNodeProperties(includeObsolete);
 
         return this.postgresClient.getHierarchicalChildren(id, nodeProps, pageable)
                 .map(e -> JsonTransformer.transformJson(e, lang, outputOpts))
@@ -227,10 +227,21 @@ public class ClassRepository {
                 ;
     }
 
+    // Walking up the class hierarchy can only ever reach classes.
     private static Map<String, String> classNodeProperties(boolean includeObsolete) {
+        return nodeProperties("OntologyClass", includeObsolete);
+    }
+
+    // Walking down the class hierarchy reaches subclasses and also individuals,
+    // whose rdf:type class is their parent in OLS.
+    private static Map<String, String> classHierarchyMemberNodeProperties(boolean includeObsolete) {
+        return nodeProperties("OntologyClass,OntologyIndividual", includeObsolete);
+    }
+
+    private static Map<String, String> nodeProperties(String types, boolean includeObsolete) {
         return includeObsolete
-                ? Map.of("type", "OntologyClass")
-                : Map.of("type", "OntologyClass", "isObsolete", "false");
+                ? Map.of("type", types)
+                : Map.of("type", types, "isObsolete", "false");
     }
 
     public double getSimilarity(String iri, String iri2, String modelName) {

--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/postgres/OlsPostgresClient.java
@@ -274,8 +274,17 @@ public class OlsPostgresClient {
                 case "isObsolete" -> condition = condition.and(
                         field(qualifier, "is_obsolete", Boolean.class)
                                 .eq("true".equals(entry.getValue())));
-                case "type" -> condition = condition.and(
-                        field(qualifier, "type", String.class).eq(entry.getValue()));
+                // "type" accepts a comma separated list of allowed types
+                case "type" -> {
+                    List<String> types = Arrays.stream(entry.getValue().split(","))
+                            .map(String::trim)
+                            .filter(type -> !type.isEmpty())
+                            .collect(Collectors.toList());
+                    Field<String> typeField = field(qualifier, "type", String.class);
+                    condition = condition.and(types.size() == 1
+                            ? typeField.eq(types.get(0))
+                            : typeField.in(types));
+                }
                 default -> {
                 }
             }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2ClassControllerIT.java
@@ -122,7 +122,14 @@ class V2ClassControllerIT {
 
     @Test
     void getsClassDescendantsThroughTheRealDatabase() throws Exception {
-        assertSingleRelationship(DESCENDANTS_URI, "http://example.org/EFO_1001");
+        // Descendants of a class include its subclasses and the individuals
+        // whose rdf:type reaches the class.
+        mockMvc.perform(get(DESCENDANTS_URI))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.numElements").value(2))
+                .andExpect(jsonPath("$.totalElements").value(2))
+                .andExpect(jsonPath("$.elements[0].iri").value("http://example.org/EFO_1001"))
+                .andExpect(jsonPath("$.elements[1].iri").value("http://example.org/EFO_I100"));
     }
 
     @Test

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeIT.java
@@ -15,11 +15,18 @@ import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Testcontainers
 class ClassRepositoryHierarchyTypeIT {
+
+    private static final String PARENT_CLASS_IRI = "http://example.org/EFO_0001";
+    private static final String CHILD_CLASS_IRI = "http://example.org/EFO_0002";
+    private static final String INDIVIDUAL_IRI = "http://example.org/EFO_I100";
+    private static final String GRANDCHILD_INDIVIDUAL_IRI = "http://example.org/EFO_I200";
+    private static final String OBSOLETE_INDIVIDUAL_IRI = "http://example.org/EFO_I999";
 
     @Container
     private static final PostgreSQLContainer<?> POSTGRES =
@@ -29,13 +36,19 @@ class ClassRepositoryHierarchyTypeIT {
 
     @BeforeAll
     static void setUpDatabase() throws SQLException {
-        PostgresIntegrationTestSupport.initializeDatabase(POSTGRES);
+        PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
         try (Connection connection = POSTGRES.createConnection("");
                 Statement statement = connection.createStatement()) {
             statement.executeUpdate("""
                     UPDATE ols_entities
                     SET direct_ancestors = ARRAY['http://example.org/EFO_0001']
                     WHERE id = 'efo+property+http://example.org/EFO_0100'
+                    """);
+            statement.executeUpdate("""
+                    UPDATE ols_entities
+                    SET hierarchical_parents = ARRAY['http://example.org/EFO_0001'],
+                        hierarchical_ancestors = ARRAY['http://example.org/EFO_0001']
+                    WHERE id = 'efo+individual+http://example.org/EFO_I100'
                     """);
         }
         repositoryHandle = PostgresIntegrationTestSupport.createClassRepository(POSTGRES);
@@ -47,16 +60,81 @@ class ClassRepositoryHierarchyTypeIT {
     }
 
     @Test
-    void classDescendantsExcludeCrossTypeEntitiesInTheSameHierarchyColumn() {
+    void classDescendantsIncludeIndividualsButExcludePropertiesAndObsoleteEntities() {
         Page<JsonElement> descendants = repositoryHandle.repository().getDescendantsByOntologyId(
                 "efo",
                 PageRequest.of(0, 20),
-                "http://example.org/EFO_0001",
+                PARENT_CLASS_IRI,
                 false,
                 "en",
                 new JsonTransformOptions());
 
-        assertThat(descendants).isEmpty();
-        assertThat(descendants.getTotalElements()).isZero();
+        assertThat(iris(descendants)).containsExactlyInAnyOrder(
+                INDIVIDUAL_IRI,
+                GRANDCHILD_INDIVIDUAL_IRI);
+    }
+
+    @Test
+    void classChildrenIncludeIndividualsWhoseTypeIsTheClass() {
+        Page<JsonElement> children = repositoryHandle.repository().getChildrenByOntologyId(
+                "efo",
+                PageRequest.of(0, 20),
+                PARENT_CLASS_IRI,
+                false,
+                null,
+                "en",
+                new JsonTransformOptions());
+
+        assertThat(iris(children)).containsExactly(INDIVIDUAL_IRI);
+    }
+
+    @Test
+    void classChildrenIncludeObsoleteIndividualsWhenRequested() {
+        Page<JsonElement> children = repositoryHandle.repository().getChildrenByOntologyId(
+                "efo",
+                PageRequest.of(0, 20),
+                PARENT_CLASS_IRI,
+                true,
+                null,
+                "en",
+                new JsonTransformOptions());
+
+        assertThat(iris(children)).containsExactlyInAnyOrder(
+                INDIVIDUAL_IRI,
+                OBSOLETE_INDIVIDUAL_IRI);
+    }
+
+    @Test
+    void classHierarchicalChildrenIncludeIndividuals() {
+        Page<JsonElement> children = repositoryHandle.repository().getHierarchicalChildrenByOntologyId(
+                "efo",
+                PageRequest.of(0, 20),
+                PARENT_CLASS_IRI,
+                false,
+                "en",
+                new JsonTransformOptions());
+
+        assertThat(iris(children)).containsExactly(INDIVIDUAL_IRI);
+    }
+
+    @Test
+    void individualAncestorsReturnOnlyClasses() {
+        Page<JsonElement> ancestors = repositoryHandle.repository().getIndividualAncestorsByOntologyId(
+                "efo",
+                PageRequest.of(0, 20),
+                GRANDCHILD_INDIVIDUAL_IRI,
+                false,
+                "en",
+                new JsonTransformOptions());
+
+        assertThat(iris(ancestors)).containsExactlyInAnyOrder(
+                PARENT_CLASS_IRI,
+                CHILD_CLASS_IRI);
+    }
+
+    private static List<String> iris(Page<JsonElement> page) {
+        return page.getContent().stream()
+                .map(element -> element.getAsJsonObject().get("iri").getAsString())
+                .toList();
     }
 }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryHierarchyTypeTest.java
@@ -17,28 +17,77 @@ import static org.springframework.test.util.ReflectionTestUtils.setField;
 
 class ClassRepositoryHierarchyTypeTest {
 
+    private static final String CLASSES_ONLY = "OntologyClass";
+    private static final String CLASSES_AND_INDIVIDUALS = "OntologyClass,OntologyIndividual";
+
     @Test
-    void everyHierarchyRouteRestrictsResultsToClassesAndActiveEntities() {
+    void downwardHierarchyRoutesAllowClassesAndIndividualsAndExcludeObsoleteEntities() {
         RecordingPostgresClient postgresClient = new RecordingPostgresClient();
         ClassRepository repository = repository(postgresClient);
 
         invokeEveryHierarchyRoute(repository, false);
 
-        assertThat(postgresClient.nodeProperties).hasSize(7)
+        assertThat(propertiesForMethods(
+                postgresClient,
+                "getDirectChildren",
+                "getDescendants",
+                "getHierarchicalDescendants",
+                "getHierarchicalChildren"))
+                .hasSize(4)
                 .allSatisfy(properties -> assertThat(properties).containsExactlyInAnyOrderEntriesOf(
-                        Map.of("type", "OntologyClass", "isObsolete", "false")));
+                        Map.of("type", CLASSES_AND_INDIVIDUALS, "isObsolete", "false")));
     }
 
     @Test
-    void includingObsoleteEntitiesStillRestrictsHierarchyResultsToClasses() {
+    void upwardHierarchyRoutesRestrictResultsToClassesAndExcludeObsoleteEntities() {
+        RecordingPostgresClient postgresClient = new RecordingPostgresClient();
+        ClassRepository repository = repository(postgresClient);
+
+        invokeEveryHierarchyRoute(repository, false);
+
+        assertThat(propertiesForMethods(
+                postgresClient,
+                "getAncestors",
+                "getHierarchicalAncestors"))
+                .hasSize(3)
+                .allSatisfy(properties -> assertThat(properties).containsExactlyInAnyOrderEntriesOf(
+                        Map.of("type", CLASSES_ONLY, "isObsolete", "false")));
+    }
+
+    @Test
+    void includingObsoleteEntitiesStillRestrictsHierarchyResultTypes() {
         RecordingPostgresClient postgresClient = new RecordingPostgresClient();
         ClassRepository repository = repository(postgresClient);
 
         invokeEveryHierarchyRoute(repository, true);
 
-        assertThat(postgresClient.nodeProperties).hasSize(7)
+        assertThat(propertiesForMethods(
+                postgresClient,
+                "getDirectChildren",
+                "getDescendants",
+                "getHierarchicalDescendants",
+                "getHierarchicalChildren"))
+                .hasSize(4)
                 .allSatisfy(properties -> assertThat(properties)
-                        .containsExactlyEntriesOf(Map.of("type", "OntologyClass")));
+                        .containsExactlyEntriesOf(Map.of("type", CLASSES_AND_INDIVIDUALS)));
+
+        assertThat(propertiesForMethods(
+                postgresClient,
+                "getAncestors",
+                "getHierarchicalAncestors"))
+                .hasSize(3)
+                .allSatisfy(properties -> assertThat(properties)
+                        .containsExactlyEntriesOf(Map.of("type", CLASSES_ONLY)));
+    }
+
+    private static List<Map<String, String>> propertiesForMethods(
+            RecordingPostgresClient postgresClient,
+            String... methods) {
+        List<String> methodNames = List.of(methods);
+        return postgresClient.invocations.stream()
+                .filter(invocation -> methodNames.contains(invocation.method()))
+                .map(Invocation::properties)
+                .toList();
     }
 
     private static ClassRepository repository(RecordingPostgresClient postgresClient) {
@@ -70,47 +119,51 @@ class ClassRepositoryHierarchyTypeTest {
                 "efo", pageable, iri, includeObsolete, "en", options);
     }
 
+    private record Invocation(String method, Map<String, String> properties) {
+    }
+
     private static class RecordingPostgresClient extends OlsPostgresClient {
-        private final List<Map<String, String>> nodeProperties = new ArrayList<>();
+        private final List<Invocation> invocations = new ArrayList<>();
 
         @Override
         public Page<JsonElement> getDirectChildren(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getDirectChildren", properties, pageable);
         }
 
         @Override
         public Page<JsonElement> getAncestors(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getAncestors", properties, pageable);
         }
 
         @Override
         public Page<JsonElement> getDescendants(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getDescendants", properties, pageable);
         }
 
         @Override
         public Page<JsonElement> getHierarchicalDescendants(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getHierarchicalDescendants", properties, pageable);
         }
 
         @Override
         public Page<JsonElement> getHierarchicalChildren(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getHierarchicalChildren", properties, pageable);
         }
 
         @Override
         public Page<JsonElement> getHierarchicalAncestors(
                 String id, Map<String, String> properties, Pageable pageable) {
-            return record(properties, pageable);
+            return record("getHierarchicalAncestors", properties, pageable);
         }
 
-        private Page<JsonElement> record(Map<String, String> properties, Pageable pageable) {
-            nodeProperties.add(properties);
+        private Page<JsonElement> record(
+                String method, Map<String, String> properties, Pageable pageable) {
+            invocations.add(new Invocation(method, properties));
             return Page.empty(pageable);
         }
     }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/ClassRepositoryIT.java
@@ -178,7 +178,8 @@ class ClassRepositoryIT {
         PageRequest page = PageRequest.of(0, 20);
 
         assertThat(iris(repository.getDescendantsByOntologyId(
-                "efo", page, ROOT_IRI, false, "en", options))).containsExactly(CHILD_IRI);
+                "efo", page, ROOT_IRI, false, "en", options)))
+                .containsExactly(CHILD_IRI, INDIVIDUAL_IRI);
         assertThat(iris(repository.getHierarchicalChildrenByOntologyId(
                 "efo", page, ROOT_IRI, false, "en", options))).containsExactly(CHILD_IRI);
         assertThat(iris(repository.getHierarchicalAncestorsByOntologyId(


### PR DESCRIPTION
Fixes #1400

## Problem

Expanding a class in the tree view (e.g. "cohort" in [COHO](https://www.ebi.ac.uk/ols4/ontologies/coho?tab=classes&viewMode=tree)) shows nothing, even though the class is marked expandable and shows a descendant count.

## Root cause

Commit a2b2aec ("fix: restrict class hierarchy result types") added a `type = OntologyClass` filter to every `ClassRepository` hierarchy query to stop cross-type leakage (e.g. a property appearing among class descendants). However, in OLS an individual's `rdf:type` class is its parent (`DirectParentsAnnotator`: "The type of individuals becomes their parent in OLS"), and both `hasDirectChildren` and `numDescendants` are computed over individuals too. The new filter therefore stripped individuals out of the `/children`, `/descendants`, `/hierarchicalChildren` and `/hierarchicalDescendants` responses, so classes whose children are (mostly) individuals expand to an empty node.

## Fix

Split the type restriction by traversal direction:

- **Downward queries** (`children`, `descendants`, `hierarchicalChildren`, `hierarchicalDescendants`) now allow `OntologyClass` and `OntologyIndividual`, restoring individuals in the tree.
- **Upward queries** (`ancestors`, `hierarchicalAncestors`, individual `ancestors`) remain restricted to `OntologyClass`, preserving the original leak fix — properties still cannot appear in class hierarchy results.

`OlsPostgresClient.buildNodePropCondition` now accepts a comma-separated list of allowed types for the `type` node property (single values behave exactly as before).

## CI workflow fix

The `build-and-push` jobs in `docker-publish.yml` derive an image tag directly from the branch name, which produces an invalid Docker tag for any branch containing `/` (like this one: `invalid tag "ghcr.io/ebispot/ols4-dataload:claude/ols-issue-1400-dwzvxr"`). The workflow now sanitizes the branch ref before using it as a tag; `dev` and `stable` tags are unchanged.

## Tests

- `ClassRepositoryHierarchyTypeTest` updated to assert the per-direction type filters (924 backend unit tests pass locally).
- `ClassRepositoryHierarchyTypeIT` extended to load the individual fixture and verify: individuals appear in children/descendants/hierarchicalChildren, obsolete individuals only appear with `includeObsoleteEntities=true`, the cross-type property row is still excluded from descendants, and individual ancestors return only classes.
- `ClassRepositoryIT` and `V2ClassControllerIT` descendant expectations updated to include the fixture individual (matching the `numDescendants` semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fpns1xEYKpib9z4vZmxn3z