### PR TITLE
Fix class tree by fetching individuals separately

### DIFF
--- a/frontend/src/pages/ontologies/ontologiesSlice.ts
+++ b/frontend/src/pages/ontologies/ontologiesSlice.ts
@@ -10,6 +10,8 @@ import Entity from "../../model/Entity";
 import Ontology from "../../model/Ontology";
 import createTreeFromEntities from "./entities/createTreeFromEntities";
 
+const RDF_TYPE_IRI = "http://www.w3.org/1999/02/22-rdf-syntax-ns#type";
+
 export interface OntologiesState {
   ontology: Ontology | undefined;
   entity: Entity | undefined;
@@ -629,17 +631,30 @@ export const getNodeChildren = createAsyncThunk(
             undefined,
             apiUrl
         );
+        const individualsPromise = getPaginated<any>(
+            `api/v2/ontologies/${ontologyId}/classes/${doubleEncodedUri}/individuals?${new URLSearchParams({
+                size: "1000",
+                lang,
+                includeObsoleteEntities: showObsoleteEnabled,
+            })}`,
+            undefined,
+            apiUrl
+        );
 
-        const [hierarchicalChildren, directChildren] = await Promise.all([
+        const [hierarchicalChildren, directChildren, individuals] =
+          await Promise.all([
             hierarchicalChildrenPromise,
             directChildrenPromise,
-        ]);
+            individualsPromise,
+          ]);
 
-        // Merge the elements from both responses
+        // A class tree displays both subclass relationships and rdf:type instances,
+        // while the V2 class hierarchy endpoints remain class-only.
         childrenPage = {
             elements: [
                 ...hierarchicalChildren.elements,
                 ...directChildren.elements,
+                ...individuals.elements,
             ],
         };
     } else if (entityTypePlural === "individuals") {
@@ -667,13 +682,20 @@ export const getNodeChildren = createAsyncThunk(
         apiUrl
       );
     }
+    const seenChildIris = new Set<string>();
     return {
       absoluteIdentity,
       children: childrenPage.elements
         .map((obj: any) => thingFromJsonProperties(obj))
+        .filter((term: Entity) => {
+          if (seenChildIris.has(term.getIri())) return false;
+          seenChildIris.add(term.getIri());
+          return true;
+        })
         .map((term: Entity) => {
-          let parenthoodMetadata =
+          const parenthoodMetadata =
             term.getHierarchicalParentReificationAxioms(entityIri);
+          const isIndividual = term.getType() === "individual";
           return {
             iri: term.getIri(),
             absoluteIdentity: absoluteIdentity + ";" + term.getIri(),
@@ -682,14 +704,12 @@ export const getNodeChildren = createAsyncThunk(
             entity: term,
             numDescendants: term.getNumDescendants(),
             numHierarchicalDescendants: term.getNumHierarchicalDescendants(),
-            parentRelationToChild:
-              (parenthoodMetadata &&
-                parenthoodMetadata["parentRelationToChild"]?.[0]) ||
-              null,
-            childRelationToParent:
-              (parenthoodMetadata &&
-                parenthoodMetadata["childRelationToParent"]?.[0]) ||
-              null,
+            parentRelationToChild: isIndividual
+              ? null
+              : parenthoodMetadata?.["parentRelationToChild"]?.[0] || null,
+            childRelationToParent: isIndividual
+              ? RDF_TYPE_IRI
+              : parenthoodMetadata?.["childRelationToParent"]?.[0] || null,
           };
         }),
     };


### PR DESCRIPTION
Fixes #1400

Alternative to #1401.

## Problem

Expanding the COHO `cohort` class in the class tree shows no children even though the class is marked expandable and has 166 descendants. Those descendants are individuals connected to the class through `rdf:type`, so the class-only `/children` and `/hierarchicalChildren` endpoints correctly return no classes.

## Solution

Keep the V2 class hierarchy APIs class-only and compose the mixed tree in the frontend:

- Fetch `/hierarchicalChildren`, `/children`, and `/individuals` in parallel when expanding a class.
- Merge the three result sets and de-duplicate entities by IRI.
- Mark individual-to-class tree edges as `rdf:type`, preserving the existing instance icon and distinguishing instances from subclasses.

This fixes the tree without changing the response types or pagination semantics of the public class hierarchy endpoints for other API and MCP consumers.

## Validation

- `npm ci`
- `npm run build`
- `npm run build:widgets`
- Focused thunk verification with mocked class and individual responses: passed
  - all three endpoints requested with the same language/obsolete filters
  - duplicate class responses collapsed
  - individual returned as an `Individual` with an `rdf:type` parent relationship
- Live public COHO verification: 166 individuals composed into the `cohort` class tree
- `git diff --check`

`npx tsc --noEmit` remains blocked by the pre-existing syntax error in `frontend/src/model/Model.ts:2`; the production frontend and widget builds both pass.

## Scope

This PR changes one frontend file. It does not widen any backend V2 hierarchy query and does not include the unrelated Docker-tag changes from #1401.
