### PR TITLE
fix: throw ResourceNotFoundException instead of NPE in McpSearchService.fetch

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/controller/mcp/McpSearchService.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/controller/mcp/McpSearchService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.gson.Gson;
 
+import uk.ac.ebi.spot.ols.controller.api.exception.ResourceNotFoundException;
 import uk.ac.ebi.spot.ols.model.mcp.McpFetchResult;
 import uk.ac.ebi.spot.ols.model.mcp.McpSearchResult;
 import uk.ac.ebi.spot.ols.repository.EntityRepository;
@@ -91,6 +92,11 @@ public class McpSearchService {
             "en",
             outputOpts
         );
+
+        if (res == null) {
+            throw new ResourceNotFoundException(
+                "No entity found for ontologyId '" + tokens[0] + "' and IRI '" + tokens[1] + "'");
+        }
 
         return gson.toJson( McpFetchResult.fromJson(res) );
     }

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/controller/mcp/McpSearchServiceFetchNotFoundTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/controller/mcp/McpSearchServiceFetchNotFoundTest.java
@@ -1,0 +1,88 @@
+package uk.ac.ebi.spot.ols.controller.mcp;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+import uk.ac.ebi.spot.ols.controller.api.exception.ResourceNotFoundException;
+import uk.ac.ebi.spot.ols.repository.EntityRepository;
+import uk.ac.ebi.spot.ols.repository.transforms.JsonTransformOptions;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Regression test for a {@code NullPointerException} in {@link McpSearchService#fetch(String)}.
+ *
+ * <p>{@code EntityRepository.getByOntologyIdAndIri} returns a plain {@code null} (not an
+ * exception) when {@code OlsSearchClient.getFirst} finds no matching row for a well-formed
+ * {@code ontologyId}/{@code iri} pair. {@code fetch()} previously passed that {@code null} straight
+ * into {@code McpFetchResult.fromJson(JsonElement)}, which immediately calls
+ * {@code entity.getAsJsonObject()} with no null check - so a syntactically valid id for an entity
+ * that genuinely does not exist threw an undocumented {@code NullPointerException} instead of a
+ * clear "not found" error.
+ *
+ * <p>Found while adding real-Postgres coverage for {@code McpSearchService} on the
+ * {@code test/cover-mcp-search-service} branch (both a hand-rolled-fake unit test and a real
+ * Postgres reproduction hit this exact NPE before this fix). This is a standalone defect PR,
+ * separate from that testing PR, per this programme's defect workflow.</p>
+ */
+class McpSearchServiceFetchNotFoundTest {
+
+    @Test
+    void throwsAClearResourceNotFoundExceptionInsteadOfANullPointerExceptionWhenNoEntityMatches() {
+        McpSearchService service = new McpSearchService();
+        service.entityRepository = new NullReturningEntityRepository();
+
+        ResourceNotFoundException thrown = assertThrows(
+                ResourceNotFoundException.class,
+                () -> service.fetch("efo+http://example.org/DOES_NOT_EXIST"));
+
+        assertEquals(
+                "No entity found for ontologyId 'efo' and IRI 'http://example.org/DOES_NOT_EXIST'",
+                thrown.getMessage());
+    }
+
+    @Test
+    void stillSucceedsNormallyWhenTheRepositoryFindsAMatchingEntity() throws IOException {
+        McpSearchService service = new McpSearchService();
+        service.entityRepository = new MatchingEntityRepository();
+
+        String json = service.fetch("efo+http://example.org/EFO_0001");
+
+        JsonObject result = JsonParser.parseString(json).getAsJsonObject();
+        assertEquals("efo+http://example.org/EFO_0001", result.get("id").getAsString());
+        assertEquals("http://example.org/EFO_0001", result.get("url").getAsString());
+        assertFalse(result.get("isObsolete").getAsBoolean());
+    }
+
+    private static class NullReturningEntityRepository extends EntityRepository {
+        @Override
+        public JsonElement getByOntologyIdAndIri(
+                String ontologyId, String iri, String lang, JsonTransformOptions outputOpts) {
+            return null;
+        }
+    }
+
+    private static class MatchingEntityRepository extends EntityRepository {
+        @Override
+        public JsonElement getByOntologyIdAndIri(
+                String ontologyId, String iri, String lang, JsonTransformOptions outputOpts) {
+            JsonObject json = new JsonObject();
+            json.addProperty("ontologyId", ontologyId);
+            json.addProperty("iri", iri);
+            json.addProperty("curie", "EFO:0001");
+            json.addProperty("label", "Liver disease");
+            json.addProperty("isObsolete", false);
+            JsonArray typeArray = new JsonArray();
+            typeArray.add("entity");
+            typeArray.add("class");
+            json.add("type", typeArray);
+            return JsonParser.parseString(json.toString());
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes an undocumented `NullPointerException` in `McpSearchService.fetch(String id)` (a Spring AI MCP `@Tool` method) whenever a syntactically well-formed `ontologyId+iri` id refers to an entity that genuinely does not exist.
- `EntityRepository.getByOntologyIdAndIri` returns a plain `null` (not an exception) when `OlsSearchClient.getFirst` finds no matching row — confirmed by reading `OlsSearchClient.getFirst`'s source, which explicitly `return`s `null` on `fetchOne() == null`. `fetch()` passed that `null` straight into `McpFetchResult.fromJson(JsonElement)`, which immediately calls `entity.getAsJsonObject()` with no null check.

## How this was found

While adding real-Postgres coverage for `McpSearchService` on the `test/cover-mcp-search-service` branch (#1415), both a hand-rolled-fake unit test and a real-Postgres reproduction (`entityRepository.fetch("efo+http://example.org/DOES_NOT_EXIST")` against a real disposable database) hit this exact `NullPointerException` before this fix. Checked against `test_api.sh`'s committed golden files first (`testcases_expected_output_api/mcp/fetch.json` only covers the success case; there is no not-found case asserted anywhere), so this is not an already-baselined contract — it is a genuine gap.

## Fix

Adds a null check in `McpSearchService.fetch()` that throws this codebase's own `uk.ac.ebi.spot.ols.controller.api.exception.ResourceNotFoundException` (the same "not found" idiom `GlobalExceptionHandler` already translates to HTTP 404 for REST controllers) with a clear message, instead of letting the `NullPointerException` propagate uncaught.

## Test added

`McpSearchServiceFetchNotFoundTest` (new, 2 cases):
- `throwsAClearResourceNotFoundExceptionInsteadOfANullPointerExceptionWhenNoEntityMatches` — reproduces the NPE pre-fix, asserts `ResourceNotFoundException` with the exact message post-fix.
- `stillSucceedsNormallyWhenTheRepositoryFindsAMatchingEntity` — confirms the success path is unaffected.

## Local verification (Java 17, Rancher Desktop)

- Focused test confirmed **red** (NPE) before the fix, **green** after.
- Docker-free `mvn -q -o test`, run twice: 0 failures / 0 errors both times (65 surefire report files, including the new 2-case test class).
- Clean `mvn -q -o clean verify -Dapi.version=1.44` (Docker-free + PostgreSQL): 1,190 tests (985 surefire + 205 failsafe), 0 failures / 0 errors, wall-clock 2m 3.48s.
- `test_api.sh` unchanged, not run locally (matches this programme's precedent for a unit-level defect fix, e.g. #1391).

## Scope

Minimal production fix (one null check + one new import) plus its own dedicated regression test. No unrelated changes. This is a standalone defect PR, separate from the `test/cover-mcp-search-service` testing PR (#1415) that exposed it — once merged, that testing branch will be rebased onto it (its own unit/IT cases documenting this exact behaviour will need their expected exception type updated from `NullPointerException` to `ResourceNotFoundException`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)