### PR TITLE
test: cover EmbeddingServiceClient

### DIFF
--- a/backend/src/test/java/uk/ac/ebi/spot/ols/service/EmbeddingServiceClientIT.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/service/EmbeddingServiceClientIT.java
@@ -1,0 +1,134 @@
+package uk.ac.ebi.spot.ols.service;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.PostgreSQLContainer;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport;
+import uk.ac.ebi.spot.ols.testsupport.PostgresIntegrationTestSupport.EmbeddingServiceClientRepositoryHandle;
+
+import java.lang.reflect.Field;
+import java.nio.charset.StandardCharsets;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+/**
+ * Real-Postgres coverage of {@link EmbeddingServiceClient#init()}/{@code loadPcaModels()} — the one
+ * part of this class that is genuinely Postgres-backed (see
+ * {@code EmbeddingServiceClientTest}'s class-level Javadoc for the HTTP-seam-based unit coverage of
+ * everything else: {@code applyPca}, response parsing, and {@code getAvailableModels()} filtering,
+ * all of which are pure logic once a {@code PcaModel} is present and need no database).
+ *
+ * <p>{@link PostgresIntegrationTestSupport#initializeEmbeddingServiceClientDatabase} loads two rows
+ * into {@code ols_pca_models}: {@code embedding_service_client_test_model_pca2} (matches
+ * {@code PCA_PATTERN}) and {@code embedding_service_client_test_model_full} (does not). This class
+ * proves both the regex-match and regex-no-match branches of {@code loadPcaModels()}'s per-row loop
+ * by reflecting into the resulting private {@code pcaModels} map after a single real
+ * {@code init()} call — there is no public getter, so a small, explicit white-box read is used
+ * rather than duplicating one in production code purely for testability.
+ */
+class EmbeddingServiceClientIT {
+
+    private static PostgreSQLContainer<?> container;
+    private static EmbeddingServiceClientRepositoryHandle handle;
+
+    @BeforeAll
+    static void setUpDatabase() {
+        container = PostgresIntegrationTestSupport.newContainer();
+        container.start();
+        PostgresIntegrationTestSupport.initializeEmbeddingServiceClientDatabase(container);
+        handle = PostgresIntegrationTestSupport.createEmbeddingServiceClientRepositories(container);
+    }
+
+    @AfterAll
+    static void tearDownDatabase() {
+        if (handle != null) {
+            handle.close();
+        }
+        if (container != null) {
+            container.stop();
+        }
+    }
+
+    @Test
+    void loadsPcaModelMatchingTheNamingPattern() throws Exception {
+        Object pcaModel = pcaModelFor("embedding_service_client_test_model_pca2");
+        assertNotNull(pcaModel, "expected a loaded PcaModel for the _pca2-suffixed fixture row");
+
+        assertEquals("embedding_service_client_test_model", readPrivateField(pcaModel, "baseModelName"));
+        assertEquals(2, readPrivateField(pcaModel, "nComponents"));
+        assertEquals(3, ((double[]) readPrivateField(pcaModel, "mean")).length);
+    }
+
+    @Test
+    void skipsRowsWhoseNameDoesNotMatchTheNamingPattern() throws Exception {
+        assertNull(
+                pcaModelFor("embedding_service_client_test_model_full"),
+                "a name without a _pca<digits> suffix must never become a loaded PcaModel");
+
+        assertEquals(
+                1, pcaModels().size(),
+                "only the one matching fixture row should have produced a loaded PCA model");
+    }
+
+    /**
+     * {@code loadPcaModels()} wraps its entire query+parse loop in one {@code try/catch(Exception)}
+     * (not a per-row one), so a row whose {@code model} bytes are not valid JSON aborts the whole
+     * load. Proves that failure is caught and logged rather than propagating out of
+     * {@code @PostConstruct init()} -- which would otherwise fail application startup -- and that no
+     * partial/corrupt model is left in the map. Uses its own disposable container, started and
+     * stopped within the test, rather than the class-shared one: poisoning the shared container's
+     * single valid {@code _pca2} row would break the two tests above.
+     */
+    @Test
+    void initSwallowsAMalformedModelRowWithoutThrowing() throws Exception {
+        PostgreSQLContainer<?> brokenContainer = PostgresIntegrationTestSupport.newContainer();
+        brokenContainer.start();
+        try {
+            PostgresIntegrationTestSupport.initializeDatabase(brokenContainer);
+            try (Connection connection = brokenContainer.createConnection("");
+                    PreparedStatement statement = connection.prepareStatement(
+                            "INSERT INTO ols_pca_models (name, model) VALUES (?, ?)")) {
+                statement.setString(1, "broken_model_pca4");
+                statement.setBytes(2, "not valid json".getBytes(StandardCharsets.UTF_8));
+                statement.executeUpdate();
+            }
+
+            // createEmbeddingServiceClientRepositories() calls init() -> loadPcaModels() internally;
+            // reaching the assertion below at all (no exception propagated up through this test)
+            // already proves the malformed row's Gson parse failure was caught, not thrown.
+            EmbeddingServiceClientRepositoryHandle brokenHandle =
+                    PostgresIntegrationTestSupport.createEmbeddingServiceClientRepositories(brokenContainer);
+            try {
+                @SuppressWarnings("unchecked")
+                Map<String, Object> pcaModels = (Map<String, Object>)
+                        readPrivateField(brokenHandle.embeddingServiceClient(), "pcaModels");
+                assertEquals(0, pcaModels.size(), "a malformed row must leave no model loaded");
+            } finally {
+                brokenHandle.close();
+            }
+        } finally {
+            brokenContainer.stop();
+        }
+    }
+
+    private static Object pcaModelFor(String name) throws ReflectiveOperationException {
+        return pcaModels().get(name);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Map<String, Object> pcaModels() throws ReflectiveOperationException {
+        return (Map<String, Object>) readPrivateField(handle.embeddingServiceClient(), "pcaModels");
+    }
+
+    private static Object readPrivateField(Object target, String fieldName) throws ReflectiveOperationException {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/service/EmbeddingServiceClientTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/service/EmbeddingServiceClientTest.java
@@ -1,0 +1,620 @@
+package uk.ac.ebi.spot.ols.service;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.net.InetSocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Direct unit coverage for {@link EmbeddingServiceClient}'s own internals: the unset-URL early
+ * returns, {@code embedTextsFromService}'s binary response parsing (success, missing header, wrong
+ * byte count, non-200 status, malformed header, interrupted request), the real {@code applyPca}
+ * math, and {@code getAvailableModels()}'s response-parsing/PCA-inclusion-filtering logic.
+ *
+ * <p><b>HTTP seam.</b> {@code embeddingServiceUrl} is null/unset in every Spring test context in
+ * this repo (see {@code V2LLMControllerTest}/{@code V2LLMControllerWIT}), which means the real
+ * {@code embedTextsFromService}/{@code getAvailableModels()} HTTP-calling code paths are otherwise
+ * unreachable without a live embedding microservice. Rather than faking the whole class (as the
+ * controller layer already does — see the "V2 LLM-controller baseline" section of
+ * {@code docs/backend-testing-strategy.md}) or reflecting into {@code applyPca} directly, this class
+ * stands up a real {@code com.sun.net.httpserver.HttpServer} bound to {@code 127.0.0.1} on an
+ * ephemeral port as a fake embedding microservice, and points the real, unmodified
+ * {@link EmbeddingServiceClient} at it via {@code ReflectionTestUtils.setField} — the same
+ * private-field-injection idiom already used throughout
+ * {@code PostgresIntegrationTestSupport} (e.g. wiring {@code EmbeddingServiceClient.postgresClient}
+ * for the V2 LLM controller-IT fixture) — rather than a new mechanism. This exercises the real HTTP
+ * request/response code, the real binary little-endian float parsing, and the real {@code applyPca}
+ * mean-centered dot product end to end, not a mock standing in for any of it.
+ *
+ * <p><b>PCA model injection.</b> {@code loadPcaModels()} itself is real, Postgres-backed logic
+ * (covered separately by {@code EmbeddingServiceClientIT} against a disposable database) and is
+ * deliberately not re-exercised here. To reach {@code applyPca} and the PCA branches of
+ * {@code embedTexts}/{@code getAvailableModels()} without a database, this class uses plain
+ * {@code java.lang.reflect} to construct the private {@code EmbeddingServiceClient.PcaModel} nested
+ * type directly and insert it into the private {@code pcaModels} map — a small, explicit
+ * white-box step, not a stand-in for the class's real behaviour once a model is present.
+ */
+class EmbeddingServiceClientTest {
+
+    private HttpServer server;
+
+    @AfterEach
+    void tearDown() {
+        if (server != null) {
+            server.stop(0);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Unset embeddingServiceUrl: early returns (no HTTP seam needed)
+    // ------------------------------------------------------------------
+
+    @Test
+    void getAvailableModelsReturnsEmptyListWhenUrlIsNull() {
+        EmbeddingServiceClient client = new EmbeddingServiceClient();
+        // embeddingServiceUrl left at its default (null): never explicitly set.
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void getAvailableModelsReturnsEmptyListWhenUrlIsEmpty() {
+        EmbeddingServiceClient client = new EmbeddingServiceClient();
+        ReflectionTestUtils.setField(client, "embeddingServiceUrl", "");
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void embedTextThrowsWhenUrlIsNull() {
+        EmbeddingServiceClient client = new EmbeddingServiceClient();
+
+        IOException exception = assertThrows(IOException.class, () -> client.embedText("model-a", "hello"));
+        assertEquals("Embedding service URL is not configured", exception.getMessage());
+    }
+
+    @Test
+    void embedTextsThrowsWhenUrlIsEmpty() {
+        EmbeddingServiceClient client = new EmbeddingServiceClient();
+        ReflectionTestUtils.setField(client, "embeddingServiceUrl", "");
+
+        IOException exception = assertThrows(
+                IOException.class, () -> client.embedTexts("model-a", List.of("hello")));
+        assertEquals("Embedding service URL is not configured", exception.getMessage());
+    }
+
+    // ------------------------------------------------------------------
+    // embedTextsFromService: success path (binary response parsing)
+    // ------------------------------------------------------------------
+
+    @Test
+    void embedTextReturnsSingleParsedEmbedding() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 3;
+        handler.embeddings = new float[][] {{1.5f, -2.25f, 100.0f}};
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        float[] result = client.embedText("model-a", "hello");
+
+        assertArrayEquals(new float[] {1.5f, -2.25f, 100.0f}, result, 0.0f);
+        assertEquals("model-a", handler.capturedModel);
+        assertEquals(1, handler.capturedTextCount);
+    }
+
+    @Test
+    void embedTextsParsesMultipleRowsInOrder() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 2;
+        handler.embeddings = new float[][] {{1.0f, 2.0f}, {3.0f, 4.0f}, {-5.5f, 6.75f}};
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        float[][] result = client.embedTexts("model-a", List.of("one", "two", "three"));
+
+        assertEquals(3, result.length);
+        assertArrayEquals(new float[] {1.0f, 2.0f}, result[0], 0.0f);
+        assertArrayEquals(new float[] {3.0f, 4.0f}, result[1], 0.0f);
+        assertArrayEquals(new float[] {-5.5f, 6.75f}, result[2], 0.0f);
+        assertEquals(3, handler.capturedTextCount);
+    }
+
+    // ------------------------------------------------------------------
+    // embedTextsFromService: error paths
+    // ------------------------------------------------------------------
+
+    @Test
+    void embedTextThrowsWhenDimensionHeaderIsMissing() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = null; // omit x-embedding-dim entirely
+        handler.body = new byte[0];
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        IOException exception = assertThrows(IOException.class, () -> client.embedText("model-a", "hello"));
+        assertEquals("Missing x-embedding-dim header in response", exception.getMessage());
+    }
+
+    @Test
+    void embedTextThrowsWhenResponseByteCountDoesNotMatchDeclaredDimension() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 4; // declares 4 floats (16 bytes) but the body only has 2 floats' worth
+        handler.body = encodeFloats(1.0f, 2.0f);
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        IOException exception = assertThrows(IOException.class, () -> client.embedText("model-a", "hello"));
+        assertTrue(exception.getMessage().contains("Unexpected response size"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("8 bytes"), exception.getMessage());
+        assertTrue(exception.getMessage().contains("expected 16 bytes"), exception.getMessage());
+    }
+
+    @Test
+    void embedTextThrowsWithBodyWhenServiceReturnsNon200() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.statusCode = 503;
+        handler.errorBody = "embedding backend unavailable";
+        startServer(handler, null);
+        String url = baseUrl();
+
+        EmbeddingServiceClient client = newClientPointedAt(url);
+
+        IOException exception = assertThrows(IOException.class, () -> client.embedText("model-a", "hello"));
+        assertTrue(exception.getMessage().contains("HTTP 503"), exception.getMessage());
+        assertTrue(exception.getMessage().contains(url), exception.getMessage());
+        assertTrue(exception.getMessage().contains("embedding backend unavailable"), exception.getMessage());
+    }
+
+    @Test
+    void embedTextThrowsWhenDimensionHeaderIsNotANumber() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimensionHeaderOverride = "not-a-number";
+        handler.body = new byte[0];
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        IOException exception = assertThrows(IOException.class, () -> client.embedText("model-a", "hello"));
+        assertEquals("Invalid dimension in x-embedding-dim header", exception.getMessage());
+        assertInstanceOf(NumberFormatException.class, exception.getCause());
+    }
+
+    @Test
+    void interruptedRequestSurfacesAsIOExceptionWithInterruptedCause() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 1;
+        handler.embeddings = new float[][] {{1.0f}};
+        handler.delayMillis = 3000; // keep httpClient.send() blocked long enough to interrupt it
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        AtomicReference<Throwable> captured = new AtomicReference<>();
+        Thread worker = new Thread(() -> {
+            try {
+                client.embedText("model-a", "hello");
+            } catch (Throwable t) {
+                captured.set(t);
+            }
+        });
+        worker.start();
+        Thread.sleep(500); // let the worker enter the blocking HttpClient.send() call
+        worker.interrupt();
+        worker.join(5000);
+
+        assertFalse(worker.isAlive(), "worker thread should have finished after being interrupted");
+        Throwable thrown = captured.get();
+        assertNotNull(thrown, "expected embedText to surface an exception once interrupted");
+        assertInstanceOf(IOException.class, thrown);
+        assertEquals("Request interrupted", thrown.getMessage());
+        assertInstanceOf(InterruptedException.class, thrown.getCause());
+    }
+
+    // ------------------------------------------------------------------
+    // embedText / embedTexts delegation and PCA vs non-PCA dispatch
+    // ------------------------------------------------------------------
+
+    @Test
+    void embedTextDelegatesToEmbedTextsFirstElement() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 2;
+        handler.embeddings = new float[][] {{9.0f, 8.0f}};
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        assertArrayEquals(new float[] {9.0f, 8.0f}, client.embedText("model-a", "hello"), 0.0f);
+    }
+
+    @Test
+    void nonPcaModelDispatchesModelNameUnchangedAndAppliesNoTransform() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 3;
+        handler.embeddings = new float[][] {{2.0f, 5.0f, 10.0f}};
+        startServer(handler, null);
+
+        // pcaModels map has no entry for "plain-model": embedTexts must send the model name as-is
+        // and return the service's raw embedding, with no PCA transform applied.
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        float[] result = client.embedText("plain-model", "hello");
+
+        assertEquals("plain-model", handler.capturedModel);
+        assertArrayEquals(new float[] {2.0f, 5.0f, 10.0f}, result, 0.0f);
+    }
+
+    /**
+     * Hand-computed PCA fixture shared by the applyPca-math and getAvailableModels-filtering tests
+     * below: mean {@code [1,2,3]}, components {@code [[1,0],[0,1],[1,1]]} (3 features, 2
+     * components). For a raw base-model embedding of {@code [2,5,10]}:
+     * <pre>
+     * j=0: (2-1)*1 + (5-2)*0 + (10-3)*1 = 1 + 0 + 7 = 8
+     * j=1: (2-1)*0 + (5-2)*1 + (10-3)*1 = 0 + 3 + 7 = 10
+     * </pre>
+     * giving expected PCA output {@code [8, 10]}. A second row, the mean itself ({@code [1,2,3]}),
+     * must transform to exactly {@code [0, 0]} (every term's {@code embedding[i] - mean[i]} is zero).
+     */
+    private static final double[] PCA_MEAN = {1.0, 2.0, 3.0};
+    private static final double[][] PCA_COMPONENTS = {{1.0, 0.0}, {0.0, 1.0}, {1.0, 1.0}};
+
+    @Test
+    void pcaModelDispatchesBaseModelNameAndAppliesHandComputedTransform() throws Exception {
+        ScriptedEmbedHandler handler = new ScriptedEmbedHandler();
+        handler.dimension = 3;
+        handler.embeddings = new float[][] {{2.0f, 5.0f, 10.0f}, {1.0f, 2.0f, 3.0f}};
+        startServer(handler, null);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+        putPcaModel(client, "base-model_pca2", "base-model", 2, PCA_MEAN, PCA_COMPONENTS);
+
+        float[][] result = client.embedTexts("base-model_pca2", List.of("hello", "world"));
+
+        // The service must have been called with the PCA model's *base* model name, not the
+        // PCA-suffixed one requested by the caller.
+        assertEquals("base-model", handler.capturedModel);
+        assertEquals(2, handler.capturedTextCount);
+
+        assertArrayEquals(new float[] {8.0f, 10.0f}, result[0], 1e-4f);
+        assertArrayEquals(new float[] {0.0f, 0.0f}, result[1], 1e-4f);
+    }
+
+    // ------------------------------------------------------------------
+    // getAvailableModels(): response parsing and PCA-inclusion filtering
+    // ------------------------------------------------------------------
+
+    @Test
+    void getAvailableModelsReturnsEmptyListWhenTheServiceIsUnreachable() throws Exception {
+        // embeddingServiceUrl points at a loopback port nothing is listening on, so
+        // httpClient.send() throws a real IOException ("connection refused"). This exercises
+        // getAvailableModels()'s outer catch(Exception) fallback -- distinct from the unset-URL
+        // early return -- proving the method degrades to an empty list rather than propagating a
+        // network failure. Binding then immediately closing a ServerSocket reserves an ephemeral
+        // port that is guaranteed free (unlike a hardcoded port number) and guaranteed refused
+        // (unlike an HttpServer created but never started, whose socket stays bound and would just
+        // hang instead of refusing the connection).
+        int unusedPort;
+        try (java.net.ServerSocket probe = new java.net.ServerSocket(0)) {
+            unusedPort = probe.getLocalPort();
+        }
+
+        EmbeddingServiceClient client = newClientPointedAt("http://127.0.0.1:" + unusedPort);
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void getAvailableModelsReturnsServiceModelsWhenNoPcaModelsAreLoaded() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.models = List.of("model-a", "model-b");
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        List<String> models = client.getAvailableModels();
+
+        assertEquals(2, models.size());
+        assertTrue(models.contains("model-a"));
+        assertTrue(models.contains("model-b"));
+    }
+
+    @Test
+    void getAvailableModelsIncludesPcaVariantWhenItsBaseModelIsAvailable() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.models = List.of("base-model");
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+        putPcaModel(client, "base-model_pca2", "base-model", 2, PCA_MEAN, PCA_COMPONENTS);
+
+        List<String> models = client.getAvailableModels();
+
+        assertTrue(models.contains("base-model"));
+        assertTrue(models.contains("base-model_pca2"));
+    }
+
+    @Test
+    void getAvailableModelsExcludesPcaVariantWhenItsBaseModelIsUnavailable() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.models = List.of("some-other-model"); // does not include "unavailable-model"
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+        putPcaModel(client, "unavailable-model_pca2", "unavailable-model", 2, PCA_MEAN, PCA_COMPONENTS);
+
+        List<String> models = client.getAvailableModels();
+
+        assertFalse(models.contains("unavailable-model_pca2"));
+    }
+
+    @Test
+    void getAvailableModelsExcludesPca16VariantEvenWhenItsBaseModelIsAvailable() throws Exception {
+        // Covers the first (reachable) pca16 exclusion guard: `!entry.getKey().contains("pca16")` in
+        // the inclusion loop. A second, later `models.removeIf(m -> m.contains("pca16"))` exists in
+        // the production code but is unreachable dead code given this guard already prevents any
+        // pca16-named entry from ever being added -- see the class-level note and
+        // docs/backend-testing-strategy.md's EmbeddingServiceClient baseline for the empirical basis
+        // of that conclusion (not a defect; left as pre-existing per the defect workflow).
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.models = List.of("base-model");
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+        putPcaModel(client, "base-model_pca16", "base-model", 16, PCA_MEAN, PCA_COMPONENTS);
+
+        List<String> models = client.getAvailableModels();
+
+        assertTrue(models.contains("base-model"));
+        assertFalse(models.contains("base-model_pca16"));
+    }
+
+    @Test
+    void getAvailableModelsReturnsEmptyListWhenModelsEndpointReturnsNon200() throws Exception {
+        // Distinct from getAvailableModelsReturnsEmptyListWhenTheServiceIsUnreachable: this is a
+        // real HTTP response, just not status 200, so json parsing is skipped and serviceModels
+        // stays empty -- no exception is thrown, this is not the catch(Exception) branch.
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.statusCode = 503;
+        modelsHandler.rawBody = "unavailable";
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void getAvailableModelsTreatsAMissingModelsKeyAsNoServiceModels() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.rawBody = "{}"; // valid JSON object, but no "models" key at all
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void getAvailableModelsTreatsANonArrayModelsFieldAsNoServiceModels() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.rawBody = "{\"models\": \"not-an-array\"}";
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        assertEquals(List.of(), client.getAvailableModels());
+    }
+
+    @Test
+    void getAvailableModelsSkipsNonPrimitiveModelsArrayElements() throws Exception {
+        ScriptedModelsHandler modelsHandler = new ScriptedModelsHandler();
+        modelsHandler.rawBody = "{\"models\": [\"model-a\", {\"nested\": true}, \"model-b\"]}";
+        startServer(null, modelsHandler);
+
+        EmbeddingServiceClient client = newClientPointedAt(baseUrl());
+
+        List<String> models = client.getAvailableModels();
+
+        assertEquals(2, models.size());
+        assertTrue(models.contains("model-a"));
+        assertTrue(models.contains("model-b"));
+    }
+
+    // ------------------------------------------------------------------
+    // Test infrastructure
+    // ------------------------------------------------------------------
+
+    private String baseUrl() {
+        return "http://127.0.0.1:" + server.getAddress().getPort();
+    }
+
+    private static EmbeddingServiceClient newClientPointedAt(String url) {
+        EmbeddingServiceClient client = new EmbeddingServiceClient();
+        ReflectionTestUtils.setField(client, "embeddingServiceUrl", url);
+        return client;
+    }
+
+    /**
+     * Starts a fake embedding microservice on an ephemeral loopback port. {@code rootHandler}
+     * answers {@code POST /} (the embed endpoint {@code embedTextsFromService} posts to directly at
+     * {@code embeddingServiceUrl}); {@code modelsHandler} answers {@code GET /models}
+     * ({@code getAvailableModels()}'s endpoint). Either may be null if the test does not need it.
+     */
+    private void startServer(HttpHandler rootHandler, HttpHandler modelsHandler) throws IOException {
+        server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+        if (rootHandler != null) {
+            server.createContext("/", rootHandler);
+        }
+        if (modelsHandler != null) {
+            server.createContext("/models", modelsHandler);
+        }
+        server.setExecutor(Executors.newCachedThreadPool());
+        server.start();
+    }
+
+    private static byte[] encodeFloats(float... values) {
+        ByteBuffer buffer = ByteBuffer.allocate(values.length * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (float value : values) {
+            buffer.putFloat(value);
+        }
+        return buffer.array();
+    }
+
+    private static byte[] encodeEmbeddings(float[][] embeddings) {
+        int texts = embeddings.length;
+        int dimension = embeddings[0].length;
+        ByteBuffer buffer = ByteBuffer.allocate(texts * dimension * 4).order(ByteOrder.LITTLE_ENDIAN);
+        for (float[] row : embeddings) {
+            for (float value : row) {
+                buffer.putFloat(value);
+            }
+        }
+        return buffer.array();
+    }
+
+    /**
+     * Constructs the private {@code EmbeddingServiceClient.PcaModel} nested type via reflection and
+     * inserts it into the client's private {@code pcaModels} map. See the class-level Javadoc for why
+     * this white-box step is needed instead of running the real (Postgres-backed) {@code
+     * loadPcaModels()} in this Docker-free test class.
+     */
+    private static void putPcaModel(
+            EmbeddingServiceClient client, String name, String baseModelName, int nComponents,
+            double[] mean, double[][] components) throws ReflectiveOperationException {
+        Class<?> pcaModelClass = Class.forName("uk.ac.ebi.spot.ols.service.EmbeddingServiceClient$PcaModel");
+        Constructor<?> constructor = pcaModelClass.getDeclaredConstructor(
+                String.class, int.class, double[].class, double[][].class);
+        constructor.setAccessible(true);
+        Object pcaModel = constructor.newInstance(baseModelName, nComponents, mean, components);
+
+        Field pcaModelsField = EmbeddingServiceClient.class.getDeclaredField("pcaModels");
+        pcaModelsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> pcaModels = (Map<String, Object>) pcaModelsField.get(client);
+        pcaModels.put(name, pcaModel);
+    }
+
+    /**
+     * Fake embed endpoint (the root {@code "/"} context) that captures the request it received and
+     * answers according to whichever fields the test configured before calling
+     * {@link #startServer}.
+     */
+    private static final class ScriptedEmbedHandler implements HttpHandler {
+        volatile String capturedModel;
+        volatile int capturedTextCount;
+
+        volatile int statusCode = 200;
+        /** Dimension advertised via the x-embedding-dim header; null omits the header entirely. */
+        volatile Integer dimension;
+        /** Overrides the literal header value sent (takes precedence over {@link #dimension}). */
+        volatile String dimensionHeaderOverride;
+        /** Success-path body; ignored if {@link #embeddings} is set. */
+        volatile byte[] body = new byte[0];
+        /** Convenience: when set, {@link #body} and {@link #dimension} are derived from it. */
+        volatile float[][] embeddings;
+        volatile String errorBody = "";
+        volatile long delayMillis;
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            byte[] requestBytes = exchange.getRequestBody().readAllBytes();
+            String requestJson = new String(requestBytes, StandardCharsets.UTF_8);
+            JsonObject request = JsonParser.parseString(requestJson).getAsJsonObject();
+            capturedModel = request.get("model").getAsString();
+            JsonArray texts = request.getAsJsonArray("text");
+            capturedTextCount = texts != null ? texts.size() : 0;
+
+            if (delayMillis > 0) {
+                try {
+                    Thread.sleep(delayMillis);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                }
+            }
+
+            byte[] responseBytes;
+            if (statusCode != 200) {
+                responseBytes = errorBody.getBytes(StandardCharsets.UTF_8);
+            } else if (embeddings != null) {
+                responseBytes = encodeEmbeddings(embeddings);
+            } else {
+                responseBytes = body;
+            }
+
+            if (statusCode == 200) {
+                String headerValue = dimensionHeaderOverride != null
+                        ? dimensionHeaderOverride
+                        : (dimension != null ? String.valueOf(dimension) : null);
+                if (headerValue != null) {
+                    exchange.getResponseHeaders().add("x-embedding-dim", headerValue);
+                }
+            }
+
+            exchange.sendResponseHeaders(statusCode, responseBytes.length);
+            try (OutputStream responseStream = exchange.getResponseBody()) {
+                responseStream.write(responseBytes);
+            }
+        }
+    }
+
+    /**
+     * Fake {@code GET /models} endpoint. By default answers {@code 200 {"models": [...]}} built
+     * from {@link #models}; setting {@link #rawBody} sends that string verbatim instead (for
+     * malformed-response-shape tests), and {@link #statusCode} controls the HTTP status.
+     */
+    private static final class ScriptedModelsHandler implements HttpHandler {
+        volatile List<String> models = List.of();
+        volatile int statusCode = 200;
+        volatile String rawBody;
+
+        @Override
+        public void handle(HttpExchange exchange) throws IOException {
+            String body;
+            if (rawBody != null) {
+                body = rawBody;
+            } else {
+                JsonObject responseJson = new JsonObject();
+                JsonArray modelsArray = new JsonArray();
+                models.forEach(modelsArray::add);
+                responseJson.add("models", modelsArray);
+                body = responseJson.toString();
+            }
+
+            byte[] responseBytes = body.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "application/json");
+            exchange.sendResponseHeaders(statusCode, responseBytes.length);
+            try (OutputStream responseStream = exchange.getResponseBody()) {
+                responseStream.write(responseBytes);
+            }
+        }
+    }
+}

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/testsupport/PostgresIntegrationTestSupport.java
@@ -108,6 +108,23 @@ public final class PostgresIntegrationTestSupport {
     }
 
     /**
+     * Loads two rows into {@code ols_pca_models} for {@code EmbeddingServiceClientIT}: one whose
+     * name matches {@code EmbeddingServiceClient.PCA_PATTERN} ({@code ^(.+)_pca(\d+)$}) and must be
+     * loaded into the client's in-memory PCA model map, and one that does not and must be skipped by
+     * the pattern's {@code continue} branch. No other fixture (ontology/entity/autosuggest) is
+     * relevant to this class, but {@link #initializeDatabase} is still called first because it is
+     * what runs {@link #executeProductionSchema}, which creates the {@code ols_pca_models} table.
+     */
+    public static void initializeEmbeddingServiceClientDatabase(PostgreSQLContainer<?> container) {
+        initializeDatabase(container);
+        try (Connection connection = container.createConnection("")) {
+            loadPcaModelsFixture(connection);
+        } catch (SQLException e) {
+            throw new IllegalStateException("Failed to load the EmbeddingServiceClient integration fixture", e);
+        }
+    }
+
+    /**
      * Loads the shared entity fixture plus the class and property fixtures (both additive to
      * {@code ols_entities}, with no id collisions between them), then adds the {@code V2LLMController}
      * embedding fixture on top. Deliberately does <em>not</em> also load
@@ -192,6 +209,25 @@ public final class PostgresIntegrationTestSupport {
 
         return new V2LLMRepositoryHandle(
                 classRepository, propertyRepository, embeddingServiceClient, olsPostgresClient, postgresClient);
+    }
+
+    /**
+     * Wires the real {@link EmbeddingServiceClient} bean against disposable Postgres carrying the
+     * {@code ols_pca_models} fixture loaded by {@link #initializeEmbeddingServiceClientDatabase}.
+     * Unlike {@link #createV2LLMRepositories} (whose fixture never populates {@code ols_pca_models},
+     * so its client is deliberately returned uninitialized), this factory calls {@code init()}
+     * eagerly so the caller observes the real Postgres-backed {@code loadPcaModels()} result
+     * immediately, before the container/handle are used for assertions.
+     */
+    public static EmbeddingServiceClientRepositoryHandle createEmbeddingServiceClientRepositories(
+            PostgreSQLContainer<?> container) {
+        PostgresClient postgresClient = createPostgresClient(container);
+
+        EmbeddingServiceClient embeddingServiceClient = new EmbeddingServiceClient();
+        ReflectionTestUtils.setField(embeddingServiceClient, "postgresClient", postgresClient);
+        embeddingServiceClient.init();
+
+        return new EmbeddingServiceClientRepositoryHandle(embeddingServiceClient, postgresClient);
     }
 
     public static V1RepositoryHandle createV1Repository(PostgreSQLContainer<?> container) {
@@ -812,6 +848,29 @@ public final class PostgresIntegrationTestSupport {
         }
     }
 
