### PR TITLE
fix: use HAS_HIERARCHICAL_CHILDREN for hasHierarchicalChildren in V1AncestorsJsTreeBuilder

### DIFF
--- a/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1AncestorsJsTreeBuilder.java
+++ b/backend/src/main/java/uk/ac/ebi/spot/ols/repository/v1/V1AncestorsJsTreeBuilder.java
@@ -94,7 +94,7 @@ public class V1AncestorsJsTreeBuilder {
 
 
         boolean hasDirectChildren = Objects.equals(JsonHelper.getString(entity, HAS_DIRECT_CHILDREN.getText()), "true");
-        boolean hasHierarchicalChildren = Objects.equals(JsonHelper.getString(entity, HAS_DIRECT_CHILDREN.getText()), "true");
+        boolean hasHierarchicalChildren = Objects.equals(JsonHelper.getString(entity, HAS_HIERARCHICAL_CHILDREN.getText()), "true");
 
         // only nodes that aren't already opened are marked as having children, (iff they actually have children!)
         boolean children = (!opened) && (hasDirectChildren || hasHierarchicalChildren);

--- a/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1AncestorsJsTreeBuilderHierarchicalChildrenFlagTest.java
+++ b/backend/src/test/java/uk/ac/ebi/spot/ols/repository/v1/V1AncestorsJsTreeBuilderHierarchicalChildrenFlagTest.java
@@ -1,0 +1,82 @@
+package uk.ac.ebi.spot.ols.repository.v1;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Dedicated regression test for a defect discovered while adding full test coverage for
+ * {@link V1AncestorsJsTreeBuilder} (see {@code docs/backend-testing-strategy.md}, "Implemented
+ * V1AncestorsJsTreeBuilder baseline"): {@code createJsTreeEntries} computed both
+ * {@code hasDirectChildren} and {@code hasHierarchicalChildren} by reading the
+ * {@code HAS_DIRECT_CHILDREN} field twice, instead of reading {@code HAS_HIERARCHICAL_CHILDREN}
+ * for the second flag. Its sibling {@link V1ChildrenJsTreeBuilder} (line 40-41) and
+ * {@code V1TermMapper} (line 52-53) both correctly OR the two distinct fields together; this
+ * class was the outlier.
+ *
+ * <p>{@code hasDirectChildren} and {@code hasHierarchicalChildren} are populated independently by
+ * {@code HierarchyFlagsAnnotator} in {@code dataload/rdf2json} from two different relation types
+ * (subClassOf-derived direct parents vs. hierarchical/part-of-style parents), so an entity with
+ * {@code hasDirectChildren=false} and {@code hasHierarchicalChildren=true} is real, reachable
+ * ontology data - not a hypothetical edge case. Before this fix, such an entity incorrectly
+ * reported {@code children: false} (not expandable) in the V1 ancestors jstree response, when it
+ * should report {@code children: true}.
+ */
+class V1AncestorsJsTreeBuilderHierarchicalChildrenFlagTest {
+
+    @Test
+    void reportsChildrenTrueWhenOnlyHasHierarchicalChildrenIsSet() {
+        JsonElement thisEntity = JsonParser.parseString("""
+                {"iri":"http://example.org/this","label":"This",
+                 "hasDirectChildren":"false","hasHierarchicalChildren":"true"}
+                """);
+
+        V1AncestorsJsTreeBuilder builder = new V1AncestorsJsTreeBuilder(
+                thisEntity, List.of(), List.of("http://example.org/relations/parent"));
+
+        List<Map<String, Object>> tree = builder.buildJsTree();
+
+        assertThat(tree).singleElement().satisfies(entry -> {
+            assertThat(entry).containsEntry("iri", "http://example.org/this");
+            assertThat(entry).containsEntry("children", true);
+        });
+    }
+
+    @Test
+    void reportsChildrenFalseWhenNeitherFlagIsSet() {
+        JsonElement thisEntity = JsonParser.parseString("""
+                {"iri":"http://example.org/this","label":"This",
+                 "hasDirectChildren":"false","hasHierarchicalChildren":"false"}
+                """);
+
+        V1AncestorsJsTreeBuilder builder = new V1AncestorsJsTreeBuilder(
+                thisEntity, List.of(), List.of("http://example.org/relations/parent"));
+
+        List<Map<String, Object>> tree = builder.buildJsTree();
+
+        assertThat(tree).singleElement()
+                .satisfies(entry -> assertThat(entry).containsEntry("children", false));
+    }
+
+    @Test
+    void reportsChildrenTrueWhenOnlyHasDirectChildrenIsSet() {
+        JsonObject thisEntityJson = JsonParser.parseString("""
+                {"iri":"http://example.org/this","label":"This",
+                 "hasDirectChildren":"true","hasHierarchicalChildren":"false"}
+                """).getAsJsonObject();
+
+        V1AncestorsJsTreeBuilder builder = new V1AncestorsJsTreeBuilder(
+                thisEntityJson, List.of(), List.of("http://example.org/relations/parent"));
+
+        List<Map<String, Object>> tree = builder.buildJsTree();
+
+        assertThat(tree).singleElement()
+                .satisfies(entry -> assertThat(entry).containsEntry("children", true));
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes a genuine production defect in `V1AncestorsJsTreeBuilder.createJsTreeEntries()`: both `hasDirectChildren` and `hasHierarchicalChildren` were computed by reading the **same** `HAS_DIRECT_CHILDREN` field twice, instead of the second read using `HAS_HIERARCHICAL_CHILDREN`. As a result, `boolean children = (!opened) && (hasDirectChildren || hasHierarchicalChildren)` was effectively `hasDirectChildren` alone — the OR was a no-op.
- Practical effect: any entity in a V1 ancestors-jstree response (`/api/v1/.../jstree`, built by `V1JsTreeRepository.getJsTreeForEntity` → `V1AncestorsJsTreeBuilder`) that has **only hierarchical children** (no direct/subClassOf children) incorrectly reported `children: false` in the jstree output, making it appear non-expandable in the jsTree.js UI when it should be expandable.

## How this was found

While adding full test coverage for `V1AncestorsJsTreeBuilder` (`test: cover V1AncestorsJsTreeBuilder`, **#1428**) and enumerating every branch of `createJsTreeEntries`. Confirmed the sibling class `V1ChildrenJsTreeBuilder` (lines 40-41) and `V1TermMapper` (lines 52-53) both correctly OR the two distinct fields together — this class was the outlier. (Note: `V1PropertyMapper` appears to have the identical mistake; that's out of scope here and untouched by this PR.)

## Why this is reachable, not hypothetical

Read `dataload/rdf2json/src/main/java/uk/ac/ebi/rdf2json/annotators/HierarchyFlagsAnnotator.java`: `hasDirectChildren` and `hasHierarchicalChildren` are populated **independently**, from two different relation sets — direct/subClassOf-derived parents vs. hierarchical (e.g. `part_of`/BFO:0000050-style) parents. An entity that is a leaf in the subsumption hierarchy but is the target of a `part_of` relation from another entity will have `hasDirectChildren=false` and `hasHierarchicalChildren=true`. This is real, populated ontology data, not a contrived edge case.

## Checked against the golden-file baseline first

Per this programme's defect workflow, checked `test_api.sh`'s committed golden files under `testcases_expected_output_api/` before concluding this is a genuine bug: there is no `a_attr`-shaped (jstree) fixture anywhere in that directory, and no `jstree` reference in `test_api.sh` at all — the V1 ancestors-jstree endpoint has no existing golden-file assertion of any kind. This is not an already-asserted-intentional contract; it's simply untested, so nothing contradicts treating this as a genuine, unasserted defect.

## Fix

One-line change: read `HAS_HIERARCHICAL_CHILDREN` instead of `HAS_DIRECT_CHILDREN` for the `hasHierarchicalChildren` local variable.

## Test added

`V1AncestorsJsTreeBuilderHierarchicalChildrenFlagTest` (new, 3 cases):
- `reportsChildrenTrueWhenOnlyHasHierarchicalChildrenIsSet` — reproduces the bug pre-fix (`children: false`), asserts `children: true` post-fix.
- `reportsChildrenFalseWhenNeitherFlagIsSet` — unaffected control case.
- `reportsChildrenTrueWhenOnlyHasDirectChildrenIsSet` — unaffected control case (this path was already correct pre-fix).

Manually verified locally (before opening this PR) that the first case fails against the unfixed code (`children: false (expected: true)`) and passes once the fix is applied — genuine red/green regression proof, not just a passing assertion written after the fact.

## Local verification (Java 17, Rancher Desktop)

Verified from `origin/dev` commit `75d96f57c`.

- Docker-free `mvn -q -o test`, run twice: 986/986 pass both times, 0 failures / 0 errors (confirmed via `target/surefire-reports/*.txt`, not just exit code).
- Postgres/IT gate (`mvn -q -o verify -Dsurefire.skip=true -Dapi.version=1.44`), run twice: 205/205 pass both times, 0 failures / 0 errors (`target/failsafe-reports/*.txt`).
- Clean `mvn -q -o clean verify -Dapi.version=1.44`: 1,191 tests (986 surefire + 205 failsafe), 0 failures / 0 errors, wall-clock 2m 6.80s.
- `test_api.sh` full system regression not run locally (matches this programme's precedent for a unit-level defect fix, e.g. #1391, #1416) — unaffected, since this fix only changes which already-existing boolean field is read, not the API response shape.

## Scope

Minimal production fix (one field reference change) plus its own dedicated regression test. No unrelated changes. This is a standalone defect PR, separate from the `test: cover V1AncestorsJsTreeBuilder` testing PR (**#1428**) that discovered it — that PR documents the pre-fix behaviour explicitly as a known, separately-tracked defect and will be rebased onto this fix once merged.

**Never to be merged without explicit go-ahead.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
