### PR TITLE
Complete V2 individual hierarchy route test coverage

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerIT.java
@@ -13,9 +13,6 @@ import uk.ac.ebi.spot.ols.controller.api.exception.GlobalExceptionHandler;
 import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
 
 import java.net.URI;
-import java.sql.Connection;
-import java.sql.SQLException;
-import java.sql.Statement;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -44,21 +41,8 @@ class V2IndividualControllerIT {
     private static MockMvc mockMvc;
 
     @BeforeAll
-    static void setUpApplicationPath() throws SQLException {
+    static void setUpApplicationPath() {
         PostgresIntegrationTestSupport.initializeIndividualDatabase(POSTGRES);
-        // A hierarchical property (e.g. COHO isSubCohortOf) makes EFO_I200 and the
-        // obsolete EFO_I999 hierarchical children of EFO_I100.
-        try (Connection connection = POSTGRES.createConnection("");
-                Statement statement = connection.createStatement()) {
-            statement.executeUpdate("""
-                    UPDATE ols_entities
-                    SET hierarchical_parents = ARRAY['http://example.org/EFO_I100'],
-                        hierarchical_ancestors = ARRAY['http://example.org/EFO_I100']
-                    WHERE id IN (
-                        'efo+individual+http://example.org/EFO_I200',
-                        'efo+individual+http://example.org/EFO_I999')
-                    """);
-        }
         repositoryHandle = PostgresIntegrationTestSupport.createIndividualRepository(POSTGRES);
 
         V2IndividualController controller = new V2IndividualController();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerTest.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonParser;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.util.LinkedMultiValueMap;
@@ -111,6 +112,50 @@ class V2IndividualControllerTest {
     }
 
     @Test
+    void hierarchicalChildrenDecodeTheIriAndDelegateEveryPublicArgument() {
+        Pageable pageable = PageRequest.of(1, 3);
+        JsonTransformOptions options = new JsonTransformOptions();
+
+        controller.getHierarchicalChildrenByOntology(
+                pageable,
+                "efo",
+                "http%3A%2F%2Fexample.org%2FEFO_I100",
+                true,
+                "de",
+                options);
+
+        assertEquals(RecordingIndividualRepository.Call.HIERARCHICAL_CHILDREN, repository.call);
+        assertEquals("efo", repository.ontologyId);
+        assertEquals("http://example.org/EFO_I100", repository.iri);
+        assertTrue(repository.includeObsoleteEntities);
+        assertSame(pageable, repository.pageable);
+        assertEquals("de", repository.lang);
+        assertSame(options, repository.outputOptions);
+    }
+
+    @Test
+    void hierarchicalAncestorsDecodeTheIriAndDelegateEveryPublicArgument() {
+        Pageable pageable = PageRequest.of(2, 5);
+        JsonTransformOptions options = new JsonTransformOptions();
+
+        controller.getHierarchicalAncestorsByOntology(
+                pageable,
+                "efo",
+                "http%3A%2F%2Fexample.org%2FEFO_I200",
+                false,
+                "fr",
+                options);
+
+        assertEquals(RecordingIndividualRepository.Call.HIERARCHICAL_ANCESTORS, repository.call);
+        assertEquals("efo", repository.ontologyId);
+        assertEquals("http://example.org/EFO_I200", repository.iri);
+        assertFalse(repository.includeObsoleteEntities);
+        assertSame(pageable, repository.pageable);
+        assertEquals("fr", repository.lang);
+        assertSame(options, repository.outputOptions);
+    }
+
+    @Test
     void classIndividualsDecodeTheClassIriAndDelegateEveryPublicArgument() throws Exception {
         Pageable pageable = PageRequest.of(1, 3);
         JsonTransformOptions options = new JsonTransformOptions();
@@ -134,7 +179,13 @@ class V2IndividualControllerTest {
     }
 
     private static class RecordingIndividualRepository extends IndividualRepository {
-        private enum Call { GLOBAL_LIST, ONTOLOGY_LIST, CLASS_INDIVIDUALS }
+        private enum Call {
+            GLOBAL_LIST,
+            ONTOLOGY_LIST,
+            HIERARCHICAL_CHILDREN,
+            HIERARCHICAL_ANCESTORS,
+            CLASS_INDIVIDUALS
+        }
 
         private Call call;
         private Pageable pageable;
@@ -201,6 +252,44 @@ class V2IndividualControllerTest {
         }
 
         @Override
+        public Page<JsonElement> getHierarchicalChildrenByOntologyId(
+                String ontologyId,
+                Pageable pageable,
+                String iri,
+                boolean includeObsoleteEntities,
+                String lang,
+                JsonTransformOptions outputOptions) {
+            recordHierarchy(
+                    Call.HIERARCHICAL_CHILDREN,
+                    ontologyId,
+                    pageable,
+                    iri,
+                    includeObsoleteEntities,
+                    lang,
+                    outputOptions);
+            return Page.empty(pageable);
+        }
+
+        @Override
+        public Page<JsonElement> getHierarchicalAncestorsByOntologyId(
+                String ontologyId,
+                Pageable pageable,
+                String iri,
+                boolean includeObsoleteEntities,
+                String lang,
+                JsonTransformOptions outputOptions) {
+            recordHierarchy(
+                    Call.HIERARCHICAL_ANCESTORS,
+                    ontologyId,
+                    pageable,
+                    iri,
+                    includeObsoleteEntities,
+                    lang,
+                    outputOptions);
+            return Page.empty(pageable);
+        }
+
+        @Override
         public OlsFacetedResultsPage<JsonElement> getIndividualsOfClass(
                 String ontologyId,
                 String classIri,
@@ -234,6 +323,23 @@ class V2IndividualControllerTest {
             this.boostFields = boostFields;
             this.exactMatch = exactMatch;
             this.properties = properties;
+            this.outputOptions = outputOptions;
+        }
+
+        private void recordHierarchy(
+                Call call,
+                String ontologyId,
+                Pageable pageable,
+                String iri,
+                boolean includeObsoleteEntities,
+                String lang,
+                JsonTransformOptions outputOptions) {
+            this.call = call;
+            this.ontologyId = ontologyId;
+            this.pageable = pageable;
+            this.iri = iri;
+            this.includeObsoleteEntities = includeObsoleteEntities;
+            this.lang = lang;
             this.outputOptions = outputOptions;
         }
 

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerWIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/api/v2/V2IndividualControllerWIT.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.MediaType;
@@ -55,6 +56,10 @@ class V2IndividualControllerWIT {
     private static final String CLASS_IRI = "http://example.org/EFO_0001";
     private static final URI INDIVIDUAL_URI = uri(
             "/api/v2/ontologies/efo/individuals/http%253A%252F%252Fexample.org%252FEFO_I100");
+    private static final URI HIERARCHICAL_CHILDREN_URI = uri(
+            "/api/v2/ontologies/efo/individuals/http%253A%252F%252Fexample.org%252FEFO_I100/hierarchicalChildren");
+    private static final URI HIERARCHICAL_ANCESTORS_URI = uri(
+            "/api/v2/ontologies/efo/individuals/http%253A%252F%252Fexample.org%252FEFO_I100/hierarchicalAncestors");
     private static final URI CLASS_INDIVIDUALS_URI = uri(
             "/api/v2/ontologies/efo/classes/http%253A%252F%252Fexample.org%252FEFO_0001/individuals");
 
@@ -75,6 +80,12 @@ class V2IndividualControllerWIT {
         when(individualRepository.getIndividualsOfClass(
                 any(), any(), any(), anyBoolean(), any(), any()))
                 .thenReturn(individualPage());
+        when(individualRepository.getHierarchicalChildrenByOntologyId(
+                any(), any(), any(), anyBoolean(), any(), any()))
+                .thenReturn(hierarchyPage());
+        when(individualRepository.getHierarchicalAncestorsByOntologyId(
+                any(), any(), any(), anyBoolean(), any(), any()))
+                .thenReturn(hierarchyPage());
     }
 
     @Test
@@ -209,7 +220,15 @@ class V2IndividualControllerWIT {
             "class, -1, 20, 0, 20",
             "class, 0, 0, 0, 20",
             "class, 0, -1, 0, 20",
-            "class, 0, 1001, 0, 1000"
+            "class, 0, 1001, 0, 1000",
+            "children, -1, 20, 0, 20",
+            "children, 0, 0, 0, 20",
+            "children, 0, -1, 0, 20",
+            "children, 0, 1001, 0, 1000",
+            "ancestors, -1, 20, 0, 20",
+            "ancestors, 0, 0, 0, 20",
+            "ancestors, 0, -1, 0, 20",
+            "ancestors, 0, 1001, 0, 1000"
     })
     void normalizesPaginationBoundaries(
             String route,
@@ -232,7 +251,11 @@ class V2IndividualControllerWIT {
             "ontology, page, not-a-number",
             "ontology, size, not-a-number",
             "class, page, not-a-number",
-            "class, size, not-a-number"
+            "class, size, not-a-number",
+            "children, page, not-a-number",
+            "children, size, not-a-number",
+            "ancestors, page, not-a-number",
+            "ancestors, size, not-a-number"
     })
     void usesPaginationDefaultsForMalformedNumericValues(
             String route, String parameter, String value) throws Exception {
@@ -254,7 +277,13 @@ class V2IndividualControllerWIT {
             "ontology, manchesterSyntax",
             "class, resolveReferences",
             "class, manchesterSyntax",
-            "class, includeObsoleteEntities"
+            "class, includeObsoleteEntities",
+            "children, includeObsoleteEntities",
+            "children, resolveReferences",
+            "children, manchesterSyntax",
+            "ancestors, includeObsoleteEntities",
+            "ancestors, resolveReferences",
+            "ancestors, manchesterSyntax"
     })
     void rejectsMalformedTypedParameters(String route, String parameter) throws Exception {
         assertStableBadRequest(get(routeUri(route)).param(parameter, "not-a-boolean"));
@@ -273,7 +302,11 @@ class V2IndividualControllerWIT {
             "ontology, asc, ASC",
             "ontology, desc, DESC",
             "class, asc, ASC",
-            "class, desc, DESC"
+            "class, desc, DESC",
+            "children, asc, ASC",
+            "children, desc, DESC",
+            "ancestors, asc, ASC",
+            "ancestors, desc, DESC"
     })
     void bindsSupportedSortDirections(String route, String requested, String expected)
             throws Exception {
@@ -290,7 +323,11 @@ class V2IndividualControllerWIT {
             "ontology, notARealField,asc",
             "ontology, iri,sideways",
             "class, notARealField,asc",
-            "class, iri,sideways"
+            "class, iri,sideways",
+            "children, notARealField,asc",
+            "children, iri,sideways",
+            "ancestors, notARealField,asc",
+            "ancestors, iri,sideways"
     })
     void returnsStableErrorForUnsupportedSort(String route, String field, String direction)
             throws Exception {
@@ -305,8 +342,16 @@ class V2IndividualControllerWIT {
             when(individualRepository.findByOntologyId(
                     any(), any(), any(), any(), any(), any(), anyBoolean(), anyMap(), any()))
                     .thenThrow(error);
-        } else {
+        } else if (route.equals("class")) {
             when(individualRepository.getIndividualsOfClass(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else if (route.equals("children")) {
+            when(individualRepository.getHierarchicalChildrenByOntologyId(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else {
+            when(individualRepository.getHierarchicalAncestorsByOntologyId(
                     any(), any(), any(), anyBoolean(), any(), any()))
                     .thenThrow(error);
         }
@@ -335,6 +380,54 @@ class V2IndividualControllerWIT {
         assertEquals(INDIVIDUAL_IRI, call.iri());
         assertEquals("en", call.lang());
         assertDefaultOptions(call.outputOptions());
+    }
+
+    @Test
+    void returnsDefaultHierarchicalChildrenContract() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_CHILDREN_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.numElements").value(1))
+                .andExpect(jsonPath("$.elements[0].iri").value(INDIVIDUAL_IRI));
+
+        assertHierarchyDefaults(captureHierarchyCall("children"));
+    }
+
+    @Test
+    void returnsDefaultHierarchicalAncestorsContract() throws Exception {
+        mockMvc.perform(get(HIERARCHICAL_ANCESTORS_URI))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.page").value(0))
+                .andExpect(jsonPath("$.numElements").value(1))
+                .andExpect(jsonPath("$.elements[0].iri").value(INDIVIDUAL_IRI));
+
+        assertHierarchyDefaults(captureHierarchyCall("ancestors"));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"children", "ancestors"})
+    void bindsEveryHierarchyParameter(String route) throws Exception {
+        mockMvc.perform(get(routeUri(route))
+                        .param("page", "1")
+                        .param("size", "3")
+                        .param("sort", "iri,desc")
+                        .param("includeObsoleteEntities", "true")
+                        .param("lang", "fr")
+                        .param("resolveReferences", "true")
+                        .param("manchesterSyntax", "true"))
+                .andExpect(status().isOk());
+
+        HierarchyCall call = captureHierarchyCall(route);
+        assertEquals("efo", call.ontologyId());
+        assertEquals(INDIVIDUAL_IRI, call.individualIri());
+        assertPage(call.pageable(), 1, 3);
+        assertEquals("iri: DESC", call.pageable().getSort().toString());
+        assertTrue(call.includeObsoleteEntities());
+        assertEquals("fr", call.lang());
+        assertTrue(call.outputOptions().resolveReferences);
+        assertTrue(call.outputOptions().manchesterSyntax);
     }
 
     @Test
@@ -411,7 +504,7 @@ class V2IndividualControllerWIT {
     }
 
     @ParameterizedTest
-    @CsvSource({"ontology", "single", "class"})
+    @CsvSource({"ontology", "single", "class", "children", "ancestors"})
     void returnsStableBadRequestForInvalidOntologyIdentifier(String route) throws Exception {
         IllegalArgumentException error =
                 new IllegalArgumentException("Invalid ontology ID: efo/unsafe");
@@ -422,8 +515,16 @@ class V2IndividualControllerWIT {
         } else if (route.equals("single")) {
             when(individualRepository.getByOntologyIdAndIri(any(), any(), any(), any()))
                     .thenThrow(error);
-        } else {
+        } else if (route.equals("class")) {
             when(individualRepository.getIndividualsOfClass(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else if (route.equals("children")) {
+            when(individualRepository.getHierarchicalChildrenByOntologyId(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else {
+            when(individualRepository.getHierarchicalAncestorsByOntologyId(
                     any(), any(), any(), anyBoolean(), any(), any()))
                     .thenThrow(error);
         }
@@ -432,8 +533,12 @@ class V2IndividualControllerWIT {
             case "ontology" -> uri("/api/v2/ontologies/efo%252Funsafe/individuals");
             case "single" -> uri("/api/v2/ontologies/efo%252Funsafe/individuals/"
                     + "http%253A%252F%252Fexample.org%252FEFO_I100");
-            default -> uri("/api/v2/ontologies/efo%252Funsafe/classes/"
+            case "class" -> uri("/api/v2/ontologies/efo%252Funsafe/classes/"
                     + "http%253A%252F%252Fexample.org%252FEFO_0001/individuals");
+            case "children" -> uri("/api/v2/ontologies/efo%252Funsafe/individuals/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_I100/hierarchicalChildren");
+            default -> uri("/api/v2/ontologies/efo%252Funsafe/individuals/"
+                    + "http%253A%252F%252Fexample.org%252FEFO_I100/hierarchicalAncestors");
         };
 
         mockMvc.perform(get(invalid))
@@ -444,7 +549,7 @@ class V2IndividualControllerWIT {
     }
 
     @ParameterizedTest
-    @CsvSource({"global", "ontology", "single", "class"})
+    @CsvSource({"global", "ontology", "single", "class", "children", "ancestors"})
     void returnsStableBadRequestForInvalidLanguage(String route) throws Exception {
         IllegalArgumentException error = new IllegalArgumentException("Invalid language: en_US");
         if (route.equals("global")) {
@@ -458,8 +563,16 @@ class V2IndividualControllerWIT {
         } else if (route.equals("single")) {
             when(individualRepository.getByOntologyIdAndIri(any(), any(), any(), any()))
                     .thenThrow(error);
-        } else {
+        } else if (route.equals("class")) {
             when(individualRepository.getIndividualsOfClass(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else if (route.equals("children")) {
+            when(individualRepository.getHierarchicalChildrenByOntologyId(
+                    any(), any(), any(), anyBoolean(), any(), any()))
+                    .thenThrow(error);
+        } else {
+            when(individualRepository.getHierarchicalAncestorsByOntologyId(
                     any(), any(), any(), anyBoolean(), any(), any()))
                     .thenThrow(error);
         }
@@ -575,7 +688,29 @@ class V2IndividualControllerWIT {
     private Pageable capturePageable(String route) throws Exception {
         if (route.equals("global")) return captureGlobalListCall().pageable();
         if (route.equals("ontology")) return captureOntologyListCall().listCall().pageable();
-        return captureClassCall().pageable();
+        if (route.equals("class")) return captureClassCall().pageable();
+        return captureHierarchyCall(route).pageable();
+    }
+
+    private HierarchyCall captureHierarchyCall(String route) throws Exception {
+        ArgumentCaptor<String> ontologyId = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Pageable> pageable = ArgumentCaptor.forClass(Pageable.class);
+        ArgumentCaptor<String> individualIri = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<Boolean> includeObsoleteEntities = ArgumentCaptor.forClass(Boolean.class);
+        ArgumentCaptor<String> lang = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<JsonTransformOptions> options = ArgumentCaptor.forClass(JsonTransformOptions.class);
+        if (route.equals("children")) {
+            verify(individualRepository).getHierarchicalChildrenByOntologyId(
+                    ontologyId.capture(), pageable.capture(), individualIri.capture(),
+                    includeObsoleteEntities.capture(), lang.capture(), options.capture());
+        } else {
+            verify(individualRepository).getHierarchicalAncestorsByOntologyId(
+                    ontologyId.capture(), pageable.capture(), individualIri.capture(),
+                    includeObsoleteEntities.capture(), lang.capture(), options.capture());
+        }
+        return new HierarchyCall(
+                ontologyId.getValue(), individualIri.getValue(), pageable.getValue(),
+                includeObsoleteEntities.getValue(), lang.getValue(), options.getValue());
     }
 
     private static URI routeUri(String route) {
@@ -583,8 +718,20 @@ class V2IndividualControllerWIT {
             case "global" -> uri("/api/v2/individuals");
             case "ontology" -> uri("/api/v2/ontologies/efo/individuals");
             case "class" -> CLASS_INDIVIDUALS_URI;
+            case "children" -> HIERARCHICAL_CHILDREN_URI;
+            case "ancestors" -> HIERARCHICAL_ANCESTORS_URI;
             default -> throw new IllegalArgumentException("Unknown route: " + route);
         };
+    }
+
+    private static void assertHierarchyDefaults(HierarchyCall call) {
+        assertEquals("efo", call.ontologyId());
+        assertEquals(INDIVIDUAL_IRI, call.individualIri());
+        assertPage(call.pageable(), 0, 20);
+        assertTrue(call.pageable().getSort().isUnsorted());
+        assertFalse(call.includeObsoleteEntities());
+        assertEquals("en", call.lang());
+        assertDefaultOptions(call.outputOptions());
     }
 
     private static void assertListDefaults(ListCall call) {
@@ -631,6 +778,10 @@ class V2IndividualControllerWIT {
                 List.of(individualJson()), Map.of(), PageRequest.of(0, 20), 1);
     }
 
+    private static PageImpl<JsonElement> hierarchyPage() {
+        return new PageImpl<>(List.of(individualJson()), PageRequest.of(0, 20), 1);
+    }
+
     private static V2Entity individualEntity() {
         return new V2Entity(individualJson());
     }
@@ -674,6 +825,15 @@ class V2IndividualControllerWIT {
     private record ClassCall(
             String ontologyId,
             String classIri,
+            Pageable pageable,
+            boolean includeObsoleteEntities,
+            String lang,
+            JsonTransformOptions outputOptions) {
+    }
+
+    private record HierarchyCall(
+            String ontologyId,
+            String individualIri,
             Pageable pageable,
             boolean includeObsoleteEntities,
             String lang,

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/IndividualRepositoryIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/IndividualRepositoryIT.java
@@ -4,6 +4,7 @@ import com.google.gson.JsonElement;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.testcontainers.containers.PostgreSQLContainer;
@@ -152,6 +153,24 @@ class IndividualRepositoryIT {
     }
 
     @Test
+    void returnsIndividualHierarchyAndCanIncludeObsoleteChildren() {
+        PageRequest page = PageRequest.of(0, 20);
+        JsonTransformOptions options = new JsonTransformOptions();
+
+        Page<JsonElement> active = repository.getHierarchicalChildrenByOntologyId(
+                "efo", page, EFO_INDIVIDUAL, false, "en", options);
+        Page<JsonElement> all = repository.getHierarchicalChildrenByOntologyId(
+                "efo", page, EFO_INDIVIDUAL, true, "en", options);
+        Page<JsonElement> ancestors = repository.getHierarchicalAncestorsByOntologyId(
+                "efo", page, SECOND_EFO_INDIVIDUAL, false, "en", options);
+
+        assertThat(iris(active)).containsExactly(SECOND_EFO_INDIVIDUAL);
+        assertThat(iris(all)).containsExactly(
+                SECOND_EFO_INDIVIDUAL, OBSOLETE_EFO_INDIVIDUAL);
+        assertThat(iris(ancestors)).containsExactly(EFO_INDIVIDUAL);
+    }
+
+    @Test
     void validatesLanguageAndOntologyIdentifiersForEveryRepositoryRoute() {
         PageRequest page = PageRequest.of(0, 20);
         JsonTransformOptions options = new JsonTransformOptions();
@@ -166,6 +185,18 @@ class IndividualRepositoryIT {
                 .isInstanceOf(IllegalArgumentException.class);
         assertThatThrownBy(() -> repository.getIndividualsOfClass(
                 "efo", LIVER_CLASS, page, false, "en_US", options))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repository.getHierarchicalChildrenByOntologyId(
+                "efo/unsafe", page, EFO_INDIVIDUAL, false, "en", options))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repository.getHierarchicalChildrenByOntologyId(
+                "efo", page, EFO_INDIVIDUAL, false, "en_US", options))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repository.getHierarchicalAncestorsByOntologyId(
+                "efo/unsafe", page, SECOND_EFO_INDIVIDUAL, false, "en", options))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> repository.getHierarchicalAncestorsByOntologyId(
+                "efo", page, SECOND_EFO_INDIVIDUAL, false, "en_US", options))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -192,7 +223,7 @@ class IndividualRepositoryIT {
                 properties, new JsonTransformOptions());
     }
 
-    private static List<String> iris(OlsFacetedResultsPage<JsonElement> page) {
+    private static List<String> iris(Page<JsonElement> page) {
         return page.getContent().stream()
                 .map(element -> element.getAsJsonObject().get("iri").getAsString())
                 .toList();

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -685,11 +685,12 @@ public final class PostgresIntegrationTestSupport {
                 INSERT INTO ols_entities (
                     id, type, iri, ontology_id, _json, is_obsolete, label, search_type,
                     short_form, curie, obo_id, synonym, definition, is_defining_ontology,
-                    subset, related_to, direct_parents, direct_ancestors,
+                    subset, related_to, direct_parents, hierarchical_parents,
+                    direct_ancestors, hierarchical_ancestors,
                     label_for_suggest, filter_tags, filter_domain,
                     "filter_http://example.org/category",
                     "filter_http://www.w3.org/1999/02/22-rdf-syntax-ns#type")
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """;
         try (PreparedStatement statement = connection.prepareStatement(sql)) {
             for (JsonElement element : fixture.getAsJsonArray("records")) {
@@ -711,14 +712,16 @@ public final class PostgresIntegrationTestSupport {
                 statement.setArray(15, textArray(connection, record.getAsJsonArray("subset")));
                 statement.setArray(16, textArray(connection, record.getAsJsonArray("relatedTo")));
                 statement.setArray(17, textArray(connection, record.getAsJsonArray("directParents")));
-                statement.setArray(18, textArray(connection, record.getAsJsonArray("directAncestors")));
-                statement.setString(19, record.getAsJsonArray("label").get(0).getAsString());
-                statement.setArray(20, textArray(connection, record.getAsJsonArray("tags")));
-                statement.setArray(21, textArray(connection, record.getAsJsonArray("domain")));
-                statement.setArray(22, textArray(
+                statement.setArray(18, textArray(connection, record.getAsJsonArray("hierarchicalParents")));
+                statement.setArray(19, textArray(connection, record.getAsJsonArray("directAncestors")));
+                statement.setArray(20, textArray(connection, record.getAsJsonArray("hierarchicalAncestors")));
+                statement.setString(21, record.getAsJsonArray("label").get(0).getAsString());
+                statement.setArray(22, textArray(connection, record.getAsJsonArray("tags")));
+                statement.setArray(23, textArray(connection, record.getAsJsonArray("domain")));
+                statement.setArray(24, textArray(
                         connection,
                         record.getAsJsonArray("http://example.org/category")));
-                statement.setArray(23, textArray(
+                statement.setArray(25, textArray(
                         connection,
                         record.getAsJsonArray("http://www.w3.org/1999/02/22-rdf-syntax-ns#type")));
                 statement.addBatch();

--- a/backend/src/test/resources/fixtures/individuals/individual-fixture.json
+++ b/backend/src/test/resources/fixtures/individuals/individual-fixture.json
@@ -18,9 +18,11 @@
       "directParents": [
         "http://example.org/EFO_0001"
       ],
+      "hierarchicalParents": [],
       "directAncestors": [
         "http://example.org/EFO_0001"
       ],
+      "hierarchicalAncestors": [],
       "tags": ["clinical"],
       "domain": ["biology"],
       "http://example.org/category": ["clinical"],
@@ -65,9 +67,15 @@
       "directParents": [
         "http://example.org/EFO_0002"
       ],
+      "hierarchicalParents": [
+        "http://example.org/EFO_I100"
+      ],
       "directAncestors": [
         "http://example.org/EFO_0001",
         "http://example.org/EFO_0002"
+      ],
+      "hierarchicalAncestors": [
+        "http://example.org/EFO_I100"
       ],
       "tags": ["experimental"],
       "domain": ["biology"],
@@ -91,7 +99,7 @@
           "http://example.org/EFO_0002"
         ],
         "hasDirectParents": true,
-        "hasHierarchicalParents": false,
+        "hasHierarchicalParents": true,
         "linkedEntities": {}
       }
     },
@@ -113,9 +121,11 @@
       "directParents": [
         "http://example.org/DUO_0001"
       ],
+      "hierarchicalParents": [],
       "directAncestors": [
         "http://example.org/DUO_0001"
       ],
+      "hierarchicalAncestors": [],
       "tags": ["policy"],
       "domain": ["information"],
       "http://example.org/category": ["policy"],
@@ -160,8 +170,14 @@
       "directParents": [
         "http://example.org/EFO_0001"
       ],
+      "hierarchicalParents": [
+        "http://example.org/EFO_I100"
+      ],
       "directAncestors": [
         "http://example.org/EFO_0001"
+      ],
+      "hierarchicalAncestors": [
+        "http://example.org/EFO_I100"
       ],
       "tags": ["archived"],
       "domain": ["biology"],
@@ -185,7 +201,7 @@
           "http://example.org/EFO_0001"
         ],
         "hasDirectParents": true,
-        "hasHierarchicalParents": false,
+        "hasHierarchicalParents": true,
         "linkedEntities": {}
       }
     }

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -931,6 +931,52 @@ This is the same category of permanent gap `V2TextTaggerController`'s baseline r
 `ols_text_tagger` binary, and it will remain true for any environment that does not run a real
 embedding service alongside the database.
 
+## Completed V2 individual hierarchy-route coverage
+
+PR #1404 added `GET /api/v2/ontologies/{onto}/individuals/{individual}/hierarchicalChildren` and
+`GET /api/v2/ontologies/{onto}/individuals/{individual}/hierarchicalAncestors` after the original
+V2 individual-controller testing milestone. It added three thin controller IT cases, but the two
+new routes were absent from both `V2IndividualControllerTest` and the exact named
+`V2IndividualControllerWIT` contract suite. This follow-up closes that route-level gap without
+duplicating the existing controller ITs.
+
+Verified locally on 2026-09-11 from `origin/dev` commit `3a8f66a6c` with Java 17 and Rancher
+Desktop:
+
+- Surefire runs 959 tests, including 8 direct `V2IndividualControllerTest` cases and 98
+  `V2IndividualControllerWIT` invocations. The two new direct tests prove single decoding and exact
+  repository delegation for both routes. The 34 new WIT invocations cover both routes' default and
+  explicit response contracts, double-encoded individual IRIs, every supported query parameter,
+  pagination normalization and malformed-number defaults, ascending/descending and unsupported
+  sort values, malformed booleans, and stable ontology/language validation errors. Two complete
+  Docker-free runs took wall-clock 23.68 and 24.42 seconds.
+- Failsafe runs 205 PostgreSQL tests. `IndividualRepositoryIT` now has 8 cases; its new hierarchy
+  case proves active/obsolete filtering for hierarchical children plus ancestor traversal, and its
+  existing validation matrix now covers both hierarchy repository methods. The 7 existing
+  `V2IndividualControllerIT` cases remain the thin end-to-end path through the real controller,
+  repository, and production PostgreSQL schema. Two complete database-gate runs took wall-clock
+  114.10 and 119.25 seconds.
+- The clean `verify` lifecycle runs all 1,164 tests in wall-clock 129.77 seconds. Whole-backend
+  JaCoCo coverage is 70.9% lines (3,410 of 4,808) and 53.2% branches (1,021 of 1,918), unchanged
+  from the post-#1404 baseline because its controller ITs already executed the new production
+  methods. `V2IndividualController` covers all 29 executable lines and all 6 branches;
+  `IndividualRepository` covers 62 of 63 lines and 11 of 14 branches. No coverage threshold is
+  introduced.
+- The committed individual fixture now owns `hierarchicalParents` and `hierarchicalAncestors` for
+  every record, and `PostgresIntegrationTestSupport` loads those arrays into the production
+  columns. `V2IndividualControllerIT` therefore no longer mutates its private database with a
+  second handwritten SQL hierarchy fixture; controller and repository ITs share one explicit,
+  reviewable source of relationship data.
+- No production defect was discovered. The gap was in test-layer completeness introduced by the
+  later feature PR, not in the behavior of either hierarchy endpoint. `test_api.sh` was not changed
+  or run; full dataload-to-deployed-API comparison remains the system-regression layer.
+
+The accompanying inventory audit also records three special surfaces outside this focused
+follow-up: `CustomErrorController` and `V1ApiUnavailable` still have no dedicated layered suites,
+while `GlobalExceptionHandler` is shared by 34 test classes and currently covers 17 of 22 lines and
+8 of 10 branches. Those surfaces should be scoped independently rather than bundled with the V2
+individual hierarchy contract.
+
 ## Out of scope for the pilot
 
 - Connecting GitHub-hosted CI to production or internal databases.


### PR DESCRIPTION
## Summary

- add direct controller coverage for both V2 individual hierarchy routes
- extend the exact V2IndividualControllerWIT suite across routing, decoding, parameters, pagination, sort, and stable errors
- add real PostgreSQL repository assertions for hierarchy traversal and obsolete filtering
- move hierarchy relationships into the committed individual fixture so repository and controller ITs share one source of truth
- document the post-PR #1404 route-completeness follow-up and measured baseline

## Local verification

Java 17 with Rancher Desktop and the production PostgreSQL schema:

- focused Test + WIT: 106 passed
- focused IndividualRepositoryIT + V2IndividualControllerIT: 15 passed
- Docker-free full suite, repeated: 959 passed in 23.68s and 24.42s wall-clock
- PostgreSQL integration gate, repeated: 205 passed in 114.10s and 119.25s wall-clock
- clean verify: 1,164 passed in 129.77s wall-clock
- JaCoCo: 3,410/4,808 lines (70.9%), 1,021/1,918 branches (53.2%)
- V2IndividualController: 29/29 lines, 6/6 branches
- IndividualRepository: 62/63 lines, 11/14 branches

No production defect was found. test_api.sh is unchanged and was not run locally; downstream CI remains the system-regression gate.