+    /**
+     * Row 1 ({@code embedding_service_client_test_model_pca2}) matches
+     * {@code EmbeddingServiceClient.PCA_PATTERN} and carries a small, hand-computable 3-feature/
+     * 2-component PCA model (mean {@code [1,2,3]}, components {@code [[1,0],[0,1],[1,1]]}). Row 2
+     * ({@code embedding_service_client_test_model_full}) has no {@code _pca<digits>} suffix and must
+     * be skipped by {@code loadPcaModels()}'s regex-filter {@code continue} branch.
+     */
+    private static void loadPcaModelsFixture(Connection connection) throws SQLException {
+        insertPcaModel(connection, "embedding_service_client_test_model_pca2",
+                "{\"mean\":[1.0,2.0,3.0],\"components\":[[1.0,0.0],[0.0,1.0],[1.0,1.0]]}");
+        insertPcaModel(connection, "embedding_service_client_test_model_full",
+                "{\"mean\":[0.0],\"components\":[[1.0]]}");
+    }
+
+    private static void insertPcaModel(Connection connection, String name, String modelJson) throws SQLException {
+        try (PreparedStatement statement = connection.prepareStatement(
+                "INSERT INTO ols_pca_models (name, model) VALUES (?, ?)")) {
+            statement.setString(1, name);
+            statement.setBytes(2, modelJson.getBytes(StandardCharsets.UTF_8));
+            statement.executeUpdate();
+        }
+    }
+
     private static java.sql.Array textArray(Connection connection, JsonArray values) throws SQLException {
         String[] strings = new String[values.size()];
         for (int i = 0; i < values.size(); i++) {
@@ -855,6 +914,16 @@ public final class PostgresIntegrationTestSupport {
             PropertyRepository propertyRepository,
             EmbeddingServiceClient embeddingServiceClient,
             OlsPostgresClient olsPostgresClient,
+            PostgresClient postgresClient) implements AutoCloseable {
+
+        @Override
+        public void close() {
+            postgresClient.close();
+        }
+    }
+
+    public record EmbeddingServiceClientRepositoryHandle(
+            EmbeddingServiceClient embeddingServiceClient,
             PostgresClient postgresClient) implements AutoCloseable {
 
         @Override

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -1118,13 +1118,14 @@ convenience-overload dead code noted in the V2 LLM-controller baseline above —
 not fixed, per the defect workflow (a testing PR must not bundle a fix).
 
 Verified locally on 2026-09-11 with Java 17 and Rancher Desktop, from `origin/dev` commit
-`aa52e09e4`:
+`75d96f57c` (post `AnnotationExtractor` merge, PR #1407 — this branch was rebased onto it since
+both Tier B baselines happened to insert their new section at the same point in this file):
 
-- Surefire runs 982 tests, including 23 direct `EmbeddingServiceClientTest` cases. Two Docker-free
-  runs took wall-clock 13.14 and 14.29 seconds.
+- Surefire runs 1,006 tests, including 23 direct `EmbeddingServiceClientTest` cases. Two
+  Docker-free runs took wall-clock 19.59 and 19.05 seconds.
 - Failsafe runs 208 PostgreSQL tests, including 3 `EmbeddingServiceClientIT` cases. Two complete
-  database-gate runs took wall-clock 123.62 and 138.37 seconds.
-- The clean `verify` lifecycle runs all 1,190 tests in wall-clock 2 minutes 10.42 seconds.
+  database-gate runs took wall-clock 128.24 and 132.19 seconds.
+- The clean `verify` lifecycle runs all 1,214 tests in wall-clock 2 minutes 15.07 seconds.
 - `EmbeddingServiceClient` now covers all 119 of its executable lines (100%, up from 19.3%) and 51
   of its 52 branches (98.1%, up from 7.7%) across all 13 of its methods (100%, up from
   partial). The one remaining missed branch is `embedTextsFromService`'s
@@ -1132,8 +1133,8 @@ Verified locally on 2026-09-11 with Java 17 and Rancher Desktop, from `origin/de
   `HttpResponse.BodyHandlers.ofByteArray()` is documented to always return a byte array (empty, not
   null, for an empty body), so the null case is not reachable through the real JDK `HttpClient`
   without fabricating a response object — a permanent, expected gap, not chased with a mock.
-  Whole-backend JaCoCo coverage is 73.0% lines (3,512 of 4,810) and 55.7% branches (1,068 of 1,918),
-  up from the most recently documented baseline of 70.9% lines and 53.2% branches.
+  Whole-backend JaCoCo coverage is 73.4% lines (3,530 of 4,810) and 56.5% branches (1,084 of 1,918),
+  up from the `AnnotationExtractor` baseline immediately above (71.3% lines, 54.1% branches).
 - No production defect was discovered by this rollout. The pca16 double-filter noted above was
   confirmed to be pre-existing dead code, not a behavioural bug (nothing observable changes whether
   it runs or not), and was left alone per the defect workflow.

--- a/docs/backend-testing-strategy.md
+++ b/docs/backend-testing-strategy.md
@@ -1035,6 +1035,116 @@ Docker gate — this class has no IT layer, per the scope note above):
   coverage failure threshold is introduced.
 - No production defect was discovered by this rollout.
 
+## Implemented EmbeddingServiceClient baseline
+
+`EmbeddingServiceClient` is the second Tier B target completed under this programme's expanded
+scope (repositories, mappers, builders, services, and MCP-tool classes with real logic and zero
+direct tests, worked once the Tier A controller backlog is empty — see
+`.claude/commands/backend-test-coverage.md`'s Tier B methodology and the `AnnotationExtractor`
+baseline above for the first). It was already touched by Tier A
+work: the "V2 LLM-controller baseline" section above wires the real, unconfigured bean directly
+into `V2LLMController` (`getAvailableModels()` degrading to `List.of()` is genuine, non-mocked
+integration behaviour) and a hand-rolled fake subclass at the controller-IT layer for the five
+text-search routes. Neither proves anything about the class's own internals: `applyPca`'s PCA-
+transform math, `loadPcaModels()`'s Postgres-backed model loading, and
+`getAvailableModels()`'s response-parsing/model-filtering logic had never been exercised directly,
+which is exactly why JaCoCo measured the class at 19.3% lines / 7.7% branches despite the
+controller-layer work.
+
+**Shape of this baseline.** Unlike a Tier A controller, this class has no routes, so "done" is a
+direct unit test plus a real-Postgres IT test (per the Tier B "what covered means" methodology),
+not four layers:
+
+- `EmbeddingServiceClientTest` — a plain, Docker-free unit test covering every public method and
+  branch that does not itself require a database.
+- `EmbeddingServiceClientIT` — a disposable-Postgres test covering the one part of this class that
+  is genuinely Postgres-backed: `init()`/`loadPcaModels()`.
+
+**HTTP seam.** `embedTextsFromService`'s binary response parsing and `applyPca`'s real math are only
+reached through `embedTexts()`, which throws immediately when `embeddingServiceUrl` is unset — the
+same state as every Spring test context in this repo (`@Value("${ols.embedding.service.url:#{null}}")`,
+never configured in tests). Rather than reflecting into `applyPca` directly or faking the whole
+class again (which the controller layer already does, and which would prove nothing new), this
+class's `EmbeddingServiceClientTest` stands up a real `com.sun.net.httpserver.HttpServer` bound to
+`127.0.0.1` on an ephemeral port as a fake embedding microservice, and points the real, unmodified
+`EmbeddingServiceClient` at it with `ReflectionTestUtils.setField(client, "embeddingServiceUrl", ...)`
+— the same private-field-injection idiom `PostgresIntegrationTestSupport` already uses throughout
+(including, already, `ReflectionTestUtils.setField(embeddingServiceClient, "postgresClient", ...)`
+in its existing `createV2LLMRepositories` factory), not a new mechanism introduced for this class.
+This exercises the real HTTP request/response code, the real little-endian binary float parsing,
+and the real `applyPca` mean-centered dot product end to end — not a mock standing in for any of
+it. No existing test in this repo stood up a local HTTP server before this; `ReflectionTestUtils`
+for private-field injection was already established precedent, so only the HTTP-server half of this
+approach is new.
+
+**PCA model injection.** `loadPcaModels()` itself is real, Postgres-backed logic, covered separately
+by `EmbeddingServiceClientIT` (below) and deliberately not re-exercised in the unit test. To reach
+`applyPca` and the PCA branches of `embedTexts()`/`getAvailableModels()` without a database,
+`EmbeddingServiceClientTest` uses plain `java.lang.reflect` to construct the class's private static
+nested `PcaModel` type directly (via its declared constructor, made accessible) and insert it into
+the private `pcaModels` map. This is a small, explicit white-box step to set up test state — not a
+stand-in for the class's real behaviour once a model is present, which runs unmodified. `applyPca`'s
+math is verified against a hand-computed expected output for a small, fixed 3-feature/2-component
+model (mean `[1,2,3]`, components `[[1,0],[0,1],[1,1]]`): a raw embedding of `[2,5,10]` transforms to
+exactly `[8,10]`, and the mean itself (`[1,2,3]`) transforms to exactly `[0,0]` (every
+`embedding[i] - mean[i]` term is zero) — both hand-checkable, not approximated.
+
+**Real-Postgres coverage.** `PostgresIntegrationTestSupport` gained
+`initializeEmbeddingServiceClientDatabase` and `createEmbeddingServiceClientRepositories`, following
+the same per-family pattern as `initializeV2LLMDatabase`/`createV2LLMRepositories`. The new fixture
+loads two rows into `ols_pca_models`: `embedding_service_client_test_model_pca2` (matches
+`PCA_PATTERN`, `^(.+)_pca(\d+)$`, with a hand-computable mean/components payload) and
+`embedding_service_client_test_model_full` (does not match — no `_pca<digits>` suffix). Unlike
+`createV2LLMRepositories` (which deliberately returns its `EmbeddingServiceClient` uninitialized
+because its fixture never populates `ols_pca_models`), the new factory calls `init()` eagerly.
+`EmbeddingServiceClientIT` then reflects into the private `pcaModels` map (there is no public
+getter) to assert the matching row produced a loaded model with the exact `baseModelName`/
+`nComponents`/`mean.length` that was inserted, and that the non-matching row produced no entry at
+all (map size `1`, not `2`) — proving both the regex-match and regex-no-match branches of the
+per-row loop empirically, not by reading the source. A third IT case inserts a row with
+deliberately-malformed (non-JSON) `model` bytes into its own disposable container (kept separate
+from the two cases above so a poisoned row can't affect their fixture) and asserts `init()` still
+completes without throwing and leaves no model loaded — proving `loadPcaModels()`'s outer
+`catch (Exception e)` swallows a real Gson parse failure rather than letting it escape
+`@PostConstruct` and fail application startup.
+
+**Dead code, not a defect.** `getAvailableModels()` has two separate pca16-exclusion mechanisms: the
+inclusion loop's `!entry.getKey().contains("pca16")` guard, and a later
+`models.removeIf(m -> m.contains("pca16"))`. `EmbeddingServiceClientTest` proves the first guard
+reachable and effective (`getAvailableModelsExcludesPca16VariantEvenWhenItsBaseModelIsAvailable`);
+the second is structurally unreachable given the first already prevents any pca16-named entry from
+ever being added to the list it operates on. This mirrors the `OlsPostgresClient` 4-/6-arg
+convenience-overload dead code noted in the V2 LLM-controller baseline above — left as pre-existing,
+not fixed, per the defect workflow (a testing PR must not bundle a fix).
+
+Verified locally on 2026-09-11 with Java 17 and Rancher Desktop, from `origin/dev` commit
+`aa52e09e4`:
+
+- Surefire runs 982 tests, including 23 direct `EmbeddingServiceClientTest` cases. Two Docker-free
+  runs took wall-clock 13.14 and 14.29 seconds.
+- Failsafe runs 208 PostgreSQL tests, including 3 `EmbeddingServiceClientIT` cases. Two complete
+  database-gate runs took wall-clock 123.62 and 138.37 seconds.
+- The clean `verify` lifecycle runs all 1,190 tests in wall-clock 2 minutes 10.42 seconds.
+- `EmbeddingServiceClient` now covers all 119 of its executable lines (100%, up from 19.3%) and 51
+  of its 52 branches (98.1%, up from 7.7%) across all 13 of its methods (100%, up from
+  partial). The one remaining missed branch is `embedTextsFromService`'s
+  `response.body() != null ? ... : "(empty)"` fallback in the non-200 error-message branch:
+  `HttpResponse.BodyHandlers.ofByteArray()` is documented to always return a byte array (empty, not
+  null, for an empty body), so the null case is not reachable through the real JDK `HttpClient`
+  without fabricating a response object — a permanent, expected gap, not chased with a mock.
+  Whole-backend JaCoCo coverage is 73.0% lines (3,512 of 4,810) and 55.7% branches (1,068 of 1,918),
+  up from the most recently documented baseline of 70.9% lines and 53.2% branches.
+- No production defect was discovered by this rollout. The pca16 double-filter noted above was
+  confirmed to be pre-existing dead code, not a behavioural bug (nothing observable changes whether
+  it runs or not), and was left alone per the defect workflow.
+
+**Permanent limitation.** As recorded in the V2 LLM-controller baseline above, genuine
+embedding-service HTTP behaviour from a real embedding model is not and cannot be exercised in this
+test environment. This baseline's local `HttpServer` fake proves the real request/response-handling
+*code* end to end (parsing, error handling, PCA math), which is new; it does not and cannot prove
+what a real embedding microservice actually returns for real text, which remains permanently out of
+reach here, as it was for the controller layer.
+
 ## Out of scope for the pilot
 
 - Connecting GitHub-hosted CI to production or internal databases.


### PR DESCRIPTION
## Summary

- Second Tier B (non-controller) target in the backend testing programme (`docs/backend-testing-strategy.md`), following `AnnotationExtractor` (#1407). Target: `EmbeddingServiceClient` (`service/EmbeddingServiceClient.java`).
- Already touched by Tier A work (the "V2 LLM-controller baseline" section): the real, unconfigured bean is wired directly into `V2LLMController` (`getAvailableModels()` degrading to `List.of()` is genuine integration behaviour), and a hand-rolled fake subclass stands in for the whole class at the controller-IT layer for the five text-search routes. Neither proves anything about the class's own internals — `applyPca`'s PCA-transform math, `loadPcaModels()`'s Postgres-backed model loading, and `getAvailableModels()`'s response-parsing/filtering logic had never been exercised directly, which is why JaCoCo measured the class at 19.3% lines / 7.7% branches despite the controller-layer work.

## Scope: unit + real-Postgres IT

Unlike `AnnotationExtractor`, this class does talk to Postgres (`loadPcaModels()`), so it gets both layers:

- `EmbeddingServiceClientTest` (Docker-free unit test) — everything that doesn't itself need a database.
- `EmbeddingServiceClientIT` (disposable Postgres) — `init()`/`loadPcaModels()`'s real query-and-parse loop.

## HTTP seam

`embedTextsFromService`'s binary response parsing and `applyPca`'s real math are only reached through `embedTexts()`, which throws immediately when `embeddingServiceUrl` is unset (the state of every Spring test context in this repo). Rather than reflecting into `applyPca` directly or faking the whole class again, `EmbeddingServiceClientTest` stands up a real `com.sun.net.httpserver.HttpServer` on an ephemeral loopback port as a fake embedding microservice, and points the real, unmodified `EmbeddingServiceClient` at it via `ReflectionTestUtils.setField(client, "embeddingServiceUrl", ...)` — the same private-field-injection idiom `PostgresIntegrationTestSupport` already uses throughout (it already does this exact thing for `EmbeddingServiceClient.postgresClient` in `createV2LLMRepositories`). This exercises the real HTTP request/response code, the real little-endian binary float parsing, and the real `applyPca` mean-centered dot product end to end. To reach the PCA branches without a database, the test also uses plain `java.lang.reflect` to construct the class's private `PcaModel` nested type and insert it into the private `pcaModels` map — a small white-box setup step, not a stand-in for real behaviour once a model is present. `applyPca`'s math is checked against a hand-computed expected output (mean `[1,2,3]`, components `[[1,0],[0,1],[1,1]]`, embedding `[2,5,10]` → `[8,10]`; the mean itself → `[0,0]`).

## Branches enumerated

Unset-URL early return in both `getAvailableModels()` and `embedTextsFromService`; `getAvailableModels()`'s non-200 response, missing-key, non-array-`models`, non-primitive-element, and unreachable-service (`catch(Exception)`) branches; PCA-inclusion-when-base-available, PCA-exclusion-when-base-unavailable, and the `pca16`-exclusion guard (with the later `models.removeIf(...)` confirmed as pre-existing dead code given the guard already prevents any `pca16` entry from being added — not fixed, per the defect workflow); `embedText`/`embedTexts` delegation and PCA vs. non-PCA dispatch; `embedTextsFromService`'s success path (single and multiple texts), missing-header, wrong-byte-count, non-200-with-body, malformed-header `NumberFormatException`, and a real interrupted-request `InterruptedException` (triggered by interrupting a worker thread blocked in a deliberately slow fake response). `loadPcaModels()`'s regex-match and regex-no-match rows, plus a malformed-JSON row proving the outer `catch(Exception)` swallows a parse failure without failing `@PostConstruct init()` — all three via `EmbeddingServiceClientIT` against real disposable Postgres.

## Local verification (Java 17, Rancher Desktop)

Verified from `origin/dev` commit `75d96f57c` (post-#1407 merge; this branch was rebased onto it since both Tier B baselines inserted their doc section at the same point). Pass/fail counts read from the actual `target/surefire-reports`/`target/failsafe-reports` `.txt` files, not just exit codes.

- Docker-free `mvn test`, run twice: 1,006/1,006 pass both times, wall-clock 19.59s and 19.05s.
- Postgres/IT gate, run twice: 208/208 pass both times, wall-clock 128.24s and 132.19s.
- Clean `mvn clean verify -Dapi.version=1.44`: 1,214/1,214 pass (1,006 surefire + 208 failsafe), wall-clock 2m15.07s.

## Coverage (JaCoCo, from the clean verify run)

- `EmbeddingServiceClient`: 119/119 lines (100%, up from 19.3%), 51/52 branches (98.1%, up from 7.7%), 13/13 methods (100%). The one remaining missed branch (`response.body() != null ? ... : "(empty)"` in the non-200 error path) is permanently unreachable: `HttpResponse.BodyHandlers.ofByteArray()` is documented to always return a byte array, never null.
- Whole-backend: 73.4% lines (3,530/4,810), 56.5% branches (1,084/1,918) — up from the `AnnotationExtractor` baseline (71.3%/54.1%). No repository-wide threshold introduced.

Baseline recorded in `docs/backend-testing-strategy.md` under "Implemented EmbeddingServiceClient baseline", including the HTTP-seam rationale and mock/real boundary.

## Defects

None found. The `pca16` double-filter (see Branches enumerated) is confirmed pre-existing dead code, not a behavioural bug — left alone per the defect workflow.

## Graphify

`graphify update .` refreshed the local graph (AST-only, no LLM cost).

## Not run locally

- `test_api.sh` full system regression (CI-only; unaffected — no production code changed).

This PR is **not to be merged** without explicit go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